### PR TITLE
feature/synchronize test callbacks fix

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -283,35 +283,18 @@ package_https_directives = AuditClass(
 
 
 @package_directives
-def _check_test_callbacks(pkgs, error_cls):
-    """Ensure stand-alone test method is not included in test callbacks."""
+def _check_build_test_callbacks(pkgs, error_cls):
+    """Ensure stand-alone test method is not included in build-time callbacks"""
     errors = []
     for pkg_name in pkgs:
         pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
-        buildsystem_variant, _ = pkg_cls.variants["build_system"]
-        buildsystem_names = [getattr(x, "value", x) for x in buildsystem_variant.values]
-        builder_cls_names = [spack.builder.BUILDER_CLS[x].__name__ for x in buildsystem_names]
-        module = pkg_cls.module
-        for builder_cls_name in builder_cls_names:
-            builder_cls = getattr(module, builder_cls_name, False)
-            if builder_cls:
-                for methods_list in ("build_time_test_callbacks", "install_time_test_callbacks"):
-                    if "test" in getattr(builder_cls, methods_list, ()):
-                        msg = "Builder '{}' defined in '{}' for package '{}'"
-                        "contains 'test' method in '{}'"
-                        instr = "Remove 'test' from '{}' in '{}'"
-                        errors.append(
-                            error_cls(
-                                msg.format(
-                                    builder_cls_name, module.__name__, pkg_name, methods_list
-                                ),
-                                [
-                                    instr.format(
-                                        methods_list, ".".join([module.__name__, builder_cls_name])
-                                    )
-                                ],
-                            )
-                        )
+        test_callbacks = pkg_cls.build_time_test_callbacks
+
+        if test_callbacks and "test" in test_callbacks:
+            msg = '{0} package contains "test" method in ' "build_time_test_callbacks"
+            instr = 'Remove "test" from: [{0}]'.format(", ".join(test_callbacks))
+            errors.append(error_cls(msg.format(pkg_name), [instr]))
+
     return errors
 
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -288,7 +288,7 @@ def _check_build_test_callbacks(pkgs, error_cls):
     errors = []
     for pkg_name in pkgs:
         pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
-        test_callbacks = pkg_cls.build_time_test_callbacks
+        test_callbacks = getattr(pkg_cls, "build_time_test_callbacks", None)
 
         if test_callbacks and "test" in test_callbacks:
             msg = '{0} package contains "test" method in ' "build_time_test_callbacks"

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -242,8 +242,8 @@ def print_tests(pkg):
     # So the presence of a callback in Spack does not necessarily correspond
     # to the actual presence of built-time tests for a package.
     for callbacks, phase in [
-        (pkg.build_time_test_callbacks, "Build"),
-        (pkg.install_time_test_callbacks, "Install"),
+        (getattr(pkg, "build_time_test_callbacks", None), "Build"),
+        (getattr(pkg, "install_time_test_callbacks", None), "Install"),
     ]:
         color.cprint("")
         color.cprint(section_title("Available {0} Phase Test Methods:".format(phase)))

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -531,6 +531,10 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
     # These are default values for instance variables.
     #
 
+    #: A list or set of build time test functions to be called when tests
+    #: are executed or 'None' if there are no such test functions.
+    build_time_test_callbacks = None  # type: Optional[List[str]]
+
     #: By default, packages are not virtual
     #: Virtual packages override this attribute
     virtual = False
@@ -538,6 +542,10 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
     #: Most Spack packages are used to install source or binary code while
     #: those that do not can be used to install a set of other Spack packages.
     has_code = True
+
+    #: A list or set of install time test functions to be called when tests
+    #: are executed or 'None' if there are no such test functions.
+    install_time_test_callbacks = None  # type: Optional[List[str]]
 
     #: By default we build in parallel.  Subclasses can override this.
     parallel = True

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -531,10 +531,6 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
     # These are default values for instance variables.
     #
 
-    #: A list or set of build time test functions to be called when tests
-    #: are executed or 'None' if there are no such test functions.
-    build_time_test_callbacks = None  # type: Optional[List[str]]
-
     #: By default, packages are not virtual
     #: Virtual packages override this attribute
     virtual = False
@@ -542,10 +538,6 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
     #: Most Spack packages are used to install source or binary code while
     #: those that do not can be used to install a set of other Spack packages.
     has_code = True
-
-    #: A list or set of install time test functions to be called when tests
-    #: are executed or 'None' if there are no such test functions.
-    install_time_test_callbacks = None  # type: Optional[List[str]]
 
     #: By default we build in parallel.  Subclasses can override this.
     parallel = True

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -121,3 +121,17 @@ def test_old_style_compatibility_with_super(spec_str, method_name, expected):
     builder = spack.builder.create(s.package)
     value = getattr(builder, method_name)()
     assert value == expected
+
+
+@pytest.mark.regression("33928")
+@pytest.mark.usefixtures("builder_test_repository", "config", "working_env")
+@pytest.mark.disable_clean_stage_check
+def test_build_time_tests_are_executed_from_default_builder():
+    s = spack.spec.Spec("old-style-autotools").concretized()
+    builder = spack.builder.create(s.package)
+    builder.pkg.run_tests = True
+    for phase_fn in builder:
+        phase_fn.execute()
+
+    assert os.environ.get("CHECK_CALLED") == "1", "Build time tests not executed"
+    assert os.environ.get("INSTALLCHECK_CALLED") == "1", "Install time tests not executed"

--- a/var/spack/repos/builder.test/packages/old-style-autotools/package.py
+++ b/var/spack/repos/builder.test/packages/old-style-autotools/package.py
@@ -48,3 +48,9 @@ class OldStyleAutotools(AutotoolsPackage):
     @run_after("autoreconf", when="@2.0")
     def after_autoreconf_2(self):
         os.environ["AFTER_AUTORECONF_2_CALLED"] = "1"
+
+    def check(self):
+        os.environ["CHECK_CALLED"] = "1"
+
+    def installcheck(self):
+        os.environ["INSTALLCHECK_CALLED"] = "1"

--- a/var/spack/repos/builtin.mock/packages/fail-test-audit/package.py
+++ b/var/spack/repos/builtin.mock/packages/fail-test-audit/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.build_systems.makefile
 from spack.package import *
 
 
@@ -14,9 +13,6 @@ class FailTestAudit(MakefilePackage):
 
     version("1.0", "0123456789abcdef0123456789abcdef")
     version("2.0", "abcdef0123456789abcdef0123456789")
-
-
-class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
     build_time_test_callbacks = ["test"]
 


### PR DESCRIPTION
- Revert "Merge pull request #66 from chissg/bugfix/PackageBase-test-callbacks"
- PackageBase should not define builder legacy attributes (#33942)
