### PR TITLE
small fixes to ups_table and ups_file modules

### DIFF
--- a/lib/spack/spack/modules/ups_table.py
+++ b/lib/spack/spack/modules/ups_table.py
@@ -66,7 +66,7 @@ class UpsTableFileLayout(BaseFileLayout):
     @property
     def filename(self):
         """Name of the module file for the current spec."""
-        fn = "{}-{}-{}.table".format(self.spec.name, self.spec.version, self.spec._hash)
+        fn = "{0}-{1}-{2}.table".format(self.spec.name, self.spec.version, self.spec._hash)
         fp = os.path.join(self.dirname(), fn)
         return  fp
 

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -25,7 +25,7 @@ Action = setup
     prodDir()
     setupEnv()
 {% for package in spec._dependencies.keys() %}
-    setupRequired({{package}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q ${UPS_PROD_QUALIFIERS})
+    setupRequired({{package}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
 {% endfor %}
 
 {% block environment %}

--- a/share/spack/templates/modules/modulefile.ups_version
+++ b/share/spack/templates/modules/modulefile.ups_version
@@ -4,6 +4,7 @@ VERSION = {{spec.version}}
 
 {% if   (spec.architecture|string).find('i686')>0   %}{%set upsbits = '' %}
 {% elif (spec.architecture|string).find('x86_64')>0 %}{%set upsbits = '64bit' %}
+{% else  %}{%set upsbits = '64bit' %}
 {% endif %}
 
 {% if   (spec.architecture|string).find('darwin')>=0 %}{%set upsos = 'Darwin' %}


### PR DESCRIPTION
A python 2.x format() fix, a quoting fix for empty qualifiers, and a micro-architecture related change in the flavor translation in the ups_version module.