### PR TITLE
ROOT: remove temporary build diagnostics

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -426,7 +426,6 @@ class Root(CMakePackage):
         spec = self.spec
         define = self.define
         define_from_variant = self.define_from_variant
-        options = ["--debug-find-pkg=OpenGL", "--trace-expand"]
 
         # ###################### Boolean Options ######################
         # For option list format see _process_opts(), below.

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -426,6 +426,7 @@ class Root(CMakePackage):
         spec = self.spec
         define = self.define
         define_from_variant = self.define_from_variant
+        options = []
 
         # ###################### Boolean Options ######################
         # For option list format see _process_opts(), below.


### PR DESCRIPTION
- Remove unwanted temporary diagnostics
- Fix silliness
