### PR TITLE
Fix up use of -lintl on Centos/Scientific/RedHat 

### DIFF
--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -27,7 +27,8 @@ class Acl(AutotoolsPackage):
     depends_on("gettext")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
+        if "intl" in self.spec["gettext"].libs.names:
+            env.append_flags("LDFLAGS", "-lintl")
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")

--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -27,7 +27,7 @@ class Acl(AutotoolsPackage):
     depends_on("gettext")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-lintl")
+        env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -116,7 +116,8 @@ class Apex(CMakePackage):
             args.append("-DBFD_ROOT={0}".format(spec["binutils"].prefix))
 
         if "+binutils ^binutils+nls" in spec:
-            args.append("-DCMAKE_SHARED_LINKER_FLAGS=%s" % self.spec['gettext'].libs_lintl)
+            if "intl" in self.spec["gettext"].libs.names:
+                args.append("-DCMAKE_SHARED_LINKER_FLAGS=-lintl")
 
         if "+otf2" in spec:
             args.append("-DOTF2_ROOT={0}".format(spec["otf2"].prefix))

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -116,7 +116,7 @@ class Apex(CMakePackage):
             args.append("-DBFD_ROOT={0}".format(spec["binutils"].prefix))
 
         if "+binutils ^binutils+nls" in spec:
-            args.append("-DCMAKE_SHARED_LINKER_FLAGS=-lintl")
+            args.append("-DCMAKE_SHARED_LINKER_FLAGS=%s" % self.spec['gettext'].libs_lintl)
 
         if "+otf2" in spec:
             args.append("-DOTF2_ROOT={0}".format(spec["otf2"].prefix))

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -25,7 +25,8 @@ class Bcache(MakefilePackage):
     depends_on("pkgconfig", type="build")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
