### PR TITLE
RFC CxxstdPackage

### DIFF
--- a/lib/spack/spack/build_systems/cxxstd.py
+++ b/lib/spack/spack/build_systems/cxxstd.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import PackageBase
+from spack.directives import depends_on, variant, conflicts
+
+import spack.variant
+
+
+class CxxstdPackage(PackageBase):
+    """Auxiliary class which contains cxxstd variant, dependencies and conflicts
+    and is meant to unify and facilitate its usage.
+    """
+    variant('cxxstd',
+            default='default',
+            values=('default', '98', '11', '14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+ 
+    @staticmethod
+    def cxxstd_to_flag(self):
+        flag = ''
+        if self.spec.variants['cxxstd'].value == '98':
+            flag = self.compiler.cxx98_flag
+        elif self.spec.variants['cxxstd'].value == '11':
+            flag = self.compiler.cxx11_flag
+        elif self.spec.variants['cxxstd'].value == '14':
+            flag = self.compiler.cxx14_flag
+        elif self.spec.variants['cxxstd'].value == '17':
+            flag = self.compiler.cxx17_flag
+        elif self.spec.variants['cxxstd'].value == 'default':
+            # Let the compiler do what it usually does.
+            pass
+        else:
+            # The user has selected a (new?) legal value that we've
+            # forgotten to deal with here.
+            tty.warn("INTERNAL ERROR: cannot accommodate unexpected variant ",
+                    "cxxstd={0}".format(self.spec.variants['cxxstd'].value))
+            pass
+        return flag

--- a/lib/spack/spack/build_systems/cxxstd.py
+++ b/lib/spack/spack/build_systems/cxxstd.py
@@ -19,7 +19,6 @@ class CxxstdPackage(PackageBase):
             multi=False,
             description='Use the specified C++ standard when building.')
  
-    @staticmethod
     def cxxstd_to_flag(self):
         flag = ''
         if self.spec.variants['cxxstd'].value == '98':
@@ -36,7 +35,6 @@ class CxxstdPackage(PackageBase):
         else:
             # The user has selected a (new?) legal value that we've
             # forgotten to deal with here.
-            tty.warn("INTERNAL ERROR: cannot accommodate unexpected variant ",
+            tty.die("INTERNAL ERROR: cannot accommodate unexpected variant ",
                     "cxxstd={0}".format(self.spec.variants['cxxstd'].value))
-            pass
         return flag

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -18,6 +18,7 @@ from spack.build_systems.aspell_dict import AspellDictPackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
 from spack.build_systems.cuda import CudaPackage
+from spack.build_systems.cxxstd import CxxstdPackage
 from spack.build_systems.qmake import QMakePackage
 from spack.build_systems.scons import SConsPackage
 from spack.build_systems.waf import WafPackage


### PR DESCRIPTION
This implements the CxxstdPackage which adds the cxxstd variant and a method that returns the flag for the compiler.

This is needed to avoid duplication of the method in many fnal-art packages.