### PR TITLE
bugfix/bad message types in PackageBase

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2453,12 +2453,12 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
                 try:
                     fn = getattr(builder, name)
 
-                    msg = ("RUN-TESTS: {0}-time tests [{1}]".format(callback_type, name),)
+                    msg = "RUN-TESTS: {0}-time tests [{1}]".format(callback_type, name)
                     print_test_message(logger, msg, True)
 
                     fn()
                 except AttributeError as e:
-                    msg = ("RUN-TESTS: method not implemented [{0}]".format(name),)
+                    msg = "RUN-TESTS: method not implemented [{0}]".format(name)
                     print_test_message(logger, msg, True)
 
                     builder.pkg.test_failures.append((e, msg))

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1179,3 +1179,11 @@ def test_install_use_buildcache(
         # Alternative to --cache-only (always) or --no-cache (never)
         for opt in ["auto", "only", "never"]:
             install_use_buildcache(opt)
+
+
+@pytest.mark.regression("34006")
+@pytest.mark.disable_clean_stage_check
+def test_padded_install_runtests_root(install_mockery_mutable_config, mock_fetch):
+    spack.config.set("config:install_tree:padded_length", 255)
+    output = install("--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False)
+    assert output.count("method not implemented") == 1


### PR DESCRIPTION
- Regression test for spack/spack:#34006
- `msg` should be `string`, not list