+        if "intl" in self.spec["gettext"].libs.names:
+            env.append_flags("LDFLAGS", "-lintl")
 
     patch(
         "func_crc64.patch",

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -25,7 +25,7 @@ class Bcache(MakefilePackage):
     depends_on("pkgconfig", type="build")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-lintl")
+        env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
 
     patch(
         "func_crc64.patch",

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -105,7 +105,8 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
             env.append_flags("LDFLAGS", "-Wl,-z,muldefs")
 
         if "+nls" in self.spec:
-            env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
+            if "intl" in self.spec["gettext"].libs.names:
+                env.append_flags("LDFLAGS", "-lintl")
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -105,7 +105,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
             env.append_flags("LDFLAGS", "-Wl,-z,muldefs")
 
         if "+nls" in self.spec:
-            env.append_flags("LDFLAGS", "-lintl")
+            env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -112,7 +112,8 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
         if "+nls" in spec:
             # configure doesn't use LIBS correctly
-            args.append("LDFLAGS=-Wl,--no-as-needed %s" % spec["gettext"].libs_intl)
+            if "intl" in self.spec["gettext"].libs.names:
+                args.append("LDFLAGS=-Wl,--no-as-needed -lintl")
         else:
             args.append("--disable-nls")
 

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -112,7 +112,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
         if "+nls" in spec:
             # configure doesn't use LIBS correctly
-            args.append("LDFLAGS=-Wl,--no-as-needed -L%s -lintl" % spec["gettext"].prefix.lib)
+            args.append("LDFLAGS=-Wl,--no-as-needed %s" % spec["gettext"].libs_intl)
         else:
             args.append("--disable-nls")
 

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -113,7 +113,8 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         if "+nls" in spec:
             # configure doesn't use LIBS correctly
             if "intl" in self.spec["gettext"].libs.names:
-                args.append("LDFLAGS=-Wl,--no-as-needed -lintl")
+                args.append("LDFLAGS=-Wl,--no-as-needed -L%s -lintl" % 
+                    self.spec['gettext'].libraries.directories[0])
         else:
             args.append("--disable-nls")
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -131,7 +131,10 @@ class Extrae(AutotoolsPackage):
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
         # - linking error
         # https://github.com/bsc-performance-tools/extrae/issues/57
-        args.append("LDFLAGS={0} -pthread".format(self.spec['gettext'].libs_lintl))
+        if "intl" in self.spec["gettext"].libs.names:
+            args.append("LDFLAGS=-lintl -pthread")
+        else:
+            args.append("LDFLAGS=-pthread")
 
         return args
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -131,7 +131,7 @@ class Extrae(AutotoolsPackage):
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
         # - linking error
         # https://github.com/bsc-performance-tools/extrae/issues/57
-        args.append("LDFLAGS=-lintl -pthread")
+        args.append("LDFLAGS={0} -pthread".format(self.spec['gettext'].libs_lintl))
 
         return args
 

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -7,7 +7,6 @@ import re
 
 from spack.package import *
 
-
 class Gettext(AutotoolsPackage, GNUMirrorPackage):
     """GNU internationalization (i18n) and localization (l10n) library."""
 
@@ -103,21 +102,25 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         return config_args
 
     @property
-    def libs(self):
-        # on redhat and clones, there is /usr/lib64/preloadable_libintl.so instead of libintl.so
-        # and sometimes 32 bit libraries you don't want in /usr/lib.
+    def gettext_libs(self):
+        return self.libs
 
-        if self.prefix == '/usr' and self.os[:-1] in ['scientific','redhat','centos']:
+
+    @property
+    def libs(self):
+        # on redhat and clones, libintl is magic, you just want libc.
+        # and sometimes 32 bit libraries you don't want in are in /usr/lib.
+
+        if self.prefix == '/usr' and self.spec.os[:-1] in ['scientific','redhat','centos']:
             root = '/usr/lib64'
+            intl = 'libc'
         else:
             root = self.prefix,
+            intl = 'libintl'
 
         return find_libraries(
-            ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", "*libintl"],
+            ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", intl],
             root=root,
             recursive=True,
         )
 
-    @property
-    def libs_intl(self):
-        return LibraryList(self.libs[-1])

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -107,7 +107,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # on redhat and clones, there is /usr/lib64/preloadable_libintl.so instead of libintl.so
         # and sometimes 32 bit libraries you don't want in /usr/lib.
 
-        if self.prefix = '/usr' and self.os[:-1] in ['scientific','redhat','centos']:
+        if self.prefix == '/usr' and self.os[:-1] in ['scientific','redhat','centos']:
             root = '/usr/lib64'
         else:
             root = self.prefix,

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -104,8 +104,20 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def libs(self):
+        # on redhat and clones, there is /usr/lib64/preloadable_libintl.so instead of libintl.so
+        # and sometimes 32 bit libraries you don't want in /usr/lib.
+
+        if self.prefix = '/usr' and self.os[:-1] in ['scientific','redhat','centos']:
+            root = '/usr/lib64'
+        else:
+            root = self.prefix,
+
         return find_libraries(
-            ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", "libintl"],
-            root=self.prefix,
+            ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", "*libintl"],
+            root=root,
             recursive=True,
         )
+
+    @property
+    def libs_intl(self):
+        return LibraryList(self.libs[-1])

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -113,13 +113,13 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
         if self.prefix == '/usr' and self.spec.os[:-1] in ['scientific','redhat','centos']:
             root = '/usr/lib64'
-            intl = 'libc'
+            liblist = ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc"],
         else:
             root = self.prefix,
-            intl = 'libintl'
+            liblist = ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", "libintl"],
 
         return find_libraries(
-            ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", intl],
+            liblist,
             root=root,
             recursive=True,
         )

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -376,7 +376,7 @@ class Git(AutotoolsPackage):
         # have a gettext dependency.
         if "+nls" in self.spec:
             if "intl" in self.spec["gettext"].libs.names:
-                env.append_flags("EXTLIBS", self.spec["gettext"].libs_intl)
+                env.append_flags("EXTLIBS", "-L{0} -lintl".format(self.spec["gettext"].prefix.lib))
             env.append_flags("CFLAGS", "-I{0}".format(self.spec["gettext"].headers.directories))
 
         if "~perl" in self.spec:

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -376,8 +376,8 @@ class Git(AutotoolsPackage):
         # have a gettext dependency.
         if "+nls" in self.spec:
             if "intl" in self.spec["gettext"].libs.names:
-                env.append_flags("EXTLIBS", "-L{0} -lintl".format(self.spec["gettext"].prefix.lib))
-            env.append_flags("CFLAGS", "-I{0}".format(self.spec["gettext"].prefix.include))
+                env.append_flags("EXTLIBS", self.spec["gettext"].libs_intl)
+            env.append_flags("CFLAGS", "-I{0}".format(self.spec["gettext"].headers.directories))
 
         if "~perl" in self.spec:
             env.append_flags("NO_PERL", "1")

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -80,9 +80,10 @@ class Krb5(AutotoolsPackage):
         return args
 
     def setup_build_environment(self, env):
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["gettext"].libs.directories[0])
+        if "intl" in self.spec["gettext"].libs.names:
+            env.prepend_path("LD_LIBRARY_PATH", "-lintl")
 
     def flag_handler(self, name, flags):
         if name == "ldlibs":
-            flags.append(self.spec["gettext"].libs_intl)
+            flags.append(self.spec["gettext"].libs[4])
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -85,5 +85,6 @@ class Krb5(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name == "ldlibs":
-            flags.append(self.spec["gettext"].libs[4])
+            if "intl" in self.spec["gettext"].libs.names:
+                flags.append("-lintl")
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -80,9 +80,9 @@ class Krb5(AutotoolsPackage):
         return args
 
     def setup_build_environment(self, env):
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["gettext"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["gettext"].libs.directories[0])
 
     def flag_handler(self, name, flags):
         if name == "ldlibs":
-            flags.append("-lintl")
+            flags.append(self.spec["gettext"].libs_intl)
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -30,5 +30,5 @@ class Libxpm(AutotoolsPackage, XorgPackage):
         # If libxpm is installed as an external package, gettext won't
         # be available in the spec. See
         # https://github.com/spack/spack/issues/9149 for details.
-        if "gettext" in self.spec:
-            env.append_flags("LDFLAGS", self.spec["gettext"].libs_intl)
+        if "gettext" in self.spec and "intl" in self.spec["gettext"].libs.names:
+            env.append_flags("LDFLAGS", "-lintl")

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -31,4 +31,4 @@ class Libxpm(AutotoolsPackage, XorgPackage):
         # be available in the spec. See
         # https://github.com/spack/spack/issues/9149 for details.
         if "gettext" in self.spec:
-            env.append_flags("LDFLAGS", "-L{0} -lintl".format(self.spec["gettext"].prefix.lib))
+            env.append_flags("LDFLAGS", self.spec["gettext"].libs_intl)

--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -30,7 +30,8 @@ class NfsUtils(AutotoolsPackage):
     depends_on("gettext")
 
     def setup_build_environment(self, env):
-        env.append_flags("LIBS", self.spec['gettext'].libs_intl)
+        if "intl" in self.spec["gettext"].libs.names:
+            env.append_flags("LIBS", "-lintl")
 
     def configure_args(self):
         args = ["--disable-gss", "--with-rpcgen=internal"]

--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -30,7 +30,7 @@ class NfsUtils(AutotoolsPackage):
     depends_on("gettext")
 
     def setup_build_environment(self, env):
-        env.append_flags("LIBS", "-lintl")
+        env.append_flags("LIBS", self.spec['gettext'].libs_intl)
 
     def configure_args(self):
         args = ["--disable-gss", "--with-rpcgen=internal"]

--- a/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
+++ b/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
@@ -28,7 +28,7 @@ class OciSystemdHook(AutotoolsPackage):
     depends_on("go-md2man")
 
     def configure_args(self):
-        args = ["LDFLAGS=-lintl"]
+        args = ["LDFLAGS={0}".format(self.spec['gettext'].libs_intl)]
         return args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
+++ b/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
@@ -28,7 +28,10 @@ class OciSystemdHook(AutotoolsPackage):
     depends_on("go-md2man")
 
     def configure_args(self):
-        args = ["LDFLAGS={0}".format(self.spec['gettext'].libs_intl)]
+        if "intl" in self.spec["gettext"].libs.names:
+            args = ["LDFLAGS=-lintl"]
+        else:
+            args = []
         return args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -551,6 +551,14 @@ class Python(Package):
         for lib in static_libraries:
             copy(lib, prefix.libs)
 
+    @run_before("configure")
+    def patch_configure_ipv6(self):
+        # configure fails to build with ipv6 support if ipv6 isn't 
+        # configured on this box...
+        # but we want it to work anyway so pull its teeth.
+        filter_file(r' test \$ipv6 = yes', ' false ', 'configure')
+
+
     def configure_args(self):
         spec = self.spec
         config_args = []

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -551,13 +551,6 @@ class Python(Package):
         for lib in static_libraries:
             copy(lib, prefix.libs)
 
-    @run_before("configure")
-    def patch_configure_ipv6(self):
-        # configure fails to build with ipv6 support if ipv6 isn't 
-        # configured on this box...
-        # but we want it to work anyway so pull its teeth.
-        filter_file(r' test \$ipv6 = yes', ' false ', 'configure')
-
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -453,7 +453,8 @@ class Qt(Package):
     # correctly, so add it here.
     def flag_handler(self, name, flags):
         if "+webkit" in self.spec and name == "ldlibs":
-            flags.append(self.spec['gettext'].libs_intl)
+            if "intl" in self.spec["gettext"].libs.names:
+                flags.append("-lintl")
 
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -453,7 +453,7 @@ class Qt(Package):
     # correctly, so add it here.
     def flag_handler(self, name, flags):
         if "+webkit" in self.spec and name == "ldlibs":
-            flags.append("-lintl")
+            flags.append(self.spec['gettext'].libs_intl)
 
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -20,7 +20,7 @@ class RpcsvcProto(AutotoolsPackage):
     depends_on("gettext")
 
     def configure_args(self):
-        return ["LIBS=-lintl"]
+        return ["LIBS={0}".format(self.spec['gettext'].libs_intl]
 
     @run_before("build")
     def change_makefile(self):

--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -20,7 +20,7 @@ class RpcsvcProto(AutotoolsPackage):
     depends_on("gettext")
 
     def configure_args(self):
-        return ["LIBS={0}".format(self.spec['gettext'].libs_intl]
+        return ["LIBS={0}".format(self.spec['gettext'].libs_intl)]
 
     @run_before("build")
     def change_makefile(self):

--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -20,7 +20,10 @@ class RpcsvcProto(AutotoolsPackage):
     depends_on("gettext")
 
     def configure_args(self):
-        return ["LIBS={0}".format(self.spec['gettext'].libs_intl)]
+        if "intl" in self.spec["gettext"].libs.names:
+            return ["LIBS=-lintl"]
+        else:
+            return []
 
     @run_before("build")
     def change_makefile(self):

--- a/var/spack/repos/builtin/packages/rrdtool/package.py
+++ b/var/spack/repos/builtin/packages/rrdtool/package.py
@@ -23,7 +23,7 @@ class Rrdtool(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            "LDFLAGS=-lintl",
+            "LDFLAGS={0}".format(self.spec['gettext'].libs_intl),
             "--with-systemdsystemunitdir=" + self.spec["rrdtool"].prefix.lib.systemd.system,
         ]
         return args

--- a/var/spack/repos/builtin/packages/rrdtool/package.py
+++ b/var/spack/repos/builtin/packages/rrdtool/package.py
@@ -23,7 +23,8 @@ class Rrdtool(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            "LDFLAGS={0}".format(self.spec['gettext'].libs_intl),
             "--with-systemdsystemunitdir=" + self.spec["rrdtool"].prefix.lib.systemd.system,
         ]
+        if "intl" in self.spec["gettext"].libs.names:
+            args.append("LDFLAGS=-lintl")
         return args

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -107,8 +107,8 @@ class Subversion(AutotoolsPackage):
                     "LDFLAGS={0}".format(spec["gettext"].libs.search_flags),
                     # Using .libs.link_flags is the canonical way to add these arguments,
                     # but since libintl is much smaller than the rest and also the only
-                    # necessary one, we specify it by hand here.
-                    "LIBS=-lintl",
+                    # necessary one, we would specify it by hand here
+                    "LIBS={0}".format(self.spec['gettext'].libs_intl.link_flags,
                     "--enable-nls",
                 ]
             )

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -108,7 +108,7 @@ class Subversion(AutotoolsPackage):
                     # Using .libs.link_flags is the canonical way to add these arguments,
                     # but since libintl is much smaller than the rest and also the only
                     # necessary one, we would specify it by hand here
-                    "LIBS={0}".format(self.spec['gettext'].libs_intl.link_flags,
+                    "LIBS={0}".format(self.spec['gettext'].libs_intl.link_flags),
                     "--enable-nls",
                 ]
             )

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -108,10 +108,11 @@ class Subversion(AutotoolsPackage):
                     # Using .libs.link_flags is the canonical way to add these arguments,
                     # but since libintl is much smaller than the rest and also the only
                     # necessary one, we would specify it by hand here
-                    "LIBS={0}".format(self.spec['gettext'].libs_intl.link_flags),
                     "--enable-nls",
                 ]
             )
