### PR TITLE
Fix '==> Error: 'NoneType' object has no attribute 'encode''

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -511,7 +511,7 @@ def new_relocate_elf_binaries(binaries, prefix_to_prefix):
 
     # Transform to binary string
     prefix_to_prefix = OrderedDict(
-       (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items() if k and v
+        (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items() if k and v
     )
 
     for path in binaries:

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -511,7 +511,7 @@ def new_relocate_elf_binaries(binaries, prefix_to_prefix):
 
     # Transform to binary string
     prefix_to_prefix = OrderedDict(
-        (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items()
+        (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items() if k and v
     )
 
     for path in binaries:

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -511,7 +511,7 @@ def new_relocate_elf_binaries(binaries, prefix_to_prefix):
 
     # Transform to binary string
     prefix_to_prefix = OrderedDict(
-        (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items() if k and v
+       (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items() if k and v
     )
 
     for path in binaries:

--- a/lib/spack/spack/relocate_text.py
+++ b/lib/spack/spack/relocate_text.py
@@ -21,7 +21,7 @@ def encode_path(p: Prefix) -> bytes:
 
 def _prefix_to_prefix_as_bytes(prefix_to_prefix) -> Dict[bytes, bytes]:
     return OrderedDict(
-       (encode_path(k), encode_path(v)) for (k, v) in prefix_to_prefix.items() if k and v
+        (encode_path(k), encode_path(v)) for (k, v) in prefix_to_prefix.items() if k and v
     )
 
 

--- a/lib/spack/spack/relocate_text.py
+++ b/lib/spack/spack/relocate_text.py
@@ -20,7 +20,9 @@ def encode_path(p: Prefix) -> bytes:
 
 
 def _prefix_to_prefix_as_bytes(prefix_to_prefix) -> Dict[bytes, bytes]:
-    return OrderedDict((encode_path(k), encode_path(v)) for (k, v) in prefix_to_prefix.items())
+    return OrderedDict(
+       (encode_path(k), encode_path(v)) for (k, v) in prefix_to_prefix.items() if k and v
+    )
 
 
 def utf8_path_to_binary_regex(prefix: str):


### PR DESCRIPTION
Doing `a spack buildcache install -oa  /32uzk6v` (for package cosmosis) was failing with:
`==> Error: 'NoneType' object has no attribute 'encode' `
in actually 2 different places as one peels the onion.  