+            if "intl" in self.spec["gettext"].libs.names:
+                args.append("LIBS=-lintl")
         else:
             args.append("--disable-nls")
 

--- a/var/spack/repos/builtin/packages/systemtap/package.py
+++ b/var/spack/repos/builtin/packages/systemtap/package.py
@@ -29,5 +29,5 @@ class Systemtap(AutotoolsPackage):
     depends_on("python", type=("build", "run"))
 
     def configure_args(self):
-        args = ["LDFLAGS=-lintl"]
+        args = ["LDFLAGS={0}".format(self.spec['gettext'].libs_intl]
         return args

--- a/var/spack/repos/builtin/packages/systemtap/package.py
+++ b/var/spack/repos/builtin/packages/systemtap/package.py
@@ -29,5 +29,8 @@ class Systemtap(AutotoolsPackage):
     depends_on("python", type=("build", "run"))
 
     def configure_args(self):
-        args = ["LDFLAGS={0}".format(self.spec['gettext'].libs_intl)]
+        if "intl" in self.spec["gettext"].libs.names:
+            args = ["LDFLAGS=-lintl"]
+        else:
+            args = []
         return args

--- a/var/spack/repos/builtin/packages/systemtap/package.py
+++ b/var/spack/repos/builtin/packages/systemtap/package.py
@@ -29,5 +29,5 @@ class Systemtap(AutotoolsPackage):
     depends_on("python", type=("build", "run"))
 
     def configure_args(self):
-        args = ["LDFLAGS={0}".format(self.spec['gettext'].libs_intl]
+        args = ["LDFLAGS={0}".format(self.spec['gettext'].libs_intl)]
         return args

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -32,7 +32,8 @@ class Xfd(AutotoolsPackage, XorgPackage):
     # correctly, so add it here.
     def flag_handler(self, name, flags):
         if name == "ldlibs":
-            flags.append(self.spec['gettext'].libs_intl)
+            if "intl" in self.spec["gettext"].libs.names:
+                flags.append("-lintl")
 
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -32,7 +32,7 @@ class Xfd(AutotoolsPackage, XorgPackage):
     # correctly, so add it here.
     def flag_handler(self, name, flags):
         if name == "ldlibs":
-            flags.append("-lintl")
+            flags.append(self.spec['gettext'].libs_intl)
 
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/xfsdump/package.py
+++ b/var/spack/repos/builtin/packages/xfsdump/package.py
@@ -26,7 +26,7 @@ class Xfsdump(MakefilePackage):
     depends_on("xfsprogs@:4.20.0")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-lintl")
+        env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
 
     def build(self, spec, prefix):
         make(

--- a/var/spack/repos/builtin/packages/xfsdump/package.py
+++ b/var/spack/repos/builtin/packages/xfsdump/package.py
@@ -26,7 +26,8 @@ class Xfsdump(MakefilePackage):
     depends_on("xfsprogs@:4.20.0")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", self.spec['gettext'].libs_intl)
+        if "intl" in self.spec["gettext"].libs.names:
+            env.append_flags("LDFLAGS", "-lintl")
 
     def build(self, spec, prefix):
         make(

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -36,9 +36,10 @@ class Xfsprogs(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            "LDFLAGS={0}".format(self.spec['gettext'].libs_intl),
             "--with-systemd-unit-dir=" + self.spec["xfsprogs"].prefix.lib.systemd.system,
         ]
+        if "intl" in self.spec["gettext"].libs.names:
+            args.append("LDFLAGS=-lintl")
         return args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -36,7 +36,7 @@ class Xfsprogs(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            "LDFLAGS=-lintl",
+            "LDFLAGS={0}".format(self.spec['gettext'].libs_intl,
             "--with-systemd-unit-dir=" + self.spec["xfsprogs"].prefix.lib.systemd.system,
         ]
         return args

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -36,7 +36,7 @@ class Xfsprogs(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            "LDFLAGS={0}".format(self.spec['gettext'].libs_intl,
+            "LDFLAGS={0}".format(self.spec['gettext'].libs_intl),
             "--with-systemd-unit-dir=" + self.spec["xfsprogs"].prefix.lib.systemd.system,
         ]
         return args


### PR DESCRIPTION
Use the -lintl libray ony when the gettext package says we have one, 
This is particularly important when trying to use the system installed gettext on RedHat and clones.