### PR TITLE
Merge from upstream/develop 2023-05-18

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -137,6 +137,7 @@ jobs:
     - name: Setup repo and non-root user
       run: |
           git --version
+          git config --global --add safe.directory /__w/spack/spack
           git fetch --unshallow
           . .github/workflows/setup_git.sh
           useradd spack-test

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Setup repo and non-root user
         run: |
           git --version
+          git config --global --add safe.directory /__w/spack/spack
           git fetch --unshallow
           . .github/workflows/setup_git.sh
           useradd spack-test

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -143,6 +143,26 @@ The OS that are currently supported are summarized in the table below:
    * - Amazon Linux 2
      - ``amazonlinux:2``
      - ``spack/amazon-linux``
+   * - AlmaLinux 8
+     - ``almalinux:8``
+     - ``spack/almalinux8``
+   * - AlmaLinux 9
+     - ``almalinux:9``
+     - ``spack/almalinux9``
+   * - Rocky Linux 8
+     - ``rockylinux:8``
+     - ``spack/rockylinux8``
+   * - Rocky Linux 9
+     - ``rockylinux:9``
+     - ``spack/rockylinux9``
+   * - Fedora Linux 37
+     - ``fedora:37``
+     - ``spack/fedora37``
+   * - Fedora Linux 38
+     - ``fedora:38``
+     - ``spack/fedora38``
+
+
 
 All the images are tagged with the corresponding release of Spack:
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -347,7 +347,7 @@ the Environment and then install the concretized specs.
    (see :ref:`build-jobs`). To speed up environment builds further, independent
    packages can be installed in parallel by launching more Spack instances. For
    example, the following will build at most four packages in parallel using
-   three background jobs: 
+   three background jobs:
 
    .. code-block:: console
 
@@ -395,7 +395,7 @@ version (and other constraints) passed as the spec argument to the
 
 For packages with ``git`` attributes, git branches, tags, and commits can
 also be used as valid concrete versions (see :ref:`version-specifier`).
-This means that for a package ``foo``, ``spack develop foo@git.main`` will clone 
+This means that for a package ``foo``, ``spack develop foo@git.main`` will clone
 the ``main`` branch of the package, and ``spack install`` will install from
 that git clone if ``foo`` is in the environment.
 Further development on ``foo`` can be tested by reinstalling the environment,
@@ -589,10 +589,11 @@ user support groups providing a large software stack for their HPC center.
 
 .. admonition:: Re-concretization of user specs
 
-   When using *unified* concretization (when possible), the entire set of specs will be
-   re-concretized after any addition of new user specs, to ensure that
-   the environment remains consistent / minimal. When instead unified concretization is
-   disabled, only the new specs will be concretized after any addition.
+   The ``spack concretize`` command without additional arguments will *not* change any
+   previously concretized specs. This may prevent it from finding a solution when using
+   ``unify: true``, and it may prevent it from finding a minimal solution when using
+   ``unify: when_possible``. You can force Spack to ignore the existing concrete environment
+   with ``spack concretize -f``.
 
 ^^^^^^^^^^^^^
 Spec Matrices
@@ -1121,19 +1122,19 @@ index once every package is pushed. Note how this target uses the generated
 
    SPACK ?= spack
    BUILDCACHE_DIR = $(CURDIR)/tarballs
-   
+
    .PHONY: all
-   
+
    all: push
-   
+
    include env.mk
-   
+
    example/push/%: example/install/%
    	@mkdir -p $(dir $@)
    	$(info About to push $(SPEC) to a buildcache)
    	$(SPACK) -e . buildcache create --allow-root --only=package --directory $(BUILDCACHE_DIR) /$(HASH)
    	@touch $@
-   
+
    push: $(addprefix example/push/,$(example/SPACK_PACKAGE_IDS))
    	$(info Updating the buildcache index)
    	$(SPACK) -e . buildcache update-index --directory $(BUILDCACHE_DIR)

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.2.0-dev (commit d02dadbac4fa8f3a60293c4fbfd59feadaf546dc)
+* Version: 0.2.1 (commit 4b1f21802a23b536bbcce73d3c631a566b20e8bd)
 
 astunparse
 ----------------

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -2083,18 +2083,28 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "10.3:",
+            "versions": "10.3:13.0",
             "name": "znver3",
             "flags": "-march={name} -mtune={name} -mavx512f -mavx512dq -mavx512ifma -mavx512cd -mavx512bw -mavx512vl -mavx512vbmi -mavx512vbmi2 -mavx512vnni -mavx512bitalg"
+          },
+          {
+            "versions": "13.1:",
+            "name": "znver4",
+            "flags": "-march={name} -mtune={name}"
           }
         ],
         "clang": [
           {
-            "versions": "12.0:",
+            "versions": "12.0:15.9",
             "name": "znver3",
             "flags": "-march={name} -mtune={name} -mavx512f -mavx512dq -mavx512ifma -mavx512cd -mavx512bw -mavx512vl -mavx512vbmi -mavx512vbmi2 -mavx512vnni -mavx512bitalg"
+          },
+          {
+            "versions": "16.0:",
+            "name": "znver4",
+            "flags": "-march={name} -mtune={name}"
           }
-        ],
+	],
         "aocc": [
           {
             "versions": "3.0:3.9",

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.20.0.dev0"
+__version__ = "0.21.0.dev0"
 spack_version = __version__
 
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -426,7 +426,7 @@ class BinaryCacheIndex(object):
 
         self._write_local_index_cache()
 
-        if all_methods_failed:
+        if configured_mirror_urls and all_methods_failed:
             raise FetchCacheError(fetch_errors)
         if fetch_errors:
             tty.warn(
@@ -2415,6 +2415,10 @@ class BinaryCacheQuery(object):
         self.possible_specs = specs
 
     def __call__(self, spec, **kwargs):
+        """
+        Args:
+            spec (str): The spec being searched for in its string representation or hash.
+        """
         matches = []
         if spec.startswith("/"):
             # Matching a DAG hash

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -531,7 +531,7 @@ class SpackCI:
         """
 
         self.ci_config = ci_config
-        self.named_jobs = ["any", "build", "cleanup", "noop", "reindex", "signing"]
+        self.named_jobs = ["any", "build", "copy", "cleanup", "noop", "reindex", "signing"]
 
         self.ir = {
             "jobs": {},
@@ -1207,7 +1207,7 @@ def generate_gitlab_ci_yaml(
                             ).format(c_spec, release_spec)
                             tty.debug(debug_msg)
 
-                if prune_dag and not rebuild_spec:
+                if prune_dag and not rebuild_spec and spack_pipeline_type != "spack_copy_only":
                     tty.debug(
                         "Pruning {0}/{1}, does not need rebuild.".format(
                             release_spec.name, release_spec.dag_hash()
@@ -1298,8 +1298,9 @@ def generate_gitlab_ci_yaml(
                     max_length_needs = length_needs
                     max_needs_job = job_name
 
-                output_object[job_name] = job_object
-                job_id += 1
+                if spack_pipeline_type != "spack_copy_only":
+                    output_object[job_name] = job_object
+                    job_id += 1
 
     if print_summary:
         for phase in phases:
@@ -1328,6 +1329,17 @@ def generate_gitlab_ci_yaml(
         "max": 2,
         "when": ["runner_system_failure", "stuck_or_timeout_failure", "script_failure"],
     }
+
+    if spack_pipeline_type == "spack_copy_only":
+        stage_names.append("copy")
+        sync_job = copy.deepcopy(spack_ci_ir["jobs"]["copy"]["attributes"])
+        sync_job["stage"] = "copy"
+        if artifacts_root:
+            sync_job["needs"] = [
+                {"job": generate_job_name, "pipeline": "{0}".format(parent_pipeline_id)}
+            ]
+        output_object["copy"] = sync_job
+        job_id += 1
 
     if job_id > 0:
         if temp_storage_url_prefix:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -347,7 +347,7 @@ def iter_groups(specs, indent, all_headers):
             spack.spec.architecture_color,
             architecture if architecture else "no arch",
             spack.spec.compiler_color,
-            f"{compiler.name}@{compiler.version}" if compiler else "no compiler",
+            f"{compiler}" if compiler else "no compiler",
         )
 
         # Sometimes we want to display specs that are not yet concretized.

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -347,7 +347,7 @@ def iter_groups(specs, indent, all_headers):
             spack.spec.architecture_color,
             architecture if architecture else "no arch",
             spack.spec.compiler_color,
-            compiler if compiler else "no compiler",
+            f"{compiler.name}@{compiler.version}" if compiler else "no compiler",
         )
 
         # Sometimes we want to display specs that are not yet concretized.

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -29,6 +29,7 @@ chosen, test dependencies are enabled for all packages in the environment.""",
     )
 
     spack.cmd.common.arguments.add_concretizer_args(subparser)
+    spack.cmd.common.arguments.add_common_arguments(subparser, ["jobs"])
 
 
 def concretize(parser, args):

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -116,21 +116,23 @@ def one_spec_or_raise(specs):
 
 
 def check_module_set_name(name):
-    modules_config = spack.config.get("modules")
-    valid_names = set(
-        [
-            key
-            for key, value in modules_config.items()
-            if isinstance(value, dict) and value.get("enable", [])
-        ]
-    )
-    if "enable" in modules_config and modules_config["enable"]:
-        valid_names.add("default")
+    modules = spack.config.get("modules")
+    if name != "prefix_inspections" and name in modules:
+        return
 
-    if name not in valid_names:
-        msg = "Cannot use invalid module set %s." % name
-        msg += "    Valid module set names are %s" % list(valid_names)
-        raise spack.config.ConfigError(msg)
+    names = [k for k in modules if k != "prefix_inspections"]
+
+    if not names:
+        raise spack.config.ConfigError(
+            f"Module set configuration is missing. Cannot use module set '{name}'"
+        )
+
+    pretty_names = "', '".join(names)
+
+    raise spack.config.ConfigError(
+        f"Cannot use invalid module set '{name}'.",
+        f"Valid module set names are: '{pretty_names}'.",
+    )
 
 
 _missing_modules_warning = (

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -140,12 +140,15 @@ def _process_result(result, show, required_format, kwargs):
 
 def solve(parser, args):
     # these are the same options as `spack spec`
-    name_fmt = "{namespace}.{name}" if args.namespaces else "{name}"
-    fmt = "{@versions}{%compiler}{compiler_flags}{variants}{arch=architecture}"
     install_status_fn = spack.spec.Spec.install_status
+
+    fmt = spack.spec.display_format
+    if args.namespaces:
+        fmt = "{namespace}." + fmt
+
     kwargs = {
         "cover": args.cover,
-        "format": name_fmt + fmt,
+        "format": fmt,
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -80,12 +80,15 @@ for further documentation regarding the spec syntax, see:
 
 
 def spec(parser, args):
-    name_fmt = "{namespace}.{name}" if args.namespaces else "{name}"
-    fmt = "{@versions}{%compiler}{compiler_flags}{variants}{arch=architecture}"
     install_status_fn = spack.spec.Spec.install_status
+
+    fmt = spack.spec.display_format
+    if args.namespaces:
+        fmt = "{namespace}." + fmt
+
     tree_kwargs = {
         "cover": args.cover,
-        "format": name_fmt + fmt,
+        "format": fmt,
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -25,7 +25,7 @@ level = "long"
 
 
 # tutorial configuration parameters
-tutorial_branch = "releases/v0.19"
+tutorial_branch = "releases/v0.20"
 tutorial_mirror = "file:///mirror"
 tutorial_key = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -804,8 +804,10 @@ def is_mixed_toolchain(compiler):
             toolchains.add(compiler_cls.__name__)
 
     if len(toolchains) > 1:
-        if toolchains == set(["Clang", "AppleClang", "Aocc"]) or toolchains == set(
-            ["Dpcpp", "Oneapi"]
+        if (
+            toolchains == set(["Clang", "AppleClang", "Aocc"])
+            # Msvc toolchain uses Intel ifx
+            or toolchains == set(["Msvc", "Dpcpp", "Oneapi"])
         ):
             return False
         tty.debug("[TOOLCHAINS] {0}".format(toolchains))

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -30,7 +30,7 @@ fortran_mapping = {
 
 
 def get_valid_fortran_pth(comp_ver):
-    cl_ver = str(comp_ver).split("@")[1]
+    cl_ver = str(comp_ver)
     sort_fn = lambda fc_ver: StrictVersion(fc_ver)
     sort_fc_ver = sorted(list(avail_fc_version), key=sort_fn)
     for ver in sort_fc_ver:
@@ -75,7 +75,7 @@ class Msvc(Compiler):
     # file based on compiler executable path.
 
     def __init__(self, *args, **kwargs):
-        new_pth = [pth if pth else get_valid_fortran_pth(args[0]) for pth in args[3]]
+        new_pth = [pth if pth else get_valid_fortran_pth(args[0].version) for pth in args[3]]
         args[3][:] = new_pth
         super(Msvc, self).__init__(*args, **kwargs)
         if os.getenv("ONEAPI_ROOT"):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1654,8 +1654,14 @@ class InvalidDatabaseVersionError(SpackError):
     """Exception raised when the database metadata is newer than current Spack."""
 
     def __init__(self, database, expected, found):
+        self.expected = expected
+        self.found = found
         msg = (
-            f"you need a newer Spack version to read the database in '{database.root}'. "
-            f"The expected database version is '{expected}', but '{found}' was found."
+            f"you need a newer Spack version to read the DB in '{database.root}'. "
+            f"{self.database_version_message}"
         )
         super(InvalidDatabaseVersionError, self).__init__(msg)
+
+    @property
+    def database_version_message(self):
+        return f"The expected DB version is '{self.expected}', but '{self.found}' was found."

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -16,18 +16,24 @@ Spack environments have existed since Spack ``v0.12.0``, and there have been 4 d
 The high-level format of a Spack lockfile hasn't changed much between versions, but the
 contents have.  Lockfiles are JSON-formatted and their top-level sections are:
 
-  1. ``_meta`` (object): this contains deatails about the file format, including:
+  1. ``_meta`` (object): this contains details about the file format, including:
       * ``file-type``: always ``"spack-lockfile"``
       * ``lockfile-version``: an integer representing the lockfile format version
       * ``specfile-version``: an integer representing the spec format version (since
         ``v0.17``)
 
-  2. ``roots`` (list): an ordered list of records representing the roots of the Spack
+  2. ``spack`` (object): optional, this identifies information about Spack
+      used to concretize the environment:
+      * ``type``: required, identifies form Spack version took (e.g., ``git``, ``release``)
+      * ``commit``: the commit if the version is from git
+      * ``version``: the Spack version
+
+  3. ``roots`` (list): an ordered list of records representing the roots of the Spack
       environment. Each has two fields:
       * ``hash``: a Spack spec hash uniquely identifying the concrete root spec
       * ``spec``: a string representation of the abstract spec that was concretized
 
-3. ``concrete_specs``: a dictionary containing the specs in the environment.
+  4. ``concrete_specs``: a dictionary containing the specs in the environment.
 
 Compatibility
 -------------
@@ -271,6 +277,8 @@ now includes build dependencies and a canonical hash of the ``package.py`` file.
 Dependencies are keyed by ``hash`` (DAG hash) as well. There are no more ``build_hash``
 fields in the specs, and there are no more issues with lockfiles being able to store
 multiple specs with the same DAG hash (because the DAG hash is now finer-grained).
+An optional ``spack`` property may be included to track version information, such as
+the commit or version.
 
 
 .. code-block:: json
@@ -278,8 +286,8 @@ multiple specs with the same DAG hash (because the DAG hash is now finer-grained
     {
         "_meta": {
             "file-type": "spack-lockfile",
-            "lockfile-version": 3,
-            "specfile-version": 2
+            "lockfile-version": 4,
+            "specfile-version": 3
         },
         "roots": [
             {
@@ -326,7 +334,6 @@ multiple specs with the same DAG hash (because the DAG hash is now finer-grained
             }
         }
     }
-
 """
 
 from .environment import (

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1119,9 +1119,9 @@ class Environment:
             raise SpackEnvironmentError(f"No list {list_name} exists in environment {self.name}")
 
         if list_name == user_speclist_name:
-            if not spec.name:
+            if spec.anonymous:
                 raise SpackEnvironmentError("cannot add anonymous specs to an environment")
-            elif not spack.repo.path.exists(spec.name):
+            elif not spack.repo.path.exists(spec.name) and not spec.abstract_hash:
                 virtuals = spack.repo.path.provider_index.providers.keys()
                 if spec.name not in virtuals:
                     msg = "no such package: %s" % spec.name

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2127,10 +2127,12 @@ class Environment:
             reader = READER_CLS[current_lockfile_format]
         except KeyError:
             msg = (
-                f"Spack {spack.__version__} cannot read environment lockfiles using the "
-                f"v{current_lockfile_format} format"
+                f"Spack {spack.__version__} cannot read the lockfile '{self.lock_path}', using "
+                f"the v{current_lockfile_format} format."
             )
-            raise RuntimeError(msg)
+            if lockfile_format_version < current_lockfile_format:
+                msg += " You need to use a newer Spack version."
+            raise SpackEnvironmentError(msg)
 
         # First pass: Put each spec in the map ignoring dependencies
         for lockfile_key, node_dict in json_specs_by_hash.items():

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1475,7 +1475,10 @@ class Environment:
 
         # Solve the environment in parallel on Linux
         start = time.time()
-        max_processes = min(len(arguments), 16)  # Number of specs  # Cap on 16 cores
+        max_processes = min(
+            len(arguments),  # Number of specs
+            spack.config.get("config:build_jobs"),  # Cap on build jobs
+        )
 
         # TODO: revisit this print as soon as darwin is parallel too
         msg = "Starting concretization"

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2324,6 +2324,7 @@ def display_specs(concretized_specs):
     def _tree_to_display(spec):
         return spec.tree(
             recurse_dependencies=True,
+            format=spack.spec.display_format,
             status_fn=spack.spec.Spec.install_status,
             hashlen=7,
             hashes=True,

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -31,6 +31,7 @@ import spack.config
 import spack.error
 import spack.hash_types as ht
 import spack.hooks
+import spack.main
 import spack.paths
 import spack.repo
 import spack.schema.env
@@ -2072,6 +2073,14 @@ class Environment:
 
         hash_spec_list = zip(self.concretized_order, self.concretized_user_specs)
 
+        spack_dict = {"version": spack.spack_version}
+        spack_commit = spack.main.get_spack_commit()
+        if spack_commit:
+            spack_dict["type"] = "git"
+            spack_dict["commit"] = spack_commit
+        else:
+            spack_dict["type"] = "release"
+
         # this is the lockfile we'll write out
         data = {
             # metadata about the format
@@ -2080,6 +2089,8 @@ class Environment:
                 "lockfile-version": lockfile_format_version,
                 "specfile-version": spack.spec.SPECFILE_FORMAT_VERSION,
             },
+            # spack version information
+            "spack": spack_dict,
             # users specs + hashes are the 'roots' of the environment
             "roots": [{"hash": h, "spec": str(s)} for h, s in hash_spec_list],
             # Concrete specs by hash, including dependencies

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -170,17 +170,12 @@ def merge_config_rules(configuration, spec):
     Returns:
         dict: actions to be taken on the spec passed as an argument
     """
-
-    # Get the top-level configuration for the module type we are using
-    module_specific_configuration = copy.deepcopy(configuration)
-
-    # Construct a dictionary with the actions we need to perform on the spec
-    # passed as a parameter
-
+    # Construct a dictionary with the actions we need to perform on the spec passed as a parameter
+    spec_configuration = {}
     # The keyword 'all' is always evaluated first, all the others are
     # evaluated in order of appearance in the module file
-    spec_configuration = module_specific_configuration.pop("all", {})
-    for constraint, action in module_specific_configuration.items():
+    spec_configuration.update(copy.deepcopy(configuration.get("all", {})))
+    for constraint, action in configuration.items():
         if spec.satisfies(constraint):
             if hasattr(constraint, "override") and constraint.override:
                 spec_configuration = {}
@@ -200,14 +195,14 @@ def merge_config_rules(configuration, spec):
     # configuration
 
     # Hash length in module files
-    hash_length = module_specific_configuration.get("hash_length", 7)
+    hash_length = configuration.get("hash_length", 7)
     spec_configuration["hash_length"] = hash_length
 
-    verbose = module_specific_configuration.get("verbose", False)
+    verbose = configuration.get("verbose", False)
     spec_configuration["verbose"] = verbose
 
     # module defaults per-package
-    defaults = module_specific_configuration.get("defaults", [])
+    defaults = configuration.get("defaults", [])
     spec_configuration["defaults"] = defaults
 
     return spec_configuration

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2017,7 +2017,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     # stack instead of from traceback.
                     # The traceback is truncated here, so we can't use it to
                     # traverse the stack.
-                    m = "\n".join(spack.build_environment.get_package_context(tb))
+                    context = spack.build_environment.get_package_context(tb)
+                    m = "\n".join(context) if context else ""
 
                 exc = e  # e is deleted after this block
 

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -92,6 +92,11 @@ named_attributes_schema = {
         {
             "type": "object",
             "additionalProperties": False,
+            "properties": {"copy-job": attributes_schema, "copy-job-remove": attributes_schema},
+        },
+        {
+            "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "reindex-job": attributes_schema,
                 "reindex-job-remove": attributes_schema,

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -861,9 +861,9 @@ class SpackSolverSetup(object):
     def __init__(self, tests=False):
         self.gen = None  # set by setup()
 
-        self.declared_versions = {}
-        self.possible_versions = {}
-        self.deprecated_versions = {}
+        self.declared_versions = collections.defaultdict(list)
+        self.possible_versions = collections.defaultdict(set)
+        self.deprecated_versions = collections.defaultdict(set)
 
         self.possible_virtuals = None
         self.possible_compilers = []
@@ -1722,10 +1722,6 @@ class SpackSolverSetup(object):
 
     def build_version_dict(self, possible_pkgs):
         """Declare any versions in specs not declared in packages."""
-        self.declared_versions = collections.defaultdict(list)
-        self.possible_versions = collections.defaultdict(set)
-        self.deprecated_versions = collections.defaultdict(set)
-
         packages_yaml = spack.config.get("packages")
         packages_yaml = _normalize_packages_yaml(packages_yaml)
         for pkg_name in possible_pkgs:
@@ -1766,12 +1762,7 @@ class SpackSolverSetup(object):
                 if isinstance(v, vn.GitVersion):
                     version_defs.append(v)
                 else:
-                    satisfying_versions = list(x for x in pkg_class.versions if x.satisfies(v))
-                    if not satisfying_versions:
-                        raise spack.config.ConfigError(
-                            "Preference for version {0} does not match any version "
-                            " defined in {1}".format(str(v), pkg_name)
-                        )
+                    satisfying_versions = self._check_for_defined_matching_versions(pkg_class, v)
                     # Amongst all defined versions satisfying this specific
                     # preference, the highest-numbered version is the
                     # most-preferred: therefore sort satisfying versions
@@ -1783,6 +1774,28 @@ class SpackSolverSetup(object):
                     DeclaredVersion(version=vdef, idx=weight, origin=Provenance.PACKAGES_YAML)
                 )
                 self.possible_versions[pkg_name].add(vdef)
+
+    def _check_for_defined_matching_versions(self, pkg_class, v):
+        """Given a version specification (which may be a concrete version,
+        range, etc.), determine if any package.py version declarations
+        or externals define a version which satisfies it.
+
+        This is primarily for determining whether a version request (e.g.
+        version preferences, which should not themselves define versions)
+        refers to a defined version.
+
+        This function raises an exception if no satisfying versions are
+        found.
+        """
+        pkg_name = pkg_class.name
+        satisfying_versions = list(x for x in pkg_class.versions if x.satisfies(v))
+        satisfying_versions.extend(x for x in self.possible_versions[pkg_name] if x.satisfies(v))
+        if not satisfying_versions:
+            raise spack.config.ConfigError(
+                "Preference for version {0} does not match any version"
+                " defined for {1} (in its package.py or any external)".format(str(v), pkg_name)
+            )
+        return satisfying_versions
 
     def add_concrete_versions_from_specs(self, specs, origin):
         """Add concrete versions to possible versions from lists of CLI/dev specs."""
@@ -2215,14 +2228,6 @@ class SpackSolverSetup(object):
         # get possible compilers
         self.possible_compilers = self.generate_possible_compilers(specs)
 
-        # traverse all specs and packages to build dict of possible versions
-        self.build_version_dict(possible)
-        self.add_concrete_versions_from_specs(specs, Provenance.SPEC)
-        self.add_concrete_versions_from_specs(dev_specs, Provenance.DEV_SPEC)
-
-        req_version_specs = _get_versioned_specs_from_pkg_requirements()
-        self.add_concrete_versions_from_specs(req_version_specs, Provenance.PACKAGE_REQUIREMENT)
-
         self.gen.h1("Concrete input spec definitions")
         self.define_concrete_input_specs(specs, possible)
 
@@ -2249,6 +2254,14 @@ class SpackSolverSetup(object):
         self.provider_defaults()
         self.provider_requirements()
         self.external_packages()
+
+        # traverse all specs and packages to build dict of possible versions
+        self.build_version_dict(possible)
+        self.add_concrete_versions_from_specs(specs, Provenance.SPEC)
+        self.add_concrete_versions_from_specs(dev_specs, Provenance.DEV_SPEC)
+
+        req_version_specs = self._get_versioned_specs_from_pkg_requirements()
+        self.add_concrete_versions_from_specs(req_version_specs, Provenance.PACKAGE_REQUIREMENT)
 
         self.gen.h1("Package Constraints")
         for pkg in sorted(self.pkgs):
@@ -2296,83 +2309,78 @@ class SpackSolverSetup(object):
         if self.concretize_everything:
             self.gen.fact(fn.concretize_everything())
 
+    def _get_versioned_specs_from_pkg_requirements(self):
+        """If package requirements mention versions that are not mentioned
+        elsewhere, then we need to collect those to mark them as possible
+        versions.
+        """
+        req_version_specs = list()
+        config = spack.config.get("packages")
+        for pkg_name, d in config.items():
+            if pkg_name == "all":
+                continue
+            if "require" in d:
+                req_version_specs.extend(self._specs_from_requires(pkg_name, d["require"]))
+        return req_version_specs
 
-def _get_versioned_specs_from_pkg_requirements():
-    """If package requirements mention versions that are not mentioned
-    elsewhere, then we need to collect those to mark them as possible
-    versions.
-    """
-    req_version_specs = list()
-    config = spack.config.get("packages")
-    for pkg_name, d in config.items():
-        if pkg_name == "all":
-            continue
-        if "require" in d:
-            req_version_specs.extend(_specs_from_requires(pkg_name, d["require"]))
-    return req_version_specs
-
-
-def _specs_from_requires(pkg_name, section):
-    """Collect specs from requirements which define versions (i.e. those that
-    have a concrete version). Requirements can define *new* versions if
-    they are included as part of an equivalence (hash=number) but not
-    otherwise.
-    """
-    if isinstance(section, str):
-        spec = spack.spec.Spec(section)
-        if not spec.name:
-            spec.name = pkg_name
-        extracted_specs = [spec]
-    else:
-        spec_strs = []
-        for spec_group in section:
-            if isinstance(spec_group, str):
-                spec_strs.append(spec_group)
-            else:
-                # Otherwise it is an object. The object can contain a single
-                # "spec" constraint, or a list of them with "any_of" or
-                # "one_of" policy.
-                if "spec" in spec_group:
-                    new_constraints = [spec_group["spec"]]
-                else:
-                    key = "one_of" if "one_of" in spec_group else "any_of"
-                    new_constraints = spec_group[key]
-                spec_strs.extend(new_constraints)
-
-        extracted_specs = []
-        for spec_str in spec_strs:
-            spec = spack.spec.Spec(spec_str)
+    def _specs_from_requires(self, pkg_name, section):
+        """Collect specs from requirements which define versions (i.e. those that
+        have a concrete version). Requirements can define *new* versions if
+        they are included as part of an equivalence (hash=number) but not
+        otherwise.
+        """
+        if isinstance(section, str):
+            spec = spack.spec.Spec(section)
             if not spec.name:
                 spec.name = pkg_name
-            extracted_specs.append(spec)
+            extracted_specs = [spec]
+        else:
+            spec_strs = []
+            for spec_group in section:
+                if isinstance(spec_group, str):
+                    spec_strs.append(spec_group)
+                else:
+                    # Otherwise it is an object. The object can contain a single
+                    # "spec" constraint, or a list of them with "any_of" or
+                    # "one_of" policy.
+                    if "spec" in spec_group:
+                        new_constraints = [spec_group["spec"]]
+                    else:
+                        key = "one_of" if "one_of" in spec_group else "any_of"
+                        new_constraints = spec_group[key]
+                    spec_strs.extend(new_constraints)
 
-    version_specs = []
-    for spec in extracted_specs:
-        if spec.versions.concrete:
-            # Note: this includes git versions
-            version_specs.append(spec)
-            continue
+            extracted_specs = []
+            for spec_str in spec_strs:
+                spec = spack.spec.Spec(spec_str)
+                if not spec.name:
+                    spec.name = pkg_name
+                extracted_specs.append(spec)
 
-        # Prefer spec's name if it exists, in case the spec is
-        # requiring a specific implementation inside of a virtual section
-        # e.g. packages:mpi:require:openmpi@4.0.1
-        pkg_class = spack.repo.path.get_pkg_class(spec.name or pkg_name)
-        satisfying_versions = list(v for v in pkg_class.versions if v.satisfies(spec.versions))
-        if not satisfying_versions:
-            raise spack.config.ConfigError(
-                "{0} assigns a version that is not defined in"
-                " the associated package.py".format(str(spec))
+        version_specs = []
+        for spec in extracted_specs:
+            if spec.versions.concrete:
+                # Note: this includes git versions
+                version_specs.append(spec)
+                continue
+
+            # Prefer spec's name if it exists, in case the spec is
+            # requiring a specific implementation inside of a virtual section
+            # e.g. packages:mpi:require:openmpi@4.0.1
+            pkg_class = spack.repo.path.get_pkg_class(spec.name or pkg_name)
+            satisfying_versions = self._check_for_defined_matching_versions(
+                pkg_class, spec.versions
             )
 
-        # Version ranges ("@1.3" without the "=", "@1.2:1.4") and lists
-        # will end up here
-        ordered_satisfying_versions = sorted(satisfying_versions, reverse=True)
-        vspecs = list(spack.spec.Spec("@{0}".format(x)) for x in ordered_satisfying_versions)
-        version_specs.extend(vspecs)
+            # Version ranges ("@1.3" without the "=", "@1.2:1.4") and lists
+            # will end up here
+            ordered_satisfying_versions = sorted(satisfying_versions, reverse=True)
+            vspecs = list(spack.spec.Spec("@{0}".format(x)) for x in ordered_satisfying_versions)
+            version_specs.extend(vspecs)
 
-    for spec in version_specs:
-        spec.attach_git_version_lookup()
-    return version_specs
+        for spec in version_specs:
+            spec.attach_git_version_lookup()
+        return version_specs
 
 
 class SpecBuilder(object):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2789,11 +2789,11 @@ class Spec(object):
         # Also record all patches required on dependencies by
         # depends_on(..., patch=...)
         for dspec in root.traverse_edges(deptype=all, cover="edges", root=False):
-            pkg_deps = dspec.parent.package_class.dependencies
-            if dspec.spec.name not in pkg_deps:
+            if dspec.spec.concrete:
                 continue
 
-            if dspec.spec.concrete:
+            pkg_deps = dspec.parent.package_class.dependencies
+            if dspec.spec.name not in pkg_deps:
                 continue
 
             patches = []

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -110,7 +110,6 @@ __all__ = [
     "UnsatisfiableDependencySpecError",
     "AmbiguousHashError",
     "InvalidHashError",
-    "NoSuchHashError",
     "RedundantSpecError",
     "SpecDeprecatedError",
 ]
@@ -147,7 +146,7 @@ _separators = "[\\%s]" % "\\".join(color_formats.keys())
 
 default_format = "{name}{@versions}"
 default_format += "{%compiler.name}{@compiler.versions}{compiler_flags}"
-default_format += "{variants}{arch=architecture}"
+default_format += "{variants}{arch=architecture}{/abstract_hash}"
 
 #: Regular expression to pull spec contents out of clearsigned signature
 #: file.
@@ -1249,6 +1248,7 @@ class SpecBuildInterface(lang.ObjectWrapper):
 class Spec(object):
     #: Cache for spec's prefix, computed lazily in the corresponding property
     _prefix = None
+    abstract_hash = None
 
     @staticmethod
     def default_arch():
@@ -1556,7 +1556,7 @@ class Spec(object):
 
     def _add_dependency(self, spec: "Spec", *, deptypes: dp.DependencyArgument):
         """Called by the parser to add another spec as a dependency."""
-        if spec.name not in self._dependencies:
+        if spec.name not in self._dependencies or not spec.name:
             self.add_dependency_edge(spec, deptypes=deptypes)
             return
 
@@ -1616,6 +1616,10 @@ class Spec(object):
             if self.namespace
             else (self.name if self.name else "")
         )
+
+    @property
+    def anonymous(self):
+        return not self.name and not self.abstract_hash
 
     @property
     def root(self):
@@ -1824,6 +1828,73 @@ class Spec(object):
     def process_hash_bit_prefix(self, bits):
         """Get the first <bits> bits of the DAG hash as an integer type."""
         return spack.util.hash.base32_prefix_bits(self.process_hash(), bits)
+
+    def _lookup_hash(self):
+        """Lookup just one spec with an abstract hash, returning a spec from the the environment,
+        store, or finally, binary caches."""
+        import spack.environment
+
+        matches = []
+        active_env = spack.environment.active_environment()
+
+        if active_env:
+            env_matches = active_env.get_by_hash(self.abstract_hash) or []
+            matches = [m for m in env_matches if m._satisfies(self)]
+        if not matches:
+            db_matches = spack.store.db.get_by_hash(self.abstract_hash) or []
+            matches = [m for m in db_matches if m._satisfies(self)]
+        if not matches:
+            query = spack.binary_distribution.BinaryCacheQuery(True)
+            remote_matches = query("/" + self.abstract_hash) or []
+            matches = [m for m in remote_matches if m._satisfies(self)]
+        if not matches:
+            raise InvalidHashError(self, self.abstract_hash)
+
+        if len(matches) != 1:
+            raise spack.spec.AmbiguousHashError(
+                f"Multiple packages specify hash beginning '{self.abstract_hash}'.", *matches
+            )
+
+        return matches[0]
+
+    def lookup_hash(self):
+        """Given a spec with an abstract hash, return a copy of the spec with all properties and
+        dependencies by looking up the hash in the environment, store, or finally, binary caches.
+        This is non-destructive."""
+        if self.concrete or not any(node.abstract_hash for node in self.traverse()):
+            return self
+
+        spec = self.copy(deps=False)
+        # root spec is replaced
+        if spec.abstract_hash:
+            new = self._lookup_hash()
+            spec._dup(new)
+            return spec
+
+        # Get dependencies that need to be replaced
+        for node in self.traverse(root=False):
+            if node.abstract_hash:
+                new = node._lookup_hash()
+                spec._add_dependency(new, deptypes=())
+
+        # reattach nodes that were not otherwise satisfied by new dependencies
+        for node in self.traverse(root=False):
+            if not any(n._satisfies(node) for n in spec.traverse()):
+                spec._add_dependency(node.copy(), deptypes=())
+
+        return spec
+
+    def replace_hash(self):
+        """Given a spec with an abstract hash, attempt to populate all properties and dependencies
+        by looking up the hash in the environment, store, or finally, binary caches.
+        This is destructive."""
+
+        if not any(node for node in self.traverse(order="post") if node.abstract_hash):
+            return
+
+        spec_by_hash = self.lookup_hash()
+
+        self._dup(spec_by_hash)
 
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
@@ -2583,6 +2654,8 @@ class Spec(object):
             )
             warnings.warn(msg)
 
+        self.replace_hash()
+
         if not self.name:
             raise spack.error.SpecError("Attempting to concretize anonymous spec")
 
@@ -2781,8 +2854,13 @@ class Spec(object):
     def _new_concretize(self, tests=False):
         import spack.solver.asp
 
-        if not self.name:
-            raise spack.error.SpecError("Spec has no name; cannot concretize an anonymous spec")
+        self.replace_hash()
+
+        for node in self.traverse():
+            if not node.name:
+                raise spack.error.SpecError(
+                    f"Spec {node} has no name; cannot concretize an anonymous spec"
+                )
 
         if self._concrete:
             return
@@ -3365,6 +3443,11 @@ class Spec(object):
                 raise spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
 
         other = self._autospec(other)
+        if other.abstract_hash:
+            if not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash):
+                self.abstract_hash = other.abstract_hash
+            elif not self.abstract_hash.startswith(other.abstract_hash):
+                raise InvalidHashError(self, other.abstract_hash)
 
         if not (self.name == other.name or (not self.name) or (not other.name)):
             raise UnsatisfiableSpecNameError(self.name, other.name)
@@ -3523,6 +3606,12 @@ class Spec(object):
         """
         other = self._autospec(other)
 
+        lhs = self.lookup_hash() or self
+        rhs = other.lookup_hash() or other
+
+        return lhs._intersects(rhs, deps)
+
+    def _intersects(self, other: "Spec", deps: bool = True) -> bool:
         if other.concrete and self.concrete:
             return self.dag_hash() == other.dag_hash()
 
@@ -3588,9 +3677,18 @@ class Spec(object):
         else:
             return True
 
-    def _intersects_dependencies(self, other):
+    def satisfies(self, other, deps=True):
+        """
+        This checks constraints on common dependencies against each other.
+        """
         other = self._autospec(other)
 
+        lhs = self.lookup_hash() or self
+        rhs = other.lookup_hash() or other
+
+        return lhs._satisfies(rhs, deps=deps)
+
+    def _intersects_dependencies(self, other):
         if not other._dependencies or not self._dependencies:
             # one spec *could* eventually satisfy the other
             return True
@@ -3625,7 +3723,7 @@ class Spec(object):
 
         return True
 
-    def satisfies(self, other: "Spec", deps: bool = True) -> bool:
+    def _satisfies(self, other: "Spec", deps: bool = True) -> bool:
         """Return True if all concrete specs matching self also match other, otherwise False.
 
         Args:
@@ -3770,6 +3868,7 @@ class Spec(object):
                 and self.external_path != other.external_path
                 and self.external_modules != other.external_modules
                 and self.compiler_flags != other.compiler_flags
+                and self.abstract_hash != other.abstract_hash
             )
 
         self._package = None
@@ -3811,6 +3910,8 @@ class Spec(object):
             self._dup_deps(other, deptypes)
 
         self._concrete = other._concrete
+
+        self.abstract_hash = other.abstract_hash
 
         if self._concrete:
             self._dunder_hash = other._dunder_hash
@@ -4001,6 +4102,7 @@ class Spec(object):
         yield self.compiler
         yield self.compiler_flags
         yield self.architecture
+        yield self.abstract_hash
 
         # this is not present on older specs
         yield getattr(self, "_package_hash", None)
@@ -4011,7 +4113,10 @@ class Spec(object):
 
     def _cmp_iter(self):
         """Lazily yield components of self for comparison."""
-        for item in self._cmp_node():
+
+        cmp_spec = self.lookup_hash() or self
+
+        for item in cmp_spec._cmp_node():
             yield item
 
         # This needs to be in _cmp_iter so that no specs with different process hashes
@@ -4022,10 +4127,10 @@ class Spec(object):
         # TODO: they exist for speed.  We should benchmark whether it's really worth
         # TODO: having two types of hashing now that we use `json` instead of `yaml` for
         # TODO: spec hashing.
-        yield self.process_hash() if self.concrete else None
+        yield cmp_spec.process_hash() if cmp_spec.concrete else None
 
         def deps():
-            for dep in sorted(itertools.chain.from_iterable(self._dependencies.values())):
+            for dep in sorted(itertools.chain.from_iterable(cmp_spec._dependencies.values())):
                 yield dep.spec.name
                 yield tuple(sorted(dep.deptypes))
                 yield hash(dep.spec)
@@ -4146,7 +4251,7 @@ class Spec(object):
                 raise SpecFormatSigilError(sig, "versions", attribute)
             elif sig == "%" and attribute not in ("compiler", "compiler.name"):
                 raise SpecFormatSigilError(sig, "compilers", attribute)
-            elif sig == "/" and not re.match(r"hash(:\d+)?$", attribute):
+            elif sig == "/" and not re.match(r"(abstract_)?hash(:\d+)?$", attribute):
                 raise SpecFormatSigilError(sig, "DAG hashes", attribute)
             elif sig == " arch=" and attribute not in ("architecture", "arch"):
                 raise SpecFormatSigilError(sig, "the architecture", attribute)
@@ -4266,7 +4371,9 @@ class Spec(object):
         return self.format(*args, **kwargs)
 
     def __str__(self):
-        sorted_nodes = [self] + sorted(self.traverse(root=False), key=lambda x: x.name)
+        sorted_nodes = [self] + sorted(
+            self.traverse(root=False), key=lambda x: x.name or x.abstract_hash
+        )
         spec_str = " ^".join(d.format() for d in sorted_nodes)
         return spec_str.strip()
 
@@ -5066,14 +5173,9 @@ class AmbiguousHashError(spack.error.SpecError):
 
 class InvalidHashError(spack.error.SpecError):
     def __init__(self, spec, hash):
-        super(InvalidHashError, self).__init__(
-            "The spec specified by %s does not match provided spec %s" % (hash, spec)
-        )
-
-
-class NoSuchHashError(spack.error.SpecError):
-    def __init__(self, hash):
-        super(NoSuchHashError, self).__init__("No installed spec matches the hash: '%s'" % hash)
+        msg = f"No spec with hash {hash} could be found to match {spec}."
+        msg += " Either the hash does not exist, or it does not match other spec constraints."
+        super(InvalidHashError, self).__init__(msg)
 
 
 class SpecFilenameError(spack.error.SpecError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -144,9 +144,20 @@ color_formats = {
 #: ``color_formats.keys()``.
 _separators = "[\\%s]" % "\\".join(color_formats.keys())
 
-default_format = "{name}{@versions}"
-default_format += "{%compiler.name}{@compiler.versions}{compiler_flags}"
-default_format += "{variants}{arch=architecture}{/abstract_hash}"
+#: Default format for Spec.format(). This format can be round-tripped, so that:
+#:     Spec(Spec("string").format()) == Spec("string)"
+default_format = (
+    "{name}{@versions}"
+    "{%compiler.name}{@compiler.versions}{compiler_flags}"
+    "{variants}{arch=architecture}{/abstract_hash}"
+)
+
+#: Display format, which eliminates extra `@=` in the output, for readability.
+display_format = (
+    "{name}{@version}"
+    "{%compiler.name}{@compiler.version}{compiler_flags}"
+    "{variants}{arch=architecture}{/abstract_hash}"
+)
 
 #: Regular expression to pull spec contents out of clearsigned signature
 #: file.

--- a/lib/spack/spack/test/cmd/concretize.py
+++ b/lib/spack/spack/test/cmd/concretize.py
@@ -7,6 +7,7 @@
 import pytest
 
 import spack.environment as ev
+from spack import spack_version
 from spack.main import SpackCommand
 
 pytestmark = pytest.mark.usefixtures("config", "mutable_mock_repo")
@@ -54,3 +55,6 @@ def test_concretize_root_test_dependencies_are_concretized(unify, mutable_mock_e
         add("b")
         concretize("--test", "root")
         assert e.matching_spec("test-dependency")
+
+        data = e._to_lockfile_dict()
+        assert data["spack"]["version"] == spack_version

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2404,7 +2404,11 @@ def test_concretize_user_specs_together():
     # Concretize a second time using 'mpich2' as the MPI provider
     e.remove("mpich")
     e.add("mpich2")
-    e.concretize()
+
+    # Concretizing without invalidating the concrete spec for mpileaks fails
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        e.concretize()
+    e.concretize(force=True)
 
     assert all("mpich2" in spec for _, spec in e.concretized_specs())
     assert all("mpich" not in spec for _, spec in e.concretized_specs())
@@ -2435,7 +2439,7 @@ def test_duplicate_packages_raise_when_concretizing_together():
     e.add("mpich")
 
     with pytest.raises(
-        spack.error.UnsatisfiableSpecError, match=r"relax the concretizer strictness"
+        spack.error.UnsatisfiableSpecError, match=r"You could consider setting `concretizer:unify`"
     ):
         e.concretize()
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -906,7 +906,7 @@ packages:
   mpileaks:
     version: ["2.2"]
   libelf:
-    version: ["0.8.11"]
+    version: ["0.8.10"]
 """
         )
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -357,3 +357,18 @@ def test_find_loaded(database, working_env):
     output = find("--loaded")
     expected = find()
     assert output == expected
+
+
+@pytest.mark.regression("37712")
+def test_environment_with_version_range_in_compiler_doesnt_fail(tmp_path):
+    """Tests that having an active environment with a root spec containing a compiler constrained
+    by a version range (i.e. @X.Y rather the single version than @=X.Y) doesn't result in an error
+    when invoking "spack find".
+    """
+    test_environment = ev.create_in_dir(tmp_path)
+    test_environment.add("zlib %gcc@12.1.0")
+    test_environment.write()
+
+    with test_environment:
+        output = find()
+    assert "zlib%gcc@12.1.0" in output

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -86,10 +86,9 @@ def test_spec_parse_unquoted_flags_report():
         # cflags, we just explain how to fix it for the immediate next arg.
         spec("gcc cflags=-Os -pipe -other-arg-that-gets-ignored cflags=-I /usr/include")
     # Verify that the generated error message is nicely formatted.
-    assert str(cm.value) == dedent(
-        '''\
-    No installed spec matches the hash: 'usr'
 
+    expected_message = dedent(
+        '''\
     Some compiler or linker flags were provided without quoting their arguments,
     which now causes spack to try to parse the *next* argument as a spec component
     such as a variant instead of an additional compiler or linker flag. If the
@@ -99,6 +98,8 @@ def test_spec_parse_unquoted_flags_report():
     (1) cflags=-Os -pipe => cflags="-Os -pipe"
     (2) cflags=-I /usr/include => cflags="-I /usr/include"'''
     )
+
+    assert expected_message in str(cm.value)
 
     # Verify that the same unquoted cflags report is generated in the error message even
     # if it fails during concretization, not just during parsing.

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -24,12 +24,12 @@ spec = SpackCommand("spec")
 def test_spec():
     output = spec("mpileaks")
 
-    assert "mpileaks@=2.3" in output
-    assert "callpath@=1.0" in output
-    assert "dyninst@=8.2" in output
-    assert "libdwarf@=20130729" in output
-    assert "libelf@=0.8.1" in output
-    assert "mpich@=3.0.4" in output
+    assert "mpileaks@2.3" in output
+    assert "callpath@1.0" in output
+    assert "dyninst@8.2" in output
+    assert "libdwarf@20130729" in output
+    assert "libelf@0.8.1" in output
+    assert "mpich@3.0.4" in output
 
 
 def test_spec_concretizer_args(mutable_config, mutable_database):
@@ -197,12 +197,12 @@ def test_env_aware_spec(mutable_mock_env_path):
 
     with env:
         output = spec()
-        assert "mpileaks@=2.3" in output
-        assert "callpath@=1.0" in output
-        assert "dyninst@=8.2" in output
-        assert "libdwarf@=20130729" in output
-        assert "libelf@=0.8.1" in output
-        assert "mpich@=3.0.4" in output
+        assert "mpileaks@2.3" in output
+        assert "callpath@1.0" in output
+        assert "dyninst@8.2" in output
+        assert "libdwarf@20130729" in output
+        assert "libelf@0.8.1" in output
+        assert "mpich@3.0.4" in output
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -319,3 +319,17 @@ def test_report_filename_for_cdash(install_mockery_mutable_config, mock_fetch):
     spack.cmd.common.arguments.sanitize_reporter_options(args)
     filename = spack.cmd.test.report_filename(args, suite)
     assert filename != "https://blahblah/submit.php?project=debugging"
+
+
+def test_test_output_multiple_specs(
+    mock_test_stage, mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config
+):
+    """Ensure proper reporting for suite with skipped, failing, and passed tests."""
+    install("test-error", "simple-standalone-test@0.9", "simple-standalone-test@1.0")
+    out = spack_test("run", "test-error", "simple-standalone-test", fail_on_error=False)
+
+    # Note that a spec with passing *and* skipped tests is still considered
+    # to have passed at this level. If you want to see the spec-specific
+    # part result summaries, you'll have to look at the "test-out.txt" files
+    # for each spec.
+    assert "1 failed, 2 passed of 3 specs" in out

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -66,6 +66,28 @@ class V(Package):
 )
 
 
+_pkgt = (
+    "t",
+    """\
+class T(Package):
+    version('2.1')
+    version('2.0')
+
+    depends_on('u', when='@2.1:')
+""",
+)
+
+
+_pkgu = (
+    "u",
+    """\
+class U(Package):
+    version('1.1')
+    version('1.0')
+""",
+)
+
+
 @pytest.fixture
 def create_test_repo(tmpdir, mutable_config):
     repo_path = str(tmpdir)
@@ -79,7 +101,7 @@ repo:
         )
 
     packages_dir = tmpdir.join("packages")
-    for pkg_name, pkg_str in [_pkgx, _pkgy, _pkgv]:
+    for pkg_name, pkg_str in [_pkgx, _pkgy, _pkgv, _pkgt, _pkgu]:
         pkg_dir = packages_dir.ensure(pkg_name, dir=True)
         pkg_file = pkg_dir.join("package.py")
         with open(str(pkg_file), "w") as f:
@@ -142,6 +164,45 @@ packages:
     update_packages_config(conf_str)
     with pytest.raises(UnsatisfiableSpecError):
         Spec("x@1.1").concretize()
+
+
+def test_require_undefined_version(concretize_scope, test_repo):
+    """If a requirement specifies a numbered version that isn't in
+    the associated package.py and isn't part of a Git hash
+    equivalence (hash=number), then Spack should raise an error
+    (it is assumed this is a typo, and raising the error here
+    avoids a likely error when Spack attempts to fetch the version).
+    """
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration requirements")
+
+    conf_str = """\
+packages:
+  x:
+    require: "@1.2"
+"""
+    update_packages_config(conf_str)
+    with pytest.raises(spack.config.ConfigError):
+        Spec("x").concretize()
+
+
+def test_require_truncated(concretize_scope, test_repo):
+    """A requirement specifies a version range, with satisfying
+    versions defined in the package.py. Make sure we choose one
+    of the defined versions (vs. allowing the requirement to
+    define a new version).
+    """
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration requirements")
+
+    conf_str = """\
+packages:
+  x:
+    require: "@1"
+"""
+    update_packages_config(conf_str)
+    xspec = Spec("x").concretized()
+    assert xspec.satisfies("@1.1")
 
 
 def test_git_user_supplied_reference_satisfaction(
@@ -218,6 +279,40 @@ packages:
     # Make sure the git commit info is retained
     assert isinstance(s1.version, spack.version.GitVersion)
     assert s1.version.ref == a_commit_hash
+
+
+def test_requirement_adds_version_satisfies(
+    concretize_scope, test_repo, mock_git_version_info, monkeypatch
+):
+    """Make sure that new versions added by requirements are factored into
+    conditions. In this case create a new version that satisfies a
+    depends_on condition and make sure it is triggered (i.e. the
+    dependency is added).
+    """
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration" " requirements")
+
+    repo_path, filename, commits = mock_git_version_info
+    monkeypatch.setattr(
+        spack.package_base.PackageBase, "git", path_to_file_url(repo_path), raising=False
+    )
+
+    # Sanity check: early version of T does not include U
+    s0 = Spec("t@2.0").concretized()
+    assert not ("u" in s0)
+
+    conf_str = """\
+packages:
+  t:
+    require: "@{0}=2.2"
+""".format(
+        commits[0]
+    )
+    update_packages_config(conf_str)
+
+    s1 = Spec("t").concretized()
+    assert "u" in s1
+    assert s1.satisfies("@2.2")
 
 
 def test_requirement_adds_git_hash_version(

--- a/lib/spack/spack/test/data/unparse/amdfftw.txt
+++ b/lib/spack/spack/test/data/unparse/amdfftw.txt
@@ -31,194 +31,164 @@ class Amdfftw(FftwBase):
     Example : spack install amdfftw precision=float
     """
 
-    _name = 'amdfftw'
+    _name = "amdfftw"
     homepage = "https://developer.amd.com/amd-aocl/fftw/"
     url = "https://github.com/amd/amd-fftw/archive/3.0.tar.gz"
     git = "https://github.com/amd/amd-fftw.git"
 
-    maintainers = ['amd-toolchain-support']
+    maintainers("amd-toolchain-support")
 
-    version('3.1', sha256='3e777f3acef13fa1910db097e818b1d0d03a6a36ef41186247c6ab1ab0afc132')
-    version('3.0.1', sha256='87030c6bbb9c710f0a64f4f306ba6aa91dc4b182bb804c9022b35aef274d1a4c')
-    version('3.0', sha256='a69deaf45478a59a69f77c4f7e9872967f1cfe996592dd12beb6318f18ea0bcd')
-    version('2.2', sha256='de9d777236fb290c335860b458131678f75aa0799c641490c644c843f0e246f8')
+    version("3.1", sha256="3e777f3acef13fa1910db097e818b1d0d03a6a36ef41186247c6ab1ab0afc132")
+    version("3.0.1", sha256="87030c6bbb9c710f0a64f4f306ba6aa91dc4b182bb804c9022b35aef274d1a4c")
+    version("3.0", sha256="a69deaf45478a59a69f77c4f7e9872967f1cfe996592dd12beb6318f18ea0bcd")
+    version("2.2", sha256="de9d777236fb290c335860b458131678f75aa0799c641490c644c843f0e246f8")
 
-    variant('shared', default=True,
-            description='Builds a shared version of the library')
-    variant('openmp', default=True,
-            description='Enable OpenMP support')
-    variant('threads', default=False,
-            description='Enable SMP threads support')
-    variant('debug', default=False,
-            description='Builds a debug version of the library')
+    variant("shared", default=True, description="Builds a shared version of the library")
+    variant("openmp", default=True, description="Enable OpenMP support")
+    variant("threads", default=False, description="Enable SMP threads support")
+    variant("debug", default=False, description="Builds a debug version of the library")
     variant(
-        'amd-fast-planner',
+        "amd-fast-planner",
         default=False,
-        description='Option to reduce the planning time without much'
-                    'tradeoff in the performance. It is supported for'
-                    'Float and double precisions only.')
+        description="Option to reduce the planning time without much"
+        "tradeoff in the performance. It is supported for"
+        "Float and double precisions only.",
+    )
+    variant("amd-top-n-planner", default=False, description="Build with amd-top-n-planner support")
     variant(
-        'amd-top-n-planner',
-        default=False,
-        description='Build with amd-top-n-planner support')
-    variant(
-        'amd-mpi-vader-limit',
-        default=False,
-        description='Build with amd-mpi-vader-limit support')
-    variant(
-        'static',
-        default=False,
-        description='Build with static suppport')
-    variant(
-        'amd-trans',
-        default=False,
-        description='Build with amd-trans suppport')
-    variant(
-        'amd-app-opt',
-        default=False,
-        description='Build with amd-app-opt suppport')
+        "amd-mpi-vader-limit", default=False, description="Build with amd-mpi-vader-limit support"
+    )
+    variant("static", default=False, description="Build with static suppport")
+    variant("amd-trans", default=False, description="Build with amd-trans suppport")
+    variant("amd-app-opt", default=False, description="Build with amd-app-opt suppport")
 
-    depends_on('texinfo')
+    depends_on("texinfo")
 
-    provides('fftw-api@3', when='@2:')
+    provides("fftw-api@3", when="@2:")
 
     conflicts(
-        'precision=quad',
-        when='@2.2 %aocc',
-        msg='Quad precision is not supported by AOCC clang version 2.2')
+        "precision=quad",
+        when="@2.2 %aocc",
+        msg="Quad precision is not supported by AOCC clang version 2.2",
+    )
     conflicts(
-        '+debug',
-        when='@2.2 %aocc',
-        msg='debug mode is not supported by AOCC clang version 2.2')
+        "+debug", when="@2.2 %aocc", msg="debug mode is not supported by AOCC clang version 2.2"
+    )
+    conflicts("%gcc@:7.2", when="@2.2:", msg="GCC version above 7.2 is required for AMDFFTW")
     conflicts(
-        '%gcc@:7.2',
-        when='@2.2:',
-        msg='GCC version above 7.2 is required for AMDFFTW')
+        "+amd-fast-planner ", when="+mpi", msg="mpi thread is not supported with amd-fast-planner"
+    )
     conflicts(
-        '+amd-fast-planner ',
-        when='+mpi',
-        msg='mpi thread is not supported with amd-fast-planner')
+        "+amd-fast-planner", when="@2.2", msg="amd-fast-planner is supported from 3.0 onwards"
+    )
     conflicts(
-        '+amd-fast-planner',
-        when='@2.2',
-        msg='amd-fast-planner is supported from 3.0 onwards')
+        "+amd-fast-planner",
+        when="precision=quad",
+        msg="Quad precision is not supported with amd-fast-planner",
+    )
     conflicts(
-        '+amd-fast-planner',
-        when='precision=quad',
-        msg='Quad precision is not supported with amd-fast-planner')
+        "+amd-fast-planner",
+        when="precision=long_double",
+        msg="long_double precision is not supported with amd-fast-planner",
+    )
     conflicts(
-        '+amd-fast-planner',
-        when='precision=long_double',
-        msg='long_double precision is not supported with amd-fast-planner')
+        "+amd-top-n-planner",
+        when="@:3.0.0",
+        msg="amd-top-n-planner is supported from 3.0.1 onwards",
+    )
     conflicts(
-        '+amd-top-n-planner',
-        when='@:3.0.0',
-        msg='amd-top-n-planner is supported from 3.0.1 onwards')
+        "+amd-top-n-planner",
+        when="precision=long_double",
+        msg="long_double precision is not supported with amd-top-n-planner",
+    )
     conflicts(
-        '+amd-top-n-planner',
-        when='precision=long_double',
-        msg='long_double precision is not supported with amd-top-n-planner')
+        "+amd-top-n-planner",
+        when="precision=quad",
+        msg="Quad precision is not supported with amd-top-n-planner",
+    )
     conflicts(
-        '+amd-top-n-planner',
-        when='precision=quad',
-        msg='Quad precision is not supported with amd-top-n-planner')
+        "+amd-top-n-planner",
+        when="+amd-fast-planner",
+        msg="amd-top-n-planner cannot be used with amd-fast-planner",
+    )
     conflicts(
-        '+amd-top-n-planner',
-        when='+amd-fast-planner',
-        msg='amd-top-n-planner cannot be used with amd-fast-planner')
+        "+amd-top-n-planner", when="+threads", msg="amd-top-n-planner works only for single thread"
+    )
     conflicts(
-        '+amd-top-n-planner',
-        when='+threads',
-        msg='amd-top-n-planner works only for single thread')
+        "+amd-top-n-planner", when="+mpi", msg="mpi thread is not supported with amd-top-n-planner"
+    )
     conflicts(
-        '+amd-top-n-planner',
-        when='+mpi',
-        msg='mpi thread is not supported with amd-top-n-planner')
+        "+amd-top-n-planner",
+        when="+openmp",
+        msg="openmp thread is not supported with amd-top-n-planner",
+    )
     conflicts(
-        '+amd-top-n-planner',
-        when='+openmp',
-        msg='openmp thread is not supported with amd-top-n-planner')
+        "+amd-mpi-vader-limit",
+        when="@:3.0.0",
+        msg="amd-mpi-vader-limit is supported from 3.0.1 onwards",
+    )
     conflicts(
-        '+amd-mpi-vader-limit',
-        when='@:3.0.0',
-        msg='amd-mpi-vader-limit is supported from 3.0.1 onwards')
+        "+amd-mpi-vader-limit",
+        when="precision=quad",
+        msg="Quad precision is not supported with amd-mpi-vader-limit",
+    )
+    conflicts("+amd-trans", when="+threads", msg="amd-trans works only for single thread")
+    conflicts("+amd-trans", when="+mpi", msg="mpi thread is not supported with amd-trans")
+    conflicts("+amd-trans", when="+openmp", msg="openmp thread is not supported with amd-trans")
     conflicts(
-        '+amd-mpi-vader-limit',
-        when='precision=quad',
-        msg='Quad precision is not supported with amd-mpi-vader-limit')
+        "+amd-trans",
+        when="precision=long_double",
+        msg="long_double precision is not supported with amd-trans",
+    )
     conflicts(
-        '+amd-trans',
-        when='+threads',
-        msg='amd-trans works only for single thread')
+        "+amd-trans", when="precision=quad", msg="Quad precision is not supported with amd-trans"
+    )
+    conflicts("+amd-app-opt", when="@:3.0.1", msg="amd-app-opt is supported from 3.1 onwards")
+    conflicts("+amd-app-opt", when="+mpi", msg="mpi thread is not supported with amd-app-opt")
     conflicts(
-        '+amd-trans',
-        when='+mpi',
-        msg='mpi thread is not supported with amd-trans')
+        "+amd-app-opt",
+        when="precision=long_double",
+        msg="long_double precision is not supported with amd-app-opt",
+    )
     conflicts(
-        '+amd-trans',
-        when='+openmp',
-        msg='openmp thread is not supported with amd-trans')
-    conflicts(
-        '+amd-trans',
-        when='precision=long_double',
-        msg='long_double precision is not supported with amd-trans')
-    conflicts(
-        '+amd-trans',
-        when='precision=quad',
-        msg='Quad precision is not supported with amd-trans')
-    conflicts(
-        '+amd-app-opt',
-        when='@:3.0.1',
-        msg='amd-app-opt is supported from 3.1 onwards')
-    conflicts(
-        '+amd-app-opt',
-        when='+mpi',
-        msg='mpi thread is not supported with amd-app-opt')
-    conflicts(
-        '+amd-app-opt',
-        when='precision=long_double',
-        msg='long_double precision is not supported with amd-app-opt')
-    conflicts(
-        '+amd-app-opt',
-        when='precision=quad',
-        msg='Quad precision is not supported with amd-app-opt')
+        "+amd-app-opt",
+        when="precision=quad",
+        msg="Quad precision is not supported with amd-app-opt",
+    )
 
     def configure(self, spec, prefix):
         """Configure function"""
         # Base options
-        options = [
-            '--prefix={0}'.format(prefix),
-            '--enable-amd-opt'
-        ]
+        options = ["--prefix={0}".format(prefix), "--enable-amd-opt"]
 
         # Check if compiler is AOCC
-        if '%aocc' in spec:
-            options.append('CC={0}'.format(os.path.basename(spack_cc)))
-            options.append('FC={0}'.format(os.path.basename(spack_fc)))
-            options.append('F77={0}'.format(os.path.basename(spack_fc)))
+        if "%aocc" in spec:
+            options.append("CC={0}".format(os.path.basename(spack_cc)))
+            options.append("FC={0}".format(os.path.basename(spack_fc)))
+            options.append("F77={0}".format(os.path.basename(spack_fc)))
 
-        if '+debug' in spec:
-            options.append('--enable-debug')
+        if "+debug" in spec:
+            options.append("--enable-debug")
 
-        if '+mpi' in spec:
-            options.append('--enable-mpi')
-            options.append('--enable-amd-mpifft')
+        if "+mpi" in spec:
+            options.append("--enable-mpi")
+            options.append("--enable-amd-mpifft")
         else:
-            options.append('--disable-mpi')
-            options.append('--disable-amd-mpifft')
+            options.append("--disable-mpi")
+            options.append("--disable-amd-mpifft")
 
-        options.extend(self.enable_or_disable('shared'))
-        options.extend(self.enable_or_disable('openmp'))
-        options.extend(self.enable_or_disable('threads'))
-        options.extend(self.enable_or_disable('amd-fast-planner'))
-        options.extend(self.enable_or_disable('amd-top-n-planner'))
-        options.extend(self.enable_or_disable('amd-mpi-vader-limit'))
-        options.extend(self.enable_or_disable('static'))
-        options.extend(self.enable_or_disable('amd-trans'))
-        options.extend(self.enable_or_disable('amd-app-opt'))
+        options.extend(self.enable_or_disable("shared"))
+        options.extend(self.enable_or_disable("openmp"))
+        options.extend(self.enable_or_disable("threads"))
+        options.extend(self.enable_or_disable("amd-fast-planner"))
+        options.extend(self.enable_or_disable("amd-top-n-planner"))
+        options.extend(self.enable_or_disable("amd-mpi-vader-limit"))
+        options.extend(self.enable_or_disable("static"))
+        options.extend(self.enable_or_disable("amd-trans"))
+        options.extend(self.enable_or_disable("amd-app-opt"))
 
         if not self.compiler.f77 or not self.compiler.fc:
-            options.append('--disable-fortran')
+            options.append("--disable-fortran")
 
         # Cross compilation is supported in amd-fftw by making use of target
         # variable to set AMD_ARCH configure option.
@@ -226,17 +196,16 @@ class Amdfftw(FftwBase):
         # use target variable to set appropriate -march option in AMD_ARCH.
         arch = spec.architecture
         options.append(
-            'AMD_ARCH={0}'.format(
-                arch.target.optimization_flags(
-                    spec.compiler).split('=')[-1]))
+            "AMD_ARCH={0}".format(arch.target.optimization_flags(spec.compiler).split("=")[-1])
+        )
 
         # Specific SIMD support.
         # float and double precisions are supported
-        simd_features = ['sse2', 'avx', 'avx2']
+        simd_features = ["sse2", "avx", "avx2"]
 
         simd_options = []
         for feature in simd_features:
-            msg = '--enable-{0}' if feature in spec.target else '--disable-{0}'
+            msg = "--enable-{0}" if feature in spec.target else "--disable-{0}"
             simd_options.append(msg.format(feature))
 
         # When enabling configure option "--enable-amd-opt", do not use the
@@ -246,20 +215,19 @@ class Amdfftw(FftwBase):
         # Double is the default precision, for all the others we need
         # to enable the corresponding option.
         enable_precision = {
-            'float': ['--enable-float'],
-            'double': None,
-            'long_double': ['--enable-long-double'],
-            'quad': ['--enable-quad-precision']
+            "float": ["--enable-float"],
+            "double": None,
+            "long_double": ["--enable-long-double"],
+            "quad": ["--enable-quad-precision"],
         }
 
         # Different precisions must be configured and compiled one at a time
-        configure = Executable('../configure')
+        configure = Executable("../configure")
         for precision in self.selected_precisions:
-
             opts = (enable_precision[precision] or []) + options[:]
 
             # SIMD optimizations are available only for float and double
-            if precision in ('float', 'double'):
+            if precision in ("float", "double"):
                 opts += simd_options
 
             with working_dir(precision, create=True):

--- a/lib/spack/spack/test/data/unparse/llvm.txt
+++ b/lib/spack/spack/test/data/unparse/llvm.txt
@@ -16,21 +16,21 @@ from spack.package import *
 
 class Llvm(CMakePackage, CudaPackage):
     """The LLVM Project is a collection of modular and reusable compiler and
-       toolchain technologies. Despite its name, LLVM has little to do
-       with traditional virtual machines, though it does provide helpful
-       libraries that can be used to build them. The name "LLVM" itself
-       is not an acronym; it is the full name of the project.
+    toolchain technologies. Despite its name, LLVM has little to do
+    with traditional virtual machines, though it does provide helpful
+    libraries that can be used to build them. The name "LLVM" itself
+    is not an acronym; it is the full name of the project.
     """
 
     homepage = "https://llvm.org/"
     url = "https://github.com/llvm/llvm-project/archive/llvmorg-7.1.0.tar.gz"
     list_url = "https://releases.llvm.org/download.html"
     git = "https://github.com/llvm/llvm-project"
-    maintainers = ['trws', 'haampie']
+    maintainers("trws", "haampie")
 
-    tags = ['e4s']
+    tags = ["e4s"]
 
-    generator = 'Ninja'
+    generator = "Ninja"
 
     family = "compiler"  # Used by lmod
 
@@ -80,13 +80,12 @@ class Llvm(CMakePackage, CudaPackage):
     # to save space, build with `build_type=Release`.
 
     variant(
-        "clang",
-        default=True,
-        description="Build the LLVM C/C++/Objective-C compiler frontend",
+        "clang", default=True, description="Build the LLVM C/C++/Objective-C compiler frontend"
     )
     variant(
         "flang",
-        default=False, when='@11: +clang',
+        default=False,
+        when="@11: +clang",
         description="Build the LLVM Fortran compiler frontend "
         "(experimental - parser only, needs GCC)",
     )
@@ -95,27 +94,23 @@ class Llvm(CMakePackage, CudaPackage):
         default=False,
         description="Include debugging code in OpenMP runtime libraries",
     )
-    variant("lldb", default=True, when='+clang', description="Build the LLVM debugger")
+    variant("lldb", default=True, when="+clang", description="Build the LLVM debugger")
     variant("lld", default=True, description="Build the LLVM linker")
-    variant("mlir", default=False, when='@10:', description="Build with MLIR support")
+    variant("mlir", default=False, when="@10:", description="Build with MLIR support")
     variant(
-        "internal_unwind",
-        default=True, when='+clang',
-        description="Build the libcxxabi libunwind",
+        "internal_unwind", default=True, when="+clang", description="Build the libcxxabi libunwind"
     )
     variant(
         "polly",
         default=True,
-        description="Build the LLVM polyhedral optimization plugin, "
-        "only builds for 3.7.0+",
+        description="Build the LLVM polyhedral optimization plugin, " "only builds for 3.7.0+",
     )
     variant(
-        "libcxx",
-        default=True, when='+clang',
-        description="Build the LLVM C++ standard library",
+        "libcxx", default=True, when="+clang", description="Build the LLVM C++ standard library"
     )
     variant(
-        "compiler-rt", when='+clang',
+        "compiler-rt",
+        when="+clang",
         default=True,
         description="Build LLVM compiler runtime, including sanitizers",
     )
@@ -124,11 +119,7 @@ class Llvm(CMakePackage, CudaPackage):
         default=(sys.platform != "darwin"),
         description="Add support for LTO with the gold linker plugin",
     )
-    variant(
-        "split_dwarf",
-        default=False,
-        description="Build with split dwarf information",
-    )
+    variant("split_dwarf", default=False, description="Build with split dwarf information")
     variant(
         "llvm_dylib",
         default=True,
@@ -136,18 +127,40 @@ class Llvm(CMakePackage, CudaPackage):
     )
     variant(
         "link_llvm_dylib",
-        default=False, when='+llvm_dylib',
+        default=False,
+        when="+llvm_dylib",
         description="Link LLVM tools against the LLVM shared library",
     )
     variant(
         "targets",
         default="none",
-        description=("What targets to build. Spack's target family is always added "
-                     "(e.g. X86 is automatically enabled when targeting znver2)."),
-        values=("all", "none", "aarch64", "amdgpu", "arm", "avr", "bpf", "cppbackend",
-                "hexagon", "lanai", "mips", "msp430", "nvptx", "powerpc", "riscv",
-                "sparc", "systemz", "webassembly", "x86", "xcore"),
-        multi=True
+        description=(
+            "What targets to build. Spack's target family is always added "
+            "(e.g. X86 is automatically enabled when targeting znver2)."
+        ),
+        values=(
+            "all",
+            "none",
+            "aarch64",
+            "amdgpu",
+            "arm",
+            "avr",
+            "bpf",
+            "cppbackend",
+            "hexagon",
+            "lanai",
+            "mips",
+            "msp430",
+            "nvptx",
+            "powerpc",
+            "riscv",
+            "sparc",
+            "systemz",
+            "webassembly",
+            "x86",
+            "xcore",
+        ),
+        multi=True,
     )
     variant(
         "build_type",
@@ -157,51 +170,52 @@ class Llvm(CMakePackage, CudaPackage):
     )
     variant(
         "omp_tsan",
-        default=False, when='@6:',
+        default=False,
+        when="@6:",
         description="Build with OpenMP capable thread sanitizer",
     )
     variant(
         "omp_as_runtime",
         default=True,
-        when='+clang @12:',
+        when="+clang @12:",
         description="Build OpenMP runtime via ENABLE_RUNTIME by just-built Clang",
     )
-    variant('code_signing', default=False,
-            when='+lldb platform=darwin',
-            description="Enable code-signing on macOS")
-    variant("python", default=False, description="Install python bindings")
-    variant('version_suffix', default='none', description="Add a symbol suffix")
     variant(
-        'shlib_symbol_version',
-        default='none',
+        "code_signing",
+        default=False,
+        when="+lldb platform=darwin",
+        description="Enable code-signing on macOS",
+    )
+    variant("python", default=False, description="Install python bindings")
+    variant("version_suffix", default="none", description="Add a symbol suffix")
+    variant(
+        "shlib_symbol_version",
+        default="none",
         description="Add shared library symbol version",
-        when='@13:'
+        when="@13:",
     )
     variant(
-        'z3',
-        default=False,
-        when='+clang @8:',
-        description='Use Z3 for the clang static analyzer'
+        "z3", default=False, when="+clang @8:", description="Use Z3 for the clang static analyzer"
     )
 
-    provides('libllvm@14', when='@14.0.0:14')
-    provides('libllvm@13', when='@13.0.0:13')
-    provides('libllvm@12', when='@12.0.0:12')
-    provides('libllvm@11', when='@11.0.0:11')
-    provides('libllvm@10', when='@10.0.0:10')
-    provides('libllvm@9', when='@9.0.0:9')
-    provides('libllvm@8', when='@8.0.0:8')
-    provides('libllvm@7', when='@7.0.0:7')
-    provides('libllvm@6', when='@6.0.0:6')
-    provides('libllvm@5', when='@5.0.0:5')
-    provides('libllvm@4', when='@4.0.0:4')
-    provides('libllvm@3', when='@3.0.0:3')
+    provides("libllvm@14", when="@14.0.0:14")
+    provides("libllvm@13", when="@13.0.0:13")
+    provides("libllvm@12", when="@12.0.0:12")
+    provides("libllvm@11", when="@11.0.0:11")
+    provides("libllvm@10", when="@10.0.0:10")
+    provides("libllvm@9", when="@9.0.0:9")
+    provides("libllvm@8", when="@8.0.0:8")
+    provides("libllvm@7", when="@7.0.0:7")
+    provides("libllvm@6", when="@6.0.0:6")
+    provides("libllvm@5", when="@5.0.0:5")
+    provides("libllvm@4", when="@4.0.0:4")
+    provides("libllvm@3", when="@3.0.0:3")
 
     extends("python", when="+python")
 
     # Build dependency
     depends_on("cmake@3.4.3:", type="build")
-    depends_on('cmake@3.13.4:', type='build', when='@12:')
+    depends_on("cmake@3.13.4:", type="build", when="@12:")
     depends_on("ninja", type="build")
     depends_on("python@2.7:2.8", when="@:4 ~python", type="build")
     depends_on("python", when="@5: ~python", type="build")
@@ -242,7 +256,7 @@ class Llvm(CMakePackage, CudaPackage):
     # clang/lib: a lambda parameter cannot shadow an explicitly captured entity
     conflicts("%clang@8:", when="@:4")
     # Internal compiler error on gcc 8.4 on aarch64 https://bugzilla.redhat.com/show_bug.cgi?id=1958295
-    conflicts('%gcc@8.4:8.4.9', when='@12: target=aarch64:')
+    conflicts("%gcc@8.4:8.4.9", when="@12: target=aarch64:")
 
     # When these versions are concretized, but not explicitly with +libcxx, these
     # conflicts will enable clingo to set ~libcxx, making the build successful:
@@ -252,17 +266,17 @@ class Llvm(CMakePackage, CudaPackage):
     # GCC    11     - latest stable release per GCC release page
     # Clang: 11, 12 - latest two stable releases per LLVM release page
     # AppleClang 12 - latest stable release per Xcode release page
-    conflicts("%gcc@:10",         when="@13:+libcxx")
-    conflicts("%clang@:10",       when="@13:+libcxx")
+    conflicts("%gcc@:10", when="@13:+libcxx")
+    conflicts("%clang@:10", when="@13:+libcxx")
     conflicts("%apple-clang@:11", when="@13:+libcxx")
 
     # libcxx-4 and compiler-rt-4 fail to build with "newer" clang and gcc versions:
-    conflicts('%gcc@7:',         when='@:4+libcxx')
-    conflicts('%clang@6:',       when='@:4+libcxx')
-    conflicts('%apple-clang@6:', when='@:4+libcxx')
-    conflicts('%gcc@7:',         when='@:4+compiler-rt')
-    conflicts('%clang@6:',       when='@:4+compiler-rt')
-    conflicts('%apple-clang@6:', when='@:4+compiler-rt')
+    conflicts("%gcc@7:", when="@:4+libcxx")
+    conflicts("%clang@6:", when="@:4+libcxx")
+    conflicts("%apple-clang@6:", when="@:4+libcxx")
+    conflicts("%gcc@7:", when="@:4+compiler-rt")
+    conflicts("%clang@6:", when="@:4+compiler-rt")
+    conflicts("%apple-clang@6:", when="@:4+compiler-rt")
 
     # cuda_arch value must be specified
     conflicts("cuda_arch=none", when="+cuda", msg="A value for cuda_arch must be specified.")
@@ -270,27 +284,27 @@ class Llvm(CMakePackage, CudaPackage):
     # LLVM bug https://bugs.llvm.org/show_bug.cgi?id=48234
     # CMake bug: https://gitlab.kitware.com/cmake/cmake/-/issues/21469
     # Fixed in upstream versions of both
-    conflicts('^cmake@3.19.0', when='@6:11.0.0')
+    conflicts("^cmake@3.19.0", when="@6:11.0.0")
 
     # Github issue #4986
     patch("llvm_gcc7.patch", when="@4.0.0:4.0.1+lldb %gcc@7.0:")
 
     # sys/ustat.h has been removed in favour of statfs from glibc-2.28. Use fixed sizes:
-    patch('llvm5-sanitizer-ustat.patch', when="@4:6.0.0+compiler-rt")
+    patch("llvm5-sanitizer-ustat.patch", when="@4:6.0.0+compiler-rt")
 
     # Fix lld templates: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=230463
-    patch('llvm4-lld-ELF-Symbols.patch', when="@4+lld%clang@6:")
-    patch('llvm5-lld-ELF-Symbols.patch', when="@5+lld%clang@7:")
+    patch("llvm4-lld-ELF-Symbols.patch", when="@4+lld%clang@6:")
+    patch("llvm5-lld-ELF-Symbols.patch", when="@5+lld%clang@7:")
 
     # Fix missing std:size_t in 'llvm@4:5' when built with '%clang@7:'
-    patch('xray_buffer_queue-cstddef.patch', when="@4:5+compiler-rt%clang@7:")
+    patch("xray_buffer_queue-cstddef.patch", when="@4:5+compiler-rt%clang@7:")
 
     # https://github.com/llvm/llvm-project/commit/947f9692440836dcb8d88b74b69dd379d85974ce
-    patch('sanitizer-ipc_perm_mode.patch', when="@5:7+compiler-rt%clang@11:")
-    patch('sanitizer-ipc_perm_mode.patch', when="@5:9+compiler-rt%gcc@9:")
+    patch("sanitizer-ipc_perm_mode.patch", when="@5:7+compiler-rt%clang@11:")
+    patch("sanitizer-ipc_perm_mode.patch", when="@5:9+compiler-rt%gcc@9:")
 
     # github.com/spack/spack/issues/24270: MicrosoftDemangle for %gcc@10: and %clang@13:
-    patch('missing-includes.patch', when='@8')
+    patch("missing-includes.patch", when="@8")
 
     # Backport from llvm master + additional fix
     # see  https://bugs.llvm.org/show_bug.cgi?id=39696
@@ -315,33 +329,33 @@ class Llvm(CMakePackage, CudaPackage):
     patch("llvm_python_path.patch", when="@:11")
 
     # Workaround for issue https://github.com/spack/spack/issues/18197
-    patch('llvm7_intel.patch', when='@7 %intel@18.0.2,19.0.0:19.1.99')
+    patch("llvm7_intel.patch", when="@7 %intel@18.0.2,19.0.0:19.1.99")
 
     # Remove cyclades support to build against newer kernel headers
     # https://reviews.llvm.org/D102059
-    patch('no_cyclades.patch', when='@10:12.0.0')
-    patch('no_cyclades9.patch', when='@6:9')
+    patch("no_cyclades.patch", when="@10:12.0.0")
+    patch("no_cyclades9.patch", when="@6:9")
 
-    patch('llvm-gcc11.patch', when='@9:11%gcc@11:')
+    patch("llvm-gcc11.patch", when="@9:11%gcc@11:")
 
     # add -lpthread to build OpenMP libraries with Fujitsu compiler
-    patch('llvm12-thread.patch', when='@12 %fj')
-    patch('llvm13-thread.patch', when='@13 %fj')
+    patch("llvm12-thread.patch", when="@12 %fj")
+    patch("llvm13-thread.patch", when="@13 %fj")
 
     # avoid build failed with Fujitsu compiler
-    patch('llvm13-fujitsu.patch', when='@13 %fj')
+    patch("llvm13-fujitsu.patch", when="@13 %fj")
 
     # patch for missing hwloc.h include for libompd
-    patch('llvm14-hwloc-ompd.patch', when='@14')
+    patch("llvm14-hwloc-ompd.patch", when="@14")
 
     # make libflags a list in openmp subproject when ~omp_as_runtime
-    patch('libomp-libflags-as-list.patch', when='@3.7:')
+    patch("libomp-libflags-as-list.patch", when="@3.7:")
 
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #
     # https://spack.readthedocs.io/en/latest/packaging_guide.html#making-a-package-discoverable-with-spack-external-find
-    executables = ['clang', 'flang', 'ld.lld', 'lldb']
+    executables = ["clang", "flang", "ld.lld", "lldb"]
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):
@@ -351,7 +365,7 @@ class Llvm(CMakePackage, CudaPackage):
             # on some port and would hang Spack during detection.
             # clang-cl and clang-cpp are dev tools that we don't
             # need to test
-            if any(x in exe for x in ('vscode', 'cpp', '-cl', '-gpu')):
+            if any(x in exe for x in ("vscode", "cpp", "-cl", "-gpu")):
                 continue
             result.append(exe)
         return result
@@ -360,20 +374,20 @@ class Llvm(CMakePackage, CudaPackage):
     def determine_version(cls, exe):
         version_regex = re.compile(
             # Normal clang compiler versions are left as-is
-            r'clang version ([^ )\n]+)-svn[~.\w\d-]*|'
+            r"clang version ([^ )\n]+)-svn[~.\w\d-]*|"
             # Don't include hyphenated patch numbers in the version
             # (see https://github.com/spack/spack/pull/14365 for details)
-            r'clang version ([^ )\n]+?)-[~.\w\d-]*|'
-            r'clang version ([^ )\n]+)|'
+            r"clang version ([^ )\n]+?)-[~.\w\d-]*|"
+            r"clang version ([^ )\n]+)|"
             # LLDB
-            r'lldb version ([^ )\n]+)|'
+            r"lldb version ([^ )\n]+)|"
             # LLD
-            r'LLD ([^ )\n]+) \(compatible with GNU linkers\)'
+            r"LLD ([^ )\n]+) \(compatible with GNU linkers\)"
         )
         try:
             compiler = Executable(exe)
-            output = compiler('--version', output=str, error=str)
-            if 'Apple' in output:
+            output = compiler("--version", output=str, error=str)
+            if "Apple" in output:
                 return None
             match = version_regex.search(output)
             if match:
@@ -387,38 +401,39 @@ class Llvm(CMakePackage, CudaPackage):
 
     @classmethod
     def determine_variants(cls, exes, version_str):
-        variants, compilers = ['+clang'], {}
+        variants, compilers = ["+clang"], {}
         lld_found, lldb_found = False, False
         for exe in exes:
-            if 'clang++' in exe:
-                compilers['cxx'] = exe
-            elif 'clang' in exe:
-                compilers['c'] = exe
-            elif 'flang' in exe:
-                variants.append('+flang')
-                compilers['fc'] = exe
-                compilers['f77'] = exe
-            elif 'ld.lld' in exe:
+            if "clang++" in exe:
+                compilers["cxx"] = exe
+            elif "clang" in exe:
+                compilers["c"] = exe
+            elif "flang" in exe:
+                variants.append("+flang")
+                compilers["fc"] = exe
+                compilers["f77"] = exe
+            elif "ld.lld" in exe:
                 lld_found = True
-                compilers['ld'] = exe
-            elif 'lldb' in exe:
+                compilers["ld"] = exe
+            elif "lldb" in exe:
                 lldb_found = True
-                compilers['lldb'] = exe
+                compilers["lldb"] = exe
 
-        variants.append('+lld' if lld_found else '~lld')
-        variants.append('+lldb' if lldb_found else '~lldb')
+        variants.append("+lld" if lld_found else "~lld")
+        variants.append("+lldb" if lldb_found else "~lldb")
 
-        return ''.join(variants), {'compilers': compilers}
+        return "".join(variants), {"compilers": compilers}
 
     @classmethod
     def validate_detected_spec(cls, spec, extra_attributes):
         # For LLVM 'compilers' is a mandatory attribute
-        msg = ('the extra attribute "compilers" must be set for '
-               'the detected spec "{0}"'.format(spec))
-        assert 'compilers' in extra_attributes, msg
-        compilers = extra_attributes['compilers']
-        for key in ('c', 'cxx'):
-            msg = '{0} compiler not found for {1}'
+        msg = 'the extra attribute "compilers" must be set for ' 'the detected spec "{0}"'.format(
+            spec
+        )
+        assert "compilers" in extra_attributes, msg
+        compilers = extra_attributes["compilers"]
+        for key in ("c", "cxx"):
+            msg = "{0} compiler not found for {1}"
             assert key in compilers, msg.format(key, spec)
 
     @property
@@ -426,10 +441,10 @@ class Llvm(CMakePackage, CudaPackage):
         msg = "cannot retrieve C compiler [spec is not concrete]"
         assert self.spec.concrete, msg
         if self.spec.external:
-            return self.spec.extra_attributes['compilers'].get('c', None)
+            return self.spec.extra_attributes["compilers"].get("c", None)
         result = None
-        if '+clang' in self.spec:
-            result = os.path.join(self.spec.prefix.bin, 'clang')
+        if "+clang" in self.spec:
+            result = os.path.join(self.spec.prefix.bin, "clang")
         return result
 
     @property
@@ -437,10 +452,10 @@ class Llvm(CMakePackage, CudaPackage):
         msg = "cannot retrieve C++ compiler [spec is not concrete]"
         assert self.spec.concrete, msg
         if self.spec.external:
-            return self.spec.extra_attributes['compilers'].get('cxx', None)
+            return self.spec.extra_attributes["compilers"].get("cxx", None)
         result = None
-        if '+clang' in self.spec:
-            result = os.path.join(self.spec.prefix.bin, 'clang++')
+        if "+clang" in self.spec:
+            result = os.path.join(self.spec.prefix.bin, "clang++")
         return result
 
     @property
@@ -448,10 +463,10 @@ class Llvm(CMakePackage, CudaPackage):
         msg = "cannot retrieve Fortran compiler [spec is not concrete]"
         assert self.spec.concrete, msg
         if self.spec.external:
-            return self.spec.extra_attributes['compilers'].get('fc', None)
+            return self.spec.extra_attributes["compilers"].get("fc", None)
         result = None
-        if '+flang' in self.spec:
-            result = os.path.join(self.spec.prefix.bin, 'flang')
+        if "+flang" in self.spec:
+            result = os.path.join(self.spec.prefix.bin, "flang")
         return result
 
     @property
@@ -459,27 +474,25 @@ class Llvm(CMakePackage, CudaPackage):
         msg = "cannot retrieve Fortran 77 compiler [spec is not concrete]"
         assert self.spec.concrete, msg
         if self.spec.external:
-            return self.spec.extra_attributes['compilers'].get('f77', None)
+            return self.spec.extra_attributes["compilers"].get("f77", None)
         result = None
-        if '+flang' in self.spec:
-            result = os.path.join(self.spec.prefix.bin, 'flang')
+        if "+flang" in self.spec:
+            result = os.path.join(self.spec.prefix.bin, "flang")
         return result
 
     @property
     def libs(self):
-        return LibraryList(self.llvm_config("--libfiles", "all",
-                                            result="list"))
+        return LibraryList(self.llvm_config("--libfiles", "all", result="list"))
 
-    @run_before('cmake')
+    @run_before("cmake")
     def codesign_check(self):
         if self.spec.satisfies("+code_signing"):
-            codesign = which('codesign')
-            mkdir('tmp')
-            llvm_check_file = join_path('tmp', 'llvm_check')
-            copy('/usr/bin/false', llvm_check_file)
+            codesign = which("codesign")
+            mkdir("tmp")
+            llvm_check_file = join_path("tmp", "llvm_check")
+            copy("/usr/bin/false", llvm_check_file)
             try:
-                codesign('-f', '-s', 'lldb_codesign', '--dryrun',
-                         llvm_check_file)
+                codesign("-f", "-s", "lldb_codesign", "--dryrun", llvm_check_file)
 
             except ProcessError:
                 # Newer LLVM versions have a simple script that sets up
@@ -489,32 +502,32 @@ class Llvm(CMakePackage, CudaPackage):
                     setup()
                 except Exception:
                     raise RuntimeError(
-                        'spack was unable to either find or set up'
-                        'code-signing on your system. Please refer to'
-                        'https://lldb.llvm.org/resources/build.html#'
-                        'code-signing-on-macos for details on how to'
-                        'create this identity.'
+                        "spack was unable to either find or set up"
+                        "code-signing on your system. Please refer to"
+                        "https://lldb.llvm.org/resources/build.html#"
+                        "code-signing-on-macos for details on how to"
+                        "create this identity."
                     )
 
     def flag_handler(self, name, flags):
-        if name == 'cxxflags':
+        if name == "cxxflags":
             flags.append(self.compiler.cxx11_flag)
-            return(None, flags, None)
-        elif name == 'ldflags' and self.spec.satisfies('%intel'):
-            flags.append('-shared-intel')
-            return(None, flags, None)
-        return(flags, None, None)
+            return (None, flags, None)
+        elif name == "ldflags" and self.spec.satisfies("%intel"):
+            flags.append("-shared-intel")
+            return (None, flags, None)
+        return (flags, None, None)
 
     def setup_build_environment(self, env):
         """When using %clang, add only its ld.lld-$ver and/or ld.lld to our PATH"""
-        if self.compiler.name in ['clang', 'apple-clang']:
-            for lld in 'ld.lld-{0}'.format(self.compiler.version.version[0]), 'ld.lld':
+        if self.compiler.name in ["clang", "apple-clang"]:
+            for lld in "ld.lld-{0}".format(self.compiler.version.version[0]), "ld.lld":
                 bin = os.path.join(os.path.dirname(self.compiler.cc), lld)
-                sym = os.path.join(self.stage.path, 'ld.lld')
+                sym = os.path.join(self.stage.path, "ld.lld")
                 if os.path.exists(bin) and not os.path.exists(sym):
                     mkdirp(self.stage.path)
                     os.symlink(bin, sym)
-            env.prepend_path('PATH', self.stage.path)
+            env.prepend_path("PATH", self.stage.path)
 
     def setup_run_environment(self, env):
         if "+clang" in self.spec:
@@ -531,7 +544,7 @@ class Llvm(CMakePackage, CudaPackage):
         define = CMakePackage.define
         from_variant = self.define_from_variant
 
-        python = spec['python']
+        python = spec["python"]
         cmake_args = [
             define("LLVM_REQUIRES_RTTI", True),
             define("LLVM_ENABLE_RTTI", True),
@@ -544,14 +557,13 @@ class Llvm(CMakePackage, CudaPackage):
             define("LIBOMP_HWLOC_INSTALL_DIR", spec["hwloc"].prefix),
         ]
 
-        version_suffix = spec.variants['version_suffix'].value
-        if version_suffix != 'none':
-            cmake_args.append(define('LLVM_VERSION_SUFFIX', version_suffix))
+        version_suffix = spec.variants["version_suffix"].value
+        if version_suffix != "none":
+            cmake_args.append(define("LLVM_VERSION_SUFFIX", version_suffix))
 
-        shlib_symbol_version = spec.variants.get('shlib_symbol_version', None)
-        if shlib_symbol_version is not None and shlib_symbol_version.value != 'none':
-            cmake_args.append(define('LLVM_SHLIB_SYMBOL_VERSION',
-                              shlib_symbol_version.value))
+        shlib_symbol_version = spec.variants.get("shlib_symbol_version", None)
+        if shlib_symbol_version is not None and shlib_symbol_version.value != "none":
+            cmake_args.append(define("LLVM_SHLIB_SYMBOL_VERSION", shlib_symbol_version.value))
 
         if python.version >= Version("3"):
             cmake_args.append(define("Python3_EXECUTABLE", python.command.path))
@@ -562,47 +574,56 @@ class Llvm(CMakePackage, CudaPackage):
         runtimes = []
 
         if "+cuda" in spec:
-            cmake_args.extend([
-                define("CUDA_TOOLKIT_ROOT_DIR", spec["cuda"].prefix),
-                define("LIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES",
-                       ",".join(spec.variants["cuda_arch"].value)),
-                define("CLANG_OPENMP_NVPTX_DEFAULT_ARCH",
-                       "sm_{0}".format(spec.variants["cuda_arch"].value[-1])),
-            ])
+            cmake_args.extend(
+                [
+                    define("CUDA_TOOLKIT_ROOT_DIR", spec["cuda"].prefix),
+                    define(
+                        "LIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES",
+                        ",".join(spec.variants["cuda_arch"].value),
+                    ),
+                    define(
+                        "CLANG_OPENMP_NVPTX_DEFAULT_ARCH",
+                        "sm_{0}".format(spec.variants["cuda_arch"].value[-1]),
+                    ),
+                ]
+            )
             if "+omp_as_runtime" in spec:
-                cmake_args.extend([
-                    define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True),
-                    # work around bad libelf detection in libomptarget
-                    define("LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR",
-                           spec["libelf"].prefix.include),
-                ])
+                cmake_args.extend(
+                    [
+                        define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True),
+                        # work around bad libelf detection in libomptarget
+                        define(
+                            "LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR", spec["libelf"].prefix.include
+                        ),
+                    ]
+                )
         else:
             # still build libomptarget but disable cuda
-            cmake_args.extend([
-                define("CUDA_TOOLKIT_ROOT_DIR", "IGNORE"),
-                define("CUDA_SDK_ROOT_DIR", "IGNORE"),
-                define("CUDA_NVCC_EXECUTABLE", "IGNORE"),
-                define("LIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES", "IGNORE"),
-            ])
+            cmake_args.extend(
+                [
+                    define("CUDA_TOOLKIT_ROOT_DIR", "IGNORE"),
+                    define("CUDA_SDK_ROOT_DIR", "IGNORE"),
+                    define("CUDA_NVCC_EXECUTABLE", "IGNORE"),
+                    define("LIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES", "IGNORE"),
+                ]
+            )
 
         cmake_args.append(from_variant("LIBOMPTARGET_ENABLE_DEBUG", "omp_debug"))
 
         if "+lldb" in spec:
             projects.append("lldb")
-            cmake_args.append(define('LLDB_ENABLE_LIBEDIT', True))
-            cmake_args.append(define('LLDB_ENABLE_NCURSES', True))
-            cmake_args.append(define('LLDB_ENABLE_LIBXML2', False))
-            if spec.version >= Version('10'):
-                cmake_args.append(from_variant("LLDB_ENABLE_PYTHON", 'python'))
+            cmake_args.append(define("LLDB_ENABLE_LIBEDIT", True))
+            cmake_args.append(define("LLDB_ENABLE_NCURSES", True))
+            cmake_args.append(define("LLDB_ENABLE_LIBXML2", False))
+            if spec.version >= Version("10"):
+                cmake_args.append(from_variant("LLDB_ENABLE_PYTHON", "python"))
             else:
-                cmake_args.append(define("LLDB_DISABLE_PYTHON", '~python' in spec))
+                cmake_args.append(define("LLDB_DISABLE_PYTHON", "~python" in spec))
             if spec.satisfies("@5.0.0: +python"):
                 cmake_args.append(define("LLDB_USE_SYSTEM_SIX", True))
 
         if "+gold" in spec:
-            cmake_args.append(
-                define("LLVM_BINUTILS_INCDIR", spec["binutils"].prefix.include)
-            )
+            cmake_args.append(define("LLVM_BINUTILS_INCDIR", spec["binutils"].prefix.include))
 
         if "+clang" in spec:
             projects.append("clang")
@@ -612,10 +633,10 @@ class Llvm(CMakePackage, CudaPackage):
             else:
                 projects.append("openmp")
 
-            if '@8' in spec:
-                cmake_args.append(from_variant('CLANG_ANALYZER_ENABLE_Z3_SOLVER', 'z3'))
-            elif '@9:' in spec:
-                cmake_args.append(from_variant('LLVM_ENABLE_Z3_SOLVER', 'z3'))
+            if "@8" in spec:
+                cmake_args.append(from_variant("CLANG_ANALYZER_ENABLE_Z3_SOLVER", "z3"))
+            elif "@9:" in spec:
+                cmake_args.append(from_variant("LLVM_ENABLE_Z3_SOLVER", "z3"))
 
         if "+flang" in spec:
             projects.append("flang")
@@ -634,26 +655,26 @@ class Llvm(CMakePackage, CudaPackage):
             projects.append("polly")
             cmake_args.append(define("LINK_POLLY_INTO_TOOLS", True))
 
-        cmake_args.extend([
-            define("BUILD_SHARED_LIBS", False),
-            from_variant("LLVM_BUILD_LLVM_DYLIB", "llvm_dylib"),
-            from_variant("LLVM_LINK_LLVM_DYLIB", "link_llvm_dylib"),
-            from_variant("LLVM_USE_SPLIT_DWARF", "split_dwarf"),
-            # By default on Linux, libc++.so is a ldscript. CMake fails to add
-            # CMAKE_INSTALL_RPATH to it, which fails. Statically link libc++abi.a
-            # into libc++.so, linking with -lc++ or -stdlib=libc++ is enough.
-            define('LIBCXX_ENABLE_STATIC_ABI_LIBRARY', True)
-        ])
+        cmake_args.extend(
+            [
+                define("BUILD_SHARED_LIBS", False),
+                from_variant("LLVM_BUILD_LLVM_DYLIB", "llvm_dylib"),
+                from_variant("LLVM_LINK_LLVM_DYLIB", "link_llvm_dylib"),
+                from_variant("LLVM_USE_SPLIT_DWARF", "split_dwarf"),
+                # By default on Linux, libc++.so is a ldscript. CMake fails to add
+                # CMAKE_INSTALL_RPATH to it, which fails. Statically link libc++abi.a
+                # into libc++.so, linking with -lc++ or -stdlib=libc++ is enough.
+                define("LIBCXX_ENABLE_STATIC_ABI_LIBRARY", True),
+            ]
+        )
 
-        cmake_args.append(define(
-            "LLVM_TARGETS_TO_BUILD",
-            get_llvm_targets_to_build(spec)))
+        cmake_args.append(define("LLVM_TARGETS_TO_BUILD", get_llvm_targets_to_build(spec)))
 
         cmake_args.append(from_variant("LIBOMP_TSAN_SUPPORT", "omp_tsan"))
 
         if self.compiler.name == "gcc":
             compiler = Executable(self.compiler.cc)
-            gcc_output = compiler('-print-search-dirs', output=str, error=str)
+            gcc_output = compiler("-print-search-dirs", output=str, error=str)
 
             for line in gcc_output.splitlines():
                 if line.startswith("install:"):
@@ -665,7 +686,7 @@ class Llvm(CMakePackage, CudaPackage):
             cmake_args.append(define("GCC_INSTALL_PREFIX", gcc_prefix))
 
         if self.spec.satisfies("~code_signing platform=darwin"):
-            cmake_args.append(define('LLDB_USE_SYSTEM_DEBUGSERVER', True))
+            cmake_args.append(define("LLDB_USE_SYSTEM_DEBUGSERVER", True))
 
         # Semicolon seperated list of projects to enable
         cmake_args.append(define("LLVM_ENABLE_PROJECTS", projects))
@@ -689,20 +710,24 @@ class Llvm(CMakePackage, CudaPackage):
             # rebuild libomptarget to get bytecode runtime library files
             with working_dir(ompdir, create=True):
                 cmake_args = [
-                    '-G', 'Ninja',
-                    define('CMAKE_BUILD_TYPE', spec.variants['build_type'].value),
+                    "-G",
+                    "Ninja",
+                    define("CMAKE_BUILD_TYPE", spec.variants["build_type"].value),
                     define("CMAKE_C_COMPILER", spec.prefix.bin + "/clang"),
                     define("CMAKE_CXX_COMPILER", spec.prefix.bin + "/clang++"),
                     define("CMAKE_INSTALL_PREFIX", spec.prefix),
-                    define('CMAKE_PREFIX_PATH', prefix_paths)
+                    define("CMAKE_PREFIX_PATH", prefix_paths),
                 ]
                 cmake_args.extend(self.cmake_args())
-                cmake_args.extend([
-                    define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True),
-                    define("LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR",
-                           spec["libelf"].prefix.include),
-                    self.stage.source_path + "/openmp",
-                ])
+                cmake_args.extend(
+                    [
+                        define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True),
+                        define(
+                            "LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR", spec["libelf"].prefix.include
+                        ),
+                        self.stage.source_path + "/openmp",
+                    ]
+                )
 
                 cmake(*cmake_args)
                 ninja()
@@ -717,22 +742,22 @@ class Llvm(CMakePackage, CudaPackage):
             install_tree("bin", join_path(self.prefix, "libexec", "llvm"))
 
     def llvm_config(self, *args, **kwargs):
-        lc = Executable(self.prefix.bin.join('llvm-config'))
-        if not kwargs.get('output'):
-            kwargs['output'] = str
+        lc = Executable(self.prefix.bin.join("llvm-config"))
+        if not kwargs.get("output"):
+            kwargs["output"] = str
         ret = lc(*args, **kwargs)
-        if kwargs.get('result') == "list":
+        if kwargs.get("result") == "list":
             return ret.split()
         else:
             return ret
 
 
 def get_llvm_targets_to_build(spec):
-    targets = spec.variants['targets'].value
+    targets = spec.variants["targets"].value
 
     # Build everything?
-    if 'all' in targets:
-        return 'all'
+    if "all" in targets:
+        return "all"
 
     # Convert targets variant values to CMake LLVM_TARGETS_TO_BUILD array.
     spack_to_cmake = {
@@ -753,10 +778,10 @@ def get_llvm_targets_to_build(spec):
         "systemz": "SystemZ",
         "webassembly": "WebAssembly",
         "x86": "X86",
-        "xcore": "XCore"
+        "xcore": "XCore",
     }
 
-    if 'none' in targets:
+    if "none" in targets:
         llvm_targets = set()
     else:
         llvm_targets = set(spack_to_cmake[target] for target in targets)

--- a/lib/spack/spack/test/data/unparse/py-torch.txt
+++ b/lib/spack/spack/test/data/unparse/py-torch.txt
@@ -22,127 +22,140 @@ class PyTorch(PythonPackage, CudaPackage):
     with strong GPU acceleration."""
 
     homepage = "https://pytorch.org/"
-    git      = "https://github.com/pytorch/pytorch.git"
+    git = "https://github.com/pytorch/pytorch.git"
 
-    maintainers = ['adamjstewart']
+    maintainers("adamjstewart")
 
     # Exact set of modules is version- and variant-specific, just attempt to import the
     # core libraries to ensure that the package was successfully installed.
-    import_modules = ['torch', 'torch.autograd', 'torch.nn', 'torch.utils']
+    import_modules = ["torch", "torch.autograd", "torch.nn", "torch.utils"]
 
-    version('master', branch='master', submodules=True)
-    version('1.10.1', tag='v1.10.1', submodules=True)
-    version('1.10.0', tag='v1.10.0', submodules=True)
-    version('1.9.1', tag='v1.9.1', submodules=True)
-    version('1.9.0', tag='v1.9.0', submodules=True)
-    version('1.8.2', tag='v1.8.2', submodules=True)
-    version('1.8.1', tag='v1.8.1', submodules=True)
-    version('1.8.0', tag='v1.8.0', submodules=True)
-    version('1.7.1', tag='v1.7.1', submodules=True)
-    version('1.7.0', tag='v1.7.0', submodules=True)
-    version('1.6.0', tag='v1.6.0', submodules=True)
-    version('1.5.1', tag='v1.5.1', submodules=True)
-    version('1.5.0', tag='v1.5.0', submodules=True)
-    version('1.4.1', tag='v1.4.1', submodules=True)
-    version('1.4.0', tag='v1.4.0', submodules=True, deprecated=True,
-            submodules_delete=['third_party/fbgemm'])
-    version('1.3.1', tag='v1.3.1', submodules=True)
-    version('1.3.0', tag='v1.3.0', submodules=True)
-    version('1.2.0', tag='v1.2.0', submodules=True)
-    version('1.1.0', tag='v1.1.0', submodules=True)
-    version('1.0.1', tag='v1.0.1', submodules=True)
-    version('1.0.0', tag='v1.0.0', submodules=True)
-    version('0.4.1', tag='v0.4.1', submodules=True, deprecated=True,
-            submodules_delete=['third_party/nervanagpu'])
-    version('0.4.0', tag='v0.4.0', submodules=True, deprecated=True)
-    version('0.3.1', tag='v0.3.1', submodules=True, deprecated=True)
+    version("master", branch="master", submodules=True)
+    version("1.10.1", tag="v1.10.1", submodules=True)
+    version("1.10.0", tag="v1.10.0", submodules=True)
+    version("1.9.1", tag="v1.9.1", submodules=True)
+    version("1.9.0", tag="v1.9.0", submodules=True)
+    version("1.8.2", tag="v1.8.2", submodules=True)
+    version("1.8.1", tag="v1.8.1", submodules=True)
+    version("1.8.0", tag="v1.8.0", submodules=True)
+    version("1.7.1", tag="v1.7.1", submodules=True)
+    version("1.7.0", tag="v1.7.0", submodules=True)
+    version("1.6.0", tag="v1.6.0", submodules=True)
+    version("1.5.1", tag="v1.5.1", submodules=True)
+    version("1.5.0", tag="v1.5.0", submodules=True)
+    version("1.4.1", tag="v1.4.1", submodules=True)
+    version(
+        "1.4.0",
+        tag="v1.4.0",
+        submodules=True,
+        deprecated=True,
+        submodules_delete=["third_party/fbgemm"],
+    )
+    version("1.3.1", tag="v1.3.1", submodules=True)
+    version("1.3.0", tag="v1.3.0", submodules=True)
+    version("1.2.0", tag="v1.2.0", submodules=True)
+    version("1.1.0", tag="v1.1.0", submodules=True)
+    version("1.0.1", tag="v1.0.1", submodules=True)
+    version("1.0.0", tag="v1.0.0", submodules=True)
+    version(
+        "0.4.1",
+        tag="v0.4.1",
+        submodules=True,
+        deprecated=True,
+        submodules_delete=["third_party/nervanagpu"],
+    )
+    version("0.4.0", tag="v0.4.0", submodules=True, deprecated=True)
+    version("0.3.1", tag="v0.3.1", submodules=True, deprecated=True)
 
-    is_darwin = sys.platform == 'darwin'
+    is_darwin = sys.platform == "darwin"
 
     # All options are defined in CMakeLists.txt.
     # Some are listed in setup.py, but not all.
-    variant('caffe2', default=True, description='Build Caffe2')
-    variant('test', default=False, description='Build C++ test binaries')
-    variant('cuda', default=not is_darwin, description='Use CUDA')
-    variant('rocm', default=False, description='Use ROCm')
-    variant('cudnn', default=not is_darwin, description='Use cuDNN')
-    variant('fbgemm', default=True, description='Use FBGEMM (quantized 8-bit server operators)')
-    variant('kineto', default=True, description='Use Kineto profiling library')
-    variant('magma', default=not is_darwin, description='Use MAGMA')
-    variant('metal', default=is_darwin, description='Use Metal for Caffe2 iOS build')
-    variant('nccl', default=not is_darwin, description='Use NCCL')
-    variant('nnpack', default=True, description='Use NNPACK')
-    variant('numa', default=not is_darwin, description='Use NUMA')
-    variant('numpy', default=True, description='Use NumPy')
-    variant('openmp', default=True, description='Use OpenMP for parallel code')
-    variant('qnnpack', default=True, description='Use QNNPACK (quantized 8-bit operators)')
-    variant('valgrind', default=not is_darwin, description='Use Valgrind')
-    variant('xnnpack', default=True, description='Use XNNPACK')
-    variant('mkldnn', default=True, description='Use MKLDNN')
-    variant('distributed', default=not is_darwin, description='Use distributed')
-    variant('mpi', default=not is_darwin, description='Use MPI for Caffe2')
-    variant('gloo', default=not is_darwin, description='Use Gloo')
-    variant('tensorpipe', default=not is_darwin, description='Use TensorPipe')
-    variant('onnx_ml', default=True, description='Enable traditional ONNX ML API')
-    variant('breakpad', default=True, description='Enable breakpad crash dump library')
+    variant("caffe2", default=True, description="Build Caffe2")
+    variant("test", default=False, description="Build C++ test binaries")
+    variant("cuda", default=not is_darwin, description="Use CUDA")
+    variant("rocm", default=False, description="Use ROCm")
+    variant("cudnn", default=not is_darwin, description="Use cuDNN")
+    variant("fbgemm", default=True, description="Use FBGEMM (quantized 8-bit server operators)")
+    variant("kineto", default=True, description="Use Kineto profiling library")
+    variant("magma", default=not is_darwin, description="Use MAGMA")
+    variant("metal", default=is_darwin, description="Use Metal for Caffe2 iOS build")
+    variant("nccl", default=not is_darwin, description="Use NCCL")
+    variant("nnpack", default=True, description="Use NNPACK")
+    variant("numa", default=not is_darwin, description="Use NUMA")
+    variant("numpy", default=True, description="Use NumPy")
+    variant("openmp", default=True, description="Use OpenMP for parallel code")
+    variant("qnnpack", default=True, description="Use QNNPACK (quantized 8-bit operators)")
+    variant("valgrind", default=not is_darwin, description="Use Valgrind")
+    variant("xnnpack", default=True, description="Use XNNPACK")
+    variant("mkldnn", default=True, description="Use MKLDNN")
+    variant("distributed", default=not is_darwin, description="Use distributed")
+    variant("mpi", default=not is_darwin, description="Use MPI for Caffe2")
+    variant("gloo", default=not is_darwin, description="Use Gloo")
+    variant("tensorpipe", default=not is_darwin, description="Use TensorPipe")
+    variant("onnx_ml", default=True, description="Enable traditional ONNX ML API")
+    variant("breakpad", default=True, description="Enable breakpad crash dump library")
 
-    conflicts('+cuda', when='+rocm')
-    conflicts('+cudnn', when='~cuda')
-    conflicts('+magma', when='~cuda')
-    conflicts('+nccl', when='~cuda~rocm')
-    conflicts('+nccl', when='platform=darwin')
-    conflicts('+numa', when='platform=darwin', msg='Only available on Linux')
-    conflicts('+valgrind', when='platform=darwin', msg='Only available on Linux')
-    conflicts('+mpi', when='~distributed')
-    conflicts('+gloo', when='~distributed')
-    conflicts('+tensorpipe', when='~distributed')
-    conflicts('+kineto', when='@:1.7')
-    conflicts('+valgrind', when='@:1.7')
-    conflicts('~caffe2', when='@0.4.0:1.6')  # no way to disable caffe2?
-    conflicts('+caffe2', when='@:0.3.1')  # caffe2 did not yet exist?
-    conflicts('+tensorpipe', when='@:1.5')
-    conflicts('+xnnpack', when='@:1.4')
-    conflicts('~onnx_ml', when='@:1.4')  # no way to disable ONNX?
-    conflicts('+rocm', when='@:0.4')
-    conflicts('+cudnn', when='@:0.4')
-    conflicts('+fbgemm', when='@:0.4,1.4.0')
-    conflicts('+qnnpack', when='@:0.4')
-    conflicts('+mkldnn', when='@:0.4')
-    conflicts('+breakpad', when='@:1.9')  # Option appeared in 1.10.0
-    conflicts('+breakpad', when='target=ppc64:', msg='Unsupported')
-    conflicts('+breakpad', when='target=ppc64le:', msg='Unsupported')
+    conflicts("+cuda", when="+rocm")
+    conflicts("+cudnn", when="~cuda")
+    conflicts("+magma", when="~cuda")
+    conflicts("+nccl", when="~cuda~rocm")
+    conflicts("+nccl", when="platform=darwin")
+    conflicts("+numa", when="platform=darwin", msg="Only available on Linux")
+    conflicts("+valgrind", when="platform=darwin", msg="Only available on Linux")
+    conflicts("+mpi", when="~distributed")
+    conflicts("+gloo", when="~distributed")
+    conflicts("+tensorpipe", when="~distributed")
+    conflicts("+kineto", when="@:1.7")
+    conflicts("+valgrind", when="@:1.7")
+    conflicts("~caffe2", when="@0.4.0:1.6")  # no way to disable caffe2?
+    conflicts("+caffe2", when="@:0.3.1")  # caffe2 did not yet exist?
+    conflicts("+tensorpipe", when="@:1.5")
+    conflicts("+xnnpack", when="@:1.4")
+    conflicts("~onnx_ml", when="@:1.4")  # no way to disable ONNX?
+    conflicts("+rocm", when="@:0.4")
+    conflicts("+cudnn", when="@:0.4")
+    conflicts("+fbgemm", when="@:0.4,1.4.0")
+    conflicts("+qnnpack", when="@:0.4")
+    conflicts("+mkldnn", when="@:0.4")
+    conflicts("+breakpad", when="@:1.9")  # Option appeared in 1.10.0
+    conflicts("+breakpad", when="target=ppc64:", msg="Unsupported")
+    conflicts("+breakpad", when="target=ppc64le:", msg="Unsupported")
 
-    conflicts('cuda_arch=none', when='+cuda',
-              msg='Must specify CUDA compute capabilities of your GPU, see '
-              'https://developer.nvidia.com/cuda-gpus')
+    conflicts(
+        "cuda_arch=none",
+        when="+cuda",
+        msg="Must specify CUDA compute capabilities of your GPU, see "
+        "https://developer.nvidia.com/cuda-gpus",
+    )
 
     # Required dependencies
-    depends_on('cmake@3.5:', type='build')
+    depends_on("cmake@3.5:", type="build")
     # Use Ninja generator to speed up build times, automatically used if found
-    depends_on('ninja@1.5:', when='@1.1.0:', type='build')
+    depends_on("ninja@1.5:", when="@1.1.0:", type="build")
     # See python_min_version in setup.py
-    depends_on('python@3.6.2:', when='@1.7.1:', type=('build', 'link', 'run'))
-    depends_on('python@3.6.1:', when='@1.6.0:1.7.0', type=('build', 'link', 'run'))
-    depends_on('python@3.5:', when='@1.5.0:1.5', type=('build', 'link', 'run'))
-    depends_on('python@2.7:2.8,3.5:', when='@1.4.0:1.4', type=('build', 'link', 'run'))
-    depends_on('python@2.7:2.8,3.5:3.7', when='@:1.3', type=('build', 'link', 'run'))
-    depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-future', when='@1.5:', type=('build', 'run'))
-    depends_on('py-future', when='@1.1: ^python@:2', type=('build', 'run'))
-    depends_on('py-pyyaml', type=('build', 'run'))
-    depends_on('py-typing', when='@0.4: ^python@:3.4', type=('build', 'run'))
-    depends_on('py-typing-extensions', when='@1.7:', type=('build', 'run'))
-    depends_on('py-pybind11@2.6.2', when='@1.8.0:', type=('build', 'link', 'run'))
-    depends_on('py-pybind11@2.3.0', when='@1.1.0:1.7', type=('build', 'link', 'run'))
-    depends_on('py-pybind11@2.2.4', when='@1.0.0:1.0', type=('build', 'link', 'run'))
-    depends_on('py-pybind11@2.2.2', when='@0.4.0:0.4', type=('build', 'link', 'run'))
-    depends_on('py-dataclasses', when='@1.7: ^python@3.6.0:3.6', type=('build', 'run'))
-    depends_on('py-tqdm', type='run')
-    depends_on('py-protobuf', when='@0.4:', type=('build', 'run'))
-    depends_on('protobuf', when='@0.4:')
-    depends_on('blas')
-    depends_on('lapack')
-    depends_on('eigen', when='@0.4:')
+    depends_on("python@3.6.2:", when="@1.7.1:", type=("build", "link", "run"))
+    depends_on("python@3.6.1:", when="@1.6.0:1.7.0", type=("build", "link", "run"))
+    depends_on("python@3.5:", when="@1.5.0:1.5", type=("build", "link", "run"))
+    depends_on("python@2.7:2.8,3.5:", when="@1.4.0:1.4", type=("build", "link", "run"))
+    depends_on("python@2.7:2.8,3.5:3.7", when="@:1.3", type=("build", "link", "run"))
+    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-future", when="@1.5:", type=("build", "run"))
+    depends_on("py-future", when="@1.1: ^python@:2", type=("build", "run"))
+    depends_on("py-pyyaml", type=("build", "run"))
+    depends_on("py-typing", when="@0.4: ^python@:3.4", type=("build", "run"))
+    depends_on("py-typing-extensions", when="@1.7:", type=("build", "run"))
+    depends_on("py-pybind11@2.6.2", when="@1.8.0:", type=("build", "link", "run"))
+    depends_on("py-pybind11@2.3.0", when="@1.1.0:1.7", type=("build", "link", "run"))
+    depends_on("py-pybind11@2.2.4", when="@1.0.0:1.0", type=("build", "link", "run"))
+    depends_on("py-pybind11@2.2.2", when="@0.4.0:0.4", type=("build", "link", "run"))
+    depends_on("py-dataclasses", when="@1.7: ^python@3.6.0:3.6", type=("build", "run"))
+    depends_on("py-tqdm", type="run")
+    depends_on("py-protobuf", when="@0.4:", type=("build", "run"))
+    depends_on("protobuf", when="@0.4:")
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("eigen", when="@0.4:")
     # https://github.com/pytorch/pytorch/issues/60329
     # depends_on('cpuinfo@2020-12-17', when='@1.8.0:')
     # depends_on('cpuinfo@2020-06-11', when='@1.6.0:1.7')
@@ -152,30 +165,30 @@ class PyTorch(PythonPackage, CudaPackage):
     # depends_on('sleef@3.4.0_2019-07-30', when='@1.6.0:1.7')
     # https://github.com/Maratyszcza/FP16/issues/18
     # depends_on('fp16@2020-05-14', when='@1.6.0:')
-    depends_on('pthreadpool@2021-04-13', when='@1.9.0:')
-    depends_on('pthreadpool@2020-10-05', when='@1.8.0:1.8')
-    depends_on('pthreadpool@2020-06-15', when='@1.6.0:1.7')
-    depends_on('psimd@2020-05-17', when='@1.6.0:')
-    depends_on('fxdiv@2020-04-17', when='@1.6.0:')
-    depends_on('benchmark', when='@1.6:+test')
+    depends_on("pthreadpool@2021-04-13", when="@1.9.0:")
+    depends_on("pthreadpool@2020-10-05", when="@1.8.0:1.8")
+    depends_on("pthreadpool@2020-06-15", when="@1.6.0:1.7")
+    depends_on("psimd@2020-05-17", when="@1.6.0:")
+    depends_on("fxdiv@2020-04-17", when="@1.6.0:")
+    depends_on("benchmark", when="@1.6:+test")
 
     # Optional dependencies
-    depends_on('cuda@7.5:', when='+cuda', type=('build', 'link', 'run'))
-    depends_on('cuda@9:', when='@1.1:+cuda', type=('build', 'link', 'run'))
-    depends_on('cuda@9.2:', when='@1.6:+cuda', type=('build', 'link', 'run'))
-    depends_on('cudnn@6.0:7', when='@:1.0+cudnn')
-    depends_on('cudnn@7.0:7', when='@1.1.0:1.5+cudnn')
-    depends_on('cudnn@7.0:', when='@1.6.0:+cudnn')
-    depends_on('magma', when='+magma')
-    depends_on('nccl', when='+nccl')
-    depends_on('numactl', when='+numa')
-    depends_on('py-numpy', when='+numpy', type=('build', 'run'))
-    depends_on('llvm-openmp', when='%apple-clang +openmp')
-    depends_on('valgrind', when='+valgrind')
+    depends_on("cuda@7.5:", when="+cuda", type=("build", "link", "run"))
+    depends_on("cuda@9:", when="@1.1:+cuda", type=("build", "link", "run"))
+    depends_on("cuda@9.2:", when="@1.6:+cuda", type=("build", "link", "run"))
+    depends_on("cudnn@6.0:7", when="@:1.0+cudnn")
+    depends_on("cudnn@7.0:7", when="@1.1.0:1.5+cudnn")
+    depends_on("cudnn@7.0:", when="@1.6.0:+cudnn")
+    depends_on("magma", when="+magma")
+    depends_on("nccl", when="+nccl")
+    depends_on("numactl", when="+numa")
+    depends_on("py-numpy", when="+numpy", type=("build", "run"))
+    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("valgrind", when="+valgrind")
     # https://github.com/pytorch/pytorch/issues/60332
     # depends_on('xnnpack@2021-02-22', when='@1.8.0:+xnnpack')
     # depends_on('xnnpack@2020-03-23', when='@1.6.0:1.7+xnnpack')
-    depends_on('mpi', when='+mpi')
+    depends_on("mpi", when="+mpi")
     # https://github.com/pytorch/pytorch/issues/60270
     # depends_on('gloo@2021-05-04', when='@1.9.0:+gloo')
     # depends_on('gloo@2020-09-18', when='@1.7.0:1.8+gloo')
@@ -183,31 +196,35 @@ class PyTorch(PythonPackage, CudaPackage):
     # https://github.com/pytorch/pytorch/issues/60331
     # depends_on('onnx@1.8.0_2020-11-03', when='@1.8.0:+onnx_ml')
     # depends_on('onnx@1.7.0_2020-05-31', when='@1.6.0:1.7+onnx_ml')
-    depends_on('mkl', when='+mkldnn')
+    depends_on("mkl", when="+mkldnn")
 
     # Test dependencies
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-psutil', type='test')
+    depends_on("py-hypothesis", type="test")
+    depends_on("py-six", type="test")
+    depends_on("py-psutil", type="test")
 
     # Fix BLAS being overridden by MKL
     # https://github.com/pytorch/pytorch/issues/60328
-    patch('https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/59220.patch',
-          sha256='e37afffe45cf7594c22050109942370e49983ad772d12ebccf508377dc9dcfc9',
-          when='@1.2.0:')
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/59220.patch",
+        sha256="e37afffe45cf7594c22050109942370e49983ad772d12ebccf508377dc9dcfc9",
+        when="@1.2.0:",
+    )
 
     # Fixes build on older systems with glibc <2.12
-    patch('https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/55063.patch',
-          sha256='e17eaa42f5d7c18bf0d7c37d7b0910127a01ad53fdce3e226a92893356a70395',
-          when='@1.1.0:1.8.1')
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/55063.patch",
+        sha256="e17eaa42f5d7c18bf0d7c37d7b0910127a01ad53fdce3e226a92893356a70395",
+        when="@1.1.0:1.8.1",
+    )
 
     # Fixes CMake configuration error when XNNPACK is disabled
     # https://github.com/pytorch/pytorch/pull/35607
     # https://github.com/pytorch/pytorch/pull/37865
-    patch('xnnpack.patch', when='@1.5.0:1.5')
+    patch("xnnpack.patch", when="@1.5.0:1.5")
 
     # Fixes build error when ROCm is enabled for pytorch-1.5 release
-    patch('rocm.patch', when='@1.5.0:1.5+rocm')
+    patch("rocm.patch", when="@1.5.0:1.5+rocm")
 
     # Fixes fatal error: sleef.h: No such file or directory
     # https://github.com/pytorch/pytorch/pull/35359
@@ -216,47 +233,56 @@ class PyTorch(PythonPackage, CudaPackage):
 
     # Fixes compilation with Clang 9.0.0 and Apple Clang 11.0.3
     # https://github.com/pytorch/pytorch/pull/37086
-    patch('https://github.com/pytorch/pytorch/commit/e921cd222a8fbeabf5a3e74e83e0d8dfb01aa8b5.patch',
-          sha256='17561b16cd2db22f10c0fe1fdcb428aecb0ac3964ba022a41343a6bb8cba7049',
-          when='@1.1:1.5')
+    patch(
+        "https://github.com/pytorch/pytorch/commit/e921cd222a8fbeabf5a3e74e83e0d8dfb01aa8b5.patch",
+        sha256="17561b16cd2db22f10c0fe1fdcb428aecb0ac3964ba022a41343a6bb8cba7049",
+        when="@1.1:1.5",
+    )
 
     # Removes duplicate definition of getCusparseErrorString
     # https://github.com/pytorch/pytorch/issues/32083
-    patch('cusparseGetErrorString.patch', when='@0.4.1:1.0^cuda@10.1.243:')
+    patch("cusparseGetErrorString.patch", when="@0.4.1:1.0^cuda@10.1.243:")
 
     # Fixes 'FindOpenMP.cmake'
     # to detect openmp settings used by Fujitsu compiler.
-    patch('detect_omp_of_fujitsu_compiler.patch', when='%fj')
+    patch("detect_omp_of_fujitsu_compiler.patch", when="%fj")
 
     # Fix compilation of +distributed~tensorpipe
     # https://github.com/pytorch/pytorch/issues/68002
-    patch('https://github.com/pytorch/pytorch/commit/c075f0f633fa0136e68f0a455b5b74d7b500865c.patch',
-          sha256='e69e41b5c171bfb00d1b5d4ee55dd5e4c8975483230274af4ab461acd37e40b8', when='@1.10.0+distributed~tensorpipe')
+    patch(
+        "https://github.com/pytorch/pytorch/commit/c075f0f633fa0136e68f0a455b5b74d7b500865c.patch",
+        sha256="e69e41b5c171bfb00d1b5d4ee55dd5e4c8975483230274af4ab461acd37e40b8",
+        when="@1.10.0+distributed~tensorpipe",
+    )
 
     # Both build and install run cmake/make/make install
     # Only run once to speed up build times
-    phases = ['install']
+    phases = ["install"]
 
     @property
     def libs(self):
-        root = join_path(self.prefix, self.spec['python'].package.site_packages_dir,
-                         'torch', 'lib')
-        return find_libraries('libtorch', root)
+        root = join_path(
+            self.prefix, self.spec["python"].package.site_packages_dir, "torch", "lib"
+        )
+        return find_libraries("libtorch", root)
 
     @property
     def headers(self):
-        root = join_path(self.prefix, self.spec['python'].package.site_packages_dir,
-                         'torch', 'include')
+        root = join_path(
+            self.prefix, self.spec["python"].package.site_packages_dir, "torch", "include"
+        )
         headers = find_all_headers(root)
         headers.directories = [root]
         return headers
 
-    @when('@1.5.0:')
+    @when("@1.5.0:")
     def patch(self):
         # https://github.com/pytorch/pytorch/issues/52208
-        filter_file('torch_global_deps PROPERTIES LINKER_LANGUAGE C',
-                    'torch_global_deps PROPERTIES LINKER_LANGUAGE CXX',
-                    'caffe2/CMakeLists.txt')
+        filter_file(
+            "torch_global_deps PROPERTIES LINKER_LANGUAGE C",
+            "torch_global_deps PROPERTIES LINKER_LANGUAGE CXX",
+            "caffe2/CMakeLists.txt",
+        )
 
     def setup_build_environment(self, env):
         """Set environment variables used to control the build.
@@ -269,7 +295,8 @@ class PyTorch(PythonPackage, CudaPackage):
         most flags defined in ``CMakeLists.txt`` can be specified as
         environment variables.
         """
-        def enable_or_disable(variant, keyword='USE', var=None, newer=False):
+
+        def enable_or_disable(variant, keyword="USE", var=None, newer=False):
             """Set environment variable to enable or disable support for a
             particular variant.
 
@@ -284,137 +311,135 @@ class PyTorch(PythonPackage, CudaPackage):
 
             # Version 1.1.0 switched from NO_* to USE_* or BUILD_*
             # But some newer variants have always used USE_* or BUILD_*
-            if self.spec.satisfies('@1.1:') or newer:
-                if '+' + variant in self.spec:
-                    env.set(keyword + '_' + var, 'ON')
+            if self.spec.satisfies("@1.1:") or newer:
+                if "+" + variant in self.spec:
+                    env.set(keyword + "_" + var, "ON")
                 else:
-                    env.set(keyword + '_' + var, 'OFF')
+                    env.set(keyword + "_" + var, "OFF")
             else:
-                if '+' + variant in self.spec:
-                    env.unset('NO_' + var)
+                if "+" + variant in self.spec:
+                    env.unset("NO_" + var)
                 else:
-                    env.set('NO_' + var, 'ON')
+                    env.set("NO_" + var, "ON")
 
         # Build in parallel to speed up build times
-        env.set('MAX_JOBS', make_jobs)
+        env.set("MAX_JOBS", make_jobs)
 
         # Spack logs have trouble handling colored output
-        env.set('COLORIZE_OUTPUT', 'OFF')
+        env.set("COLORIZE_OUTPUT", "OFF")
 
-        if self.spec.satisfies('@0.4:'):
-            enable_or_disable('test', keyword='BUILD')
+        if self.spec.satisfies("@0.4:"):
+            enable_or_disable("test", keyword="BUILD")
 
-        if self.spec.satisfies('@1.7:'):
-            enable_or_disable('caffe2', keyword='BUILD')
+        if self.spec.satisfies("@1.7:"):
+            enable_or_disable("caffe2", keyword="BUILD")
 
-        enable_or_disable('cuda')
-        if '+cuda' in self.spec:
+        enable_or_disable("cuda")
+        if "+cuda" in self.spec:
             # cmake/public/cuda.cmake
             # cmake/Modules_CUDA_fix/upstream/FindCUDA.cmake
-            env.unset('CUDA_ROOT')
-            torch_cuda_arch = ';'.join('{0:.1f}'.format(float(i) / 10.0) for i
-                                       in
-                                       self.spec.variants['cuda_arch'].value)
-            env.set('TORCH_CUDA_ARCH_LIST', torch_cuda_arch)
+            env.unset("CUDA_ROOT")
+            torch_cuda_arch = ";".join(
+                "{0:.1f}".format(float(i) / 10.0) for i in self.spec.variants["cuda_arch"].value
+            )
+            env.set("TORCH_CUDA_ARCH_LIST", torch_cuda_arch)
 
-        enable_or_disable('rocm')
+        enable_or_disable("rocm")
 
-        enable_or_disable('cudnn')
-        if '+cudnn' in self.spec:
+        enable_or_disable("cudnn")
+        if "+cudnn" in self.spec:
             # cmake/Modules_CUDA_fix/FindCUDNN.cmake
-            env.set('CUDNN_INCLUDE_DIR', self.spec['cudnn'].prefix.include)
-            env.set('CUDNN_LIBRARY', self.spec['cudnn'].libs[0])
+            env.set("CUDNN_INCLUDE_DIR", self.spec["cudnn"].prefix.include)
+            env.set("CUDNN_LIBRARY", self.spec["cudnn"].libs[0])
 
-        enable_or_disable('fbgemm')
-        if self.spec.satisfies('@1.8:'):
-            enable_or_disable('kineto')
-        enable_or_disable('magma')
-        enable_or_disable('metal')
-        if self.spec.satisfies('@1.10:'):
-            enable_or_disable('breakpad')
+        enable_or_disable("fbgemm")
+        if self.spec.satisfies("@1.8:"):
+            enable_or_disable("kineto")
+        enable_or_disable("magma")
+        enable_or_disable("metal")
+        if self.spec.satisfies("@1.10:"):
+            enable_or_disable("breakpad")
 
-        enable_or_disable('nccl')
-        if '+nccl' in self.spec:
-            env.set('NCCL_LIB_DIR', self.spec['nccl'].libs.directories[0])
-            env.set('NCCL_INCLUDE_DIR', self.spec['nccl'].prefix.include)
+        enable_or_disable("nccl")
+        if "+nccl" in self.spec:
+            env.set("NCCL_LIB_DIR", self.spec["nccl"].libs.directories[0])
+            env.set("NCCL_INCLUDE_DIR", self.spec["nccl"].prefix.include)
 
         # cmake/External/nnpack.cmake
-        enable_or_disable('nnpack')
+        enable_or_disable("nnpack")
 
-        enable_or_disable('numa')
-        if '+numa' in self.spec:
+        enable_or_disable("numa")
+        if "+numa" in self.spec:
             # cmake/Modules/FindNuma.cmake
-            env.set('NUMA_ROOT_DIR', self.spec['numactl'].prefix)
+            env.set("NUMA_ROOT_DIR", self.spec["numactl"].prefix)
 
         # cmake/Modules/FindNumPy.cmake
-        enable_or_disable('numpy')
+        enable_or_disable("numpy")
         # cmake/Modules/FindOpenMP.cmake
-        enable_or_disable('openmp', newer=True)
-        enable_or_disable('qnnpack')
-        if self.spec.satisfies('@1.3:'):
-            enable_or_disable('qnnpack', var='PYTORCH_QNNPACK')
-        if self.spec.satisfies('@1.8:'):
-            enable_or_disable('valgrind')
-        if self.spec.satisfies('@1.5:'):
-            enable_or_disable('xnnpack')
-        enable_or_disable('mkldnn')
-        enable_or_disable('distributed')
-        enable_or_disable('mpi')
+        enable_or_disable("openmp", newer=True)
+        enable_or_disable("qnnpack")
+        if self.spec.satisfies("@1.3:"):
+            enable_or_disable("qnnpack", var="PYTORCH_QNNPACK")
+        if self.spec.satisfies("@1.8:"):
+            enable_or_disable("valgrind")
+        if self.spec.satisfies("@1.5:"):
+            enable_or_disable("xnnpack")
+        enable_or_disable("mkldnn")
+        enable_or_disable("distributed")
+        enable_or_disable("mpi")
         # cmake/Modules/FindGloo.cmake
-        enable_or_disable('gloo', newer=True)
-        if self.spec.satisfies('@1.6:'):
-            enable_or_disable('tensorpipe')
+        enable_or_disable("gloo", newer=True)
+        if self.spec.satisfies("@1.6:"):
+            enable_or_disable("tensorpipe")
 
-        if '+onnx_ml' in self.spec:
-            env.set('ONNX_ML', 'ON')
+        if "+onnx_ml" in self.spec:
+            env.set("ONNX_ML", "ON")
         else:
-            env.set('ONNX_ML', 'OFF')
+            env.set("ONNX_ML", "OFF")
 
-        if not self.spec.satisfies('@master'):
-            env.set('PYTORCH_BUILD_VERSION', self.version)
-            env.set('PYTORCH_BUILD_NUMBER', 0)
+        if not self.spec.satisfies("@master"):
+            env.set("PYTORCH_BUILD_VERSION", self.version)
+            env.set("PYTORCH_BUILD_NUMBER", 0)
 
         # BLAS to be used by Caffe2
         # Options defined in cmake/Dependencies.cmake and cmake/Modules/FindBLAS.cmake
-        if self.spec['blas'].name == 'atlas':
-            env.set('BLAS', 'ATLAS')
-            env.set('WITH_BLAS', 'atlas')
-        elif self.spec['blas'].name in ['blis', 'amdblis']:
-            env.set('BLAS', 'BLIS')
-            env.set('WITH_BLAS', 'blis')
-        elif self.spec['blas'].name == 'eigen':
-            env.set('BLAS', 'Eigen')
-        elif self.spec['lapack'].name in ['libflame', 'amdlibflame']:
-            env.set('BLAS', 'FLAME')
-            env.set('WITH_BLAS', 'FLAME')
-        elif self.spec['blas'].name in [
-                'intel-mkl', 'intel-parallel-studio', 'intel-oneapi-mkl']:
-            env.set('BLAS', 'MKL')
-            env.set('WITH_BLAS', 'mkl')
-        elif self.spec['blas'].name == 'openblas':
-            env.set('BLAS', 'OpenBLAS')
-            env.set('WITH_BLAS', 'open')
-        elif self.spec['blas'].name == 'veclibfort':
-            env.set('BLAS', 'vecLib')
-            env.set('WITH_BLAS', 'veclib')
+        if self.spec["blas"].name == "atlas":
+            env.set("BLAS", "ATLAS")
+            env.set("WITH_BLAS", "atlas")
+        elif self.spec["blas"].name in ["blis", "amdblis"]:
+            env.set("BLAS", "BLIS")
+            env.set("WITH_BLAS", "blis")
+        elif self.spec["blas"].name == "eigen":
+            env.set("BLAS", "Eigen")
+        elif self.spec["lapack"].name in ["libflame", "amdlibflame"]:
+            env.set("BLAS", "FLAME")
+            env.set("WITH_BLAS", "FLAME")
+        elif self.spec["blas"].name in ["intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"]:
+            env.set("BLAS", "MKL")
+            env.set("WITH_BLAS", "mkl")
+        elif self.spec["blas"].name == "openblas":
+            env.set("BLAS", "OpenBLAS")
+            env.set("WITH_BLAS", "open")
+        elif self.spec["blas"].name == "veclibfort":
+            env.set("BLAS", "vecLib")
+            env.set("WITH_BLAS", "veclib")
         else:
-            env.set('BLAS', 'Generic')
-            env.set('WITH_BLAS', 'generic')
+            env.set("BLAS", "Generic")
+            env.set("WITH_BLAS", "generic")
 
         # Don't use vendored third-party libraries when possible
-        env.set('BUILD_CUSTOM_PROTOBUF', 'OFF')
-        env.set('USE_SYSTEM_NCCL', 'ON')
-        env.set('USE_SYSTEM_EIGEN_INSTALL', 'ON')
-        if self.spec.satisfies('@0.4:'):
-            env.set('pybind11_DIR', self.spec['py-pybind11'].prefix)
-            env.set('pybind11_INCLUDE_DIR',
-                    self.spec['py-pybind11'].prefix.include)
-        if self.spec.satisfies('@1.10:'):
-            env.set('USE_SYSTEM_PYBIND11', 'ON')
+        env.set("BUILD_CUSTOM_PROTOBUF", "OFF")
+        env.set("USE_SYSTEM_NCCL", "ON")
+        env.set("USE_SYSTEM_EIGEN_INSTALL", "ON")
+        if self.spec.satisfies("@0.4:"):
+            env.set("pybind11_DIR", self.spec["py-pybind11"].prefix)
+            env.set("pybind11_INCLUDE_DIR", self.spec["py-pybind11"].prefix.include)
+        if self.spec.satisfies("@1.10:"):
+            env.set("USE_SYSTEM_PYBIND11", "ON")
         # https://github.com/pytorch/pytorch/issues/60334
         # if self.spec.satisfies('@1.8:'):
         #     env.set('USE_SYSTEM_SLEEF', 'ON')
-        if self.spec.satisfies('@1.6:'):
+        if self.spec.satisfies("@1.6:"):
             # env.set('USE_SYSTEM_LIBS', 'ON')
             # https://github.com/pytorch/pytorch/issues/60329
             # env.set('USE_SYSTEM_CPUINFO', 'ON')
@@ -422,27 +447,26 @@ class PyTorch(PythonPackage, CudaPackage):
             # env.set('USE_SYSTEM_GLOO', 'ON')
             # https://github.com/Maratyszcza/FP16/issues/18
             # env.set('USE_SYSTEM_FP16', 'ON')
-            env.set('USE_SYSTEM_PTHREADPOOL', 'ON')
-            env.set('USE_SYSTEM_PSIMD', 'ON')
-            env.set('USE_SYSTEM_FXDIV', 'ON')
-            env.set('USE_SYSTEM_BENCHMARK', 'ON')
+            env.set("USE_SYSTEM_PTHREADPOOL", "ON")
+            env.set("USE_SYSTEM_PSIMD", "ON")
+            env.set("USE_SYSTEM_FXDIV", "ON")
+            env.set("USE_SYSTEM_BENCHMARK", "ON")
             # https://github.com/pytorch/pytorch/issues/60331
             # env.set('USE_SYSTEM_ONNX', 'ON')
             # https://github.com/pytorch/pytorch/issues/60332
             # env.set('USE_SYSTEM_XNNPACK', 'ON')
 
-    @run_before('install')
+    @run_before("install")
     def build_amd(self):
-        if '+rocm' in self.spec:
-            python(os.path.join('tools', 'amd_build', 'build_amd.py'))
+        if "+rocm" in self.spec:
+            python(os.path.join("tools", "amd_build", "build_amd.py"))
 
-    @run_after('install')
+    @run_after("install")
     @on_package_attributes(run_tests=True)
     def install_test(self):
-        with working_dir('test'):
-            python('run_test.py')
+        with working_dir("test"):
+            python("run_test.py")
 
     # Tests need to be re-added since `phases` was overridden
-    run_after('install')(
-        PythonPackage._run_default_install_time_test_callbacks)
-    run_after('install')(PythonPackage.sanity_check_prefix)
+    run_after("install")(PythonPackage._run_default_install_time_test_callbacks)
+    run_after("install")(PythonPackage.sanity_check_prefix)

--- a/lib/spack/spack/test/data/unparse/trilinos.txt
+++ b/lib/spack/spack/test/data/unparse/trilinos.txt
@@ -1,4 +1,4 @@
- # -*- python -*-
+# -*- python -*-
 # Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
@@ -36,296 +36,339 @@ class Trilinos(CMakePackage, CudaPackage):
     of large-scale, complex multi-physics engineering and scientific problems.
     A unique design feature of Trilinos is its focus on packages.
     """
+
     homepage = "https://trilinos.org/"
-    url      = "https://github.com/trilinos/Trilinos/archive/trilinos-release-12-12-1.tar.gz"
-    git      = "https://github.com/trilinos/Trilinos.git"
+    url = "https://github.com/trilinos/Trilinos/archive/trilinos-release-12-12-1.tar.gz"
+    git = "https://github.com/trilinos/Trilinos.git"
 
-    maintainers = ['keitat', 'sethrj', 'kuberry']
+    maintainers("keitat", "sethrj", "kuberry")
 
-    tags = ['e4s']
+    tags = ["e4s"]
 
     # ###################### Versions ##########################
 
-    version('master', branch='master')
-    version('develop', branch='develop')
-    version('13.2.0', commit='4a5f7906a6420ee2f9450367e9cc95b28c00d744')  # tag trilinos-release-13-2-0
-    version('13.0.1', commit='4796b92fb0644ba8c531dd9953e7a4878b05c62d', preferred=True)  # tag trilinos-release-13-0-1
-    version('13.0.0', commit='9fec35276d846a667bc668ff4cbdfd8be0dfea08')  # tag trilinos-release-13-0-0
-    version('12.18.1', commit='55a75997332636a28afc9db1aee4ae46fe8d93e7')  # tag trilinos-release-12-8-1
-    version('12.14.1', sha256='52a4406cca2241f5eea8e166c2950471dd9478ad6741cbb2a7fc8225814616f0')
-    version('12.12.1', sha256='5474c5329c6309224a7e1726cf6f0d855025b2042959e4e2be2748bd6bb49e18')
-    version('12.10.1', sha256='ab81d917196ffbc21c4927d42df079dd94c83c1a08bda43fef2dd34d0c1a5512')
-    version('12.8.1', sha256='d20fe60e31e3ba1ef36edecd88226240a518f50a4d6edcc195b88ee9dda5b4a1')
-    version('12.6.4', sha256='1c7104ba60ee8cc4ec0458a1c4f6a26130616bae7580a7b15f2771a955818b73')
-    version('12.6.3', sha256='4d28298bb4074eef522db6cd1626f1a934e3d80f292caf669b8846c0a458fe81')
-    version('12.6.2', sha256='8be7e3e1166cc05aea7f856cc8033182e8114aeb8f87184cb38873bfb2061779')
-    version('12.6.1', sha256='4b38ede471bed0036dcb81a116fba8194f7bf1a9330da4e29c3eb507d2db18db')
-    version('12.4.2', sha256='fd2c12e87a7cedc058bcb8357107ffa2474997aa7b17b8e37225a1f7c32e6f0e')
-    version('12.2.1', sha256='088f303e0dc00fb4072b895c6ecb4e2a3ad9a2687b9c62153de05832cf242098')
-    version('12.0.1', sha256='eee7c19ca108538fa1c77a6651b084e06f59d7c3307dae77144136639ab55980')
-    version('11.14.3', sha256='e37fa5f69103576c89300e14d43ba77ad75998a54731008b25890d39892e6e60')
-    version('11.14.2', sha256='f22b2b0df7b88e28b992e19044ba72b845292b93cbbb3a948488199647381119')
-    version('11.14.1', sha256='f10fc0a496bf49427eb6871c80816d6e26822a39177d850cc62cf1484e4eec07')
+    version("master", branch="master")
+    version("develop", branch="develop")
+    version(
+        "13.2.0", commit="4a5f7906a6420ee2f9450367e9cc95b28c00d744"
+    )  # tag trilinos-release-13-2-0
+    version(
+        "13.0.1", commit="4796b92fb0644ba8c531dd9953e7a4878b05c62d", preferred=True
+    )  # tag trilinos-release-13-0-1
+    version(
+        "13.0.0", commit="9fec35276d846a667bc668ff4cbdfd8be0dfea08"
+    )  # tag trilinos-release-13-0-0
+    version(
+        "12.18.1", commit="55a75997332636a28afc9db1aee4ae46fe8d93e7"
+    )  # tag trilinos-release-12-8-1
+    version("12.14.1", sha256="52a4406cca2241f5eea8e166c2950471dd9478ad6741cbb2a7fc8225814616f0")
+    version("12.12.1", sha256="5474c5329c6309224a7e1726cf6f0d855025b2042959e4e2be2748bd6bb49e18")
+    version("12.10.1", sha256="ab81d917196ffbc21c4927d42df079dd94c83c1a08bda43fef2dd34d0c1a5512")
+    version("12.8.1", sha256="d20fe60e31e3ba1ef36edecd88226240a518f50a4d6edcc195b88ee9dda5b4a1")
+    version("12.6.4", sha256="1c7104ba60ee8cc4ec0458a1c4f6a26130616bae7580a7b15f2771a955818b73")
+    version("12.6.3", sha256="4d28298bb4074eef522db6cd1626f1a934e3d80f292caf669b8846c0a458fe81")
+    version("12.6.2", sha256="8be7e3e1166cc05aea7f856cc8033182e8114aeb8f87184cb38873bfb2061779")
+    version("12.6.1", sha256="4b38ede471bed0036dcb81a116fba8194f7bf1a9330da4e29c3eb507d2db18db")
+    version("12.4.2", sha256="fd2c12e87a7cedc058bcb8357107ffa2474997aa7b17b8e37225a1f7c32e6f0e")
+    version("12.2.1", sha256="088f303e0dc00fb4072b895c6ecb4e2a3ad9a2687b9c62153de05832cf242098")
+    version("12.0.1", sha256="eee7c19ca108538fa1c77a6651b084e06f59d7c3307dae77144136639ab55980")
+    version("11.14.3", sha256="e37fa5f69103576c89300e14d43ba77ad75998a54731008b25890d39892e6e60")
+    version("11.14.2", sha256="f22b2b0df7b88e28b992e19044ba72b845292b93cbbb3a948488199647381119")
+    version("11.14.1", sha256="f10fc0a496bf49427eb6871c80816d6e26822a39177d850cc62cf1484e4eec07")
 
     # ###################### Variants ##########################
 
     # Build options
-    variant('complex', default=False, description='Enable complex numbers in Trilinos')
-    variant('cuda_rdc', default=False, description='turn on RDC for CUDA build')
-    variant('cxxstd', default='14', values=['11', '14', '17'], multi=False)
-    variant('debug', default=False, description='Enable runtime safety and debug checks')
-    variant('explicit_template_instantiation', default=True, description='Enable explicit template instantiation (ETI)')
-    variant('float', default=False, description='Enable single precision (float) numbers in Trilinos')
-    variant('fortran', default=True, description='Compile with Fortran support')
-    variant('gotype', default='long_long',
-            values=('int', 'long', 'long_long', 'all'),
-            multi=False,
-            description='global ordinal type for Tpetra')
-    variant('openmp', default=False, description='Enable OpenMP')
-    variant('python', default=False, description='Build PyTrilinos wrappers')
-    variant('shared', default=True, description='Enables the build of shared libraries')
-    variant('wrapper', default=False, description="Use nvcc-wrapper for CUDA build")
+    variant("complex", default=False, description="Enable complex numbers in Trilinos")
+    variant("cuda_rdc", default=False, description="turn on RDC for CUDA build")
+    variant("cxxstd", default="14", values=["11", "14", "17"], multi=False)
+    variant("debug", default=False, description="Enable runtime safety and debug checks")
+    variant(
+        "explicit_template_instantiation",
+        default=True,
+        description="Enable explicit template instantiation (ETI)",
+    )
+    variant(
+        "float", default=False, description="Enable single precision (float) numbers in Trilinos"
+    )
+    variant("fortran", default=True, description="Compile with Fortran support")
+    variant(
+        "gotype",
+        default="long_long",
+        values=("int", "long", "long_long", "all"),
+        multi=False,
+        description="global ordinal type for Tpetra",
+    )
+    variant("openmp", default=False, description="Enable OpenMP")
+    variant("python", default=False, description="Build PyTrilinos wrappers")
+    variant("shared", default=True, description="Enables the build of shared libraries")
+    variant("wrapper", default=False, description="Use nvcc-wrapper for CUDA build")
 
     # TPLs (alphabet order)
-    variant('adios2',       default=False, description='Enable ADIOS2')
-    variant('boost',        default=False, description='Compile with Boost')
-    variant('hdf5',         default=False, description='Compile with HDF5')
-    variant('hypre',        default=False, description='Compile with Hypre preconditioner')
-    variant('mpi',          default=True, description='Compile with MPI parallelism')
-    variant('mumps',        default=False, description='Compile with support for MUMPS solvers')
-    variant('suite-sparse', default=False, description='Compile with SuiteSparse solvers')
-    variant('superlu-dist', default=False, description='Compile with SuperluDist solvers')
-    variant('superlu',      default=False, description='Compile with SuperLU solvers')
-    variant('strumpack',    default=False, description='Compile with STRUMPACK solvers')
-    variant('x11',          default=False, description='Compile with X11 when +exodus')
+    variant("adios2", default=False, description="Enable ADIOS2")
+    variant("boost", default=False, description="Compile with Boost")
+    variant("hdf5", default=False, description="Compile with HDF5")
+    variant("hypre", default=False, description="Compile with Hypre preconditioner")
+    variant("mpi", default=True, description="Compile with MPI parallelism")
+    variant("mumps", default=False, description="Compile with support for MUMPS solvers")
+    variant("suite-sparse", default=False, description="Compile with SuiteSparse solvers")
+    variant("superlu-dist", default=False, description="Compile with SuperluDist solvers")
+    variant("superlu", default=False, description="Compile with SuperLU solvers")
+    variant("strumpack", default=False, description="Compile with STRUMPACK solvers")
+    variant("x11", default=False, description="Compile with X11 when +exodus")
 
     # Package options (alphabet order)
-    variant('amesos',       default=True, description='Compile with Amesos')
-    variant('amesos2',      default=True, description='Compile with Amesos2')
-    variant('anasazi',      default=True, description='Compile with Anasazi')
-    variant('aztec',        default=True, description='Compile with Aztec')
-    variant('belos',        default=True, description='Compile with Belos')
-    variant('chaco',        default=False, description='Compile with Chaco from SEACAS')
-    variant('epetra',       default=True, description='Compile with Epetra')
-    variant('epetraext',    default=True, description='Compile with EpetraExt')
-    variant('exodus',       default=False, description='Compile with Exodus from SEACAS')
-    variant('ifpack',       default=True, description='Compile with Ifpack')
-    variant('ifpack2',      default=True, description='Compile with Ifpack2')
-    variant('intrepid',     default=False, description='Enable Intrepid')
-    variant('intrepid2',    default=False, description='Enable Intrepid2')
-    variant('isorropia',    default=False, description='Compile with Isorropia')
-    variant('gtest',        default=False, description='Build vendored Googletest')
-    variant('kokkos',       default=True, description='Compile with Kokkos')
-    variant('ml',           default=True, description='Compile with ML')
-    variant('minitensor',   default=False, description='Compile with MiniTensor')
-    variant('muelu',        default=True, description='Compile with Muelu')
-    variant('nox',          default=False, description='Compile with NOX')
-    variant('piro',         default=False, description='Compile with Piro')
-    variant('phalanx',      default=False, description='Compile with Phalanx')
-    variant('rol',          default=False, description='Compile with ROL')
-    variant('rythmos',      default=False, description='Compile with Rythmos')
-    variant('sacado',       default=True, description='Compile with Sacado')
-    variant('stk',          default=False, description='Compile with STK')
-    variant('shards',       default=False, description='Compile with Shards')
-    variant('shylu',        default=False, description='Compile with ShyLU')
-    variant('stokhos',      default=False, description='Compile with Stokhos')
-    variant('stratimikos',  default=False, description='Compile with Stratimikos')
-    variant('teko',         default=False, description='Compile with Teko')
-    variant('tempus',       default=False, description='Compile with Tempus')
-    variant('tpetra',       default=True, description='Compile with Tpetra')
-    variant('trilinoscouplings', default=False, description='Compile with TrilinosCouplings')
-    variant('zoltan',       default=False, description='Compile with Zoltan')
-    variant('zoltan2',      default=False, description='Compile with Zoltan2')
+    variant("amesos", default=True, description="Compile with Amesos")
+    variant("amesos2", default=True, description="Compile with Amesos2")
+    variant("anasazi", default=True, description="Compile with Anasazi")
+    variant("aztec", default=True, description="Compile with Aztec")
+    variant("belos", default=True, description="Compile with Belos")
+    variant("chaco", default=False, description="Compile with Chaco from SEACAS")
+    variant("epetra", default=True, description="Compile with Epetra")
+    variant("epetraext", default=True, description="Compile with EpetraExt")
+    variant("exodus", default=False, description="Compile with Exodus from SEACAS")
+    variant("ifpack", default=True, description="Compile with Ifpack")
+    variant("ifpack2", default=True, description="Compile with Ifpack2")
+    variant("intrepid", default=False, description="Enable Intrepid")
+    variant("intrepid2", default=False, description="Enable Intrepid2")
+    variant("isorropia", default=False, description="Compile with Isorropia")
+    variant("gtest", default=False, description="Build vendored Googletest")
+    variant("kokkos", default=True, description="Compile with Kokkos")
+    variant("ml", default=True, description="Compile with ML")
+    variant("minitensor", default=False, description="Compile with MiniTensor")
+    variant("muelu", default=True, description="Compile with Muelu")
+    variant("nox", default=False, description="Compile with NOX")
+    variant("piro", default=False, description="Compile with Piro")
+    variant("phalanx", default=False, description="Compile with Phalanx")
+    variant("rol", default=False, description="Compile with ROL")
+    variant("rythmos", default=False, description="Compile with Rythmos")
+    variant("sacado", default=True, description="Compile with Sacado")
+    variant("stk", default=False, description="Compile with STK")
+    variant("shards", default=False, description="Compile with Shards")
+    variant("shylu", default=False, description="Compile with ShyLU")
+    variant("stokhos", default=False, description="Compile with Stokhos")
+    variant("stratimikos", default=False, description="Compile with Stratimikos")
+    variant("teko", default=False, description="Compile with Teko")
+    variant("tempus", default=False, description="Compile with Tempus")
+    variant("tpetra", default=True, description="Compile with Tpetra")
+    variant("trilinoscouplings", default=False, description="Compile with TrilinosCouplings")
+    variant("zoltan", default=False, description="Compile with Zoltan")
+    variant("zoltan2", default=False, description="Compile with Zoltan2")
 
     # Internal package options (alphabetical order)
-    variant('basker',                    default=False, description='Compile with the Basker solver in Amesos2')
-    variant('epetraextbtf',              default=False, description='Compile with BTF in EpetraExt')
-    variant('epetraextexperimental',     default=False, description='Compile with experimental in EpetraExt')
-    variant('epetraextgraphreorderings', default=False, description='Compile with graph reorderings in EpetraExt')
+    variant("basker", default=False, description="Compile with the Basker solver in Amesos2")
+    variant("epetraextbtf", default=False, description="Compile with BTF in EpetraExt")
+    variant(
+        "epetraextexperimental",
+        default=False,
+        description="Compile with experimental in EpetraExt",
+    )
+    variant(
+        "epetraextgraphreorderings",
+        default=False,
+        description="Compile with graph reorderings in EpetraExt",
+    )
 
     # External package options
-    variant('dtk',      default=False, description='Enable DataTransferKit (deprecated)')
-    variant('scorec',   default=False, description='Enable SCOREC')
-    variant('mesquite', default=False, description='Enable Mesquite (deprecated)')
+    variant("dtk", default=False, description="Enable DataTransferKit (deprecated)")
+    variant("scorec", default=False, description="Enable SCOREC")
+    variant("mesquite", default=False, description="Enable Mesquite (deprecated)")
 
-    resource(name='dtk',
-             git='https://github.com/ornl-cees/DataTransferKit.git',
-             commit='4fe4d9d56cfd4f8a61f392b81d8efd0e389ee764',  # branch dtk-3.0
-             placement='DataTransferKit',
-             when='+dtk @12.14.0:12.14')
-    resource(name='dtk',
-             git='https://github.com/ornl-cees/DataTransferKit.git',
-             commit='edfa050cd46e2274ab0a0b7558caca0079c2e4ca',  # tag 3.1-rc1
-             placement='DataTransferKit',
-             submodules=True,
-             when='+dtk @12.18.0:12.18')
-    resource(name='scorec',
-             git='https://github.com/SCOREC/core.git',
-             commit='73c16eae073b179e45ec625a5abe4915bc589af2',  # tag v2.2.5
-             placement='SCOREC',
-             when='+scorec')
-    resource(name='mesquite',
-             url='https://github.com/trilinos/mesquite/archive/trilinos-release-12-12-1.tar.gz',
-             sha256='e0d09b0939dbd461822477449dca611417316e8e8d8268fd795debb068edcbb5',
-             placement='packages/mesquite',
-             when='+mesquite @12.12.1:12.16')
-    resource(name='mesquite',
-             git='https://github.com/trilinos/mesquite.git',
-             commit='20a679679b5cdf15bf573d66c5dc2b016e8b9ca1',  # branch trilinos-release-12-12-1
-             placement='packages/mesquite',
-             when='+mesquite @12.18.1:12.18')
-    resource(name='mesquite',
-             git='https://github.com/trilinos/mesquite.git',
-             tag='develop',
-             placement='packages/mesquite',
-             when='+mesquite @master')
+    resource(
+        name="dtk",
+        git="https://github.com/ornl-cees/DataTransferKit.git",
+        commit="4fe4d9d56cfd4f8a61f392b81d8efd0e389ee764",  # branch dtk-3.0
+        placement="DataTransferKit",
+        when="+dtk @12.14.0:12.14",
+    )
+    resource(
+        name="dtk",
+        git="https://github.com/ornl-cees/DataTransferKit.git",
+        commit="edfa050cd46e2274ab0a0b7558caca0079c2e4ca",  # tag 3.1-rc1
+        placement="DataTransferKit",
+        submodules=True,
+        when="+dtk @12.18.0:12.18",
+    )
+    resource(
+        name="scorec",
+        git="https://github.com/SCOREC/core.git",
+        commit="73c16eae073b179e45ec625a5abe4915bc589af2",  # tag v2.2.5
+        placement="SCOREC",
+        when="+scorec",
+    )
+    resource(
+        name="mesquite",
+        url="https://github.com/trilinos/mesquite/archive/trilinos-release-12-12-1.tar.gz",
+        sha256="e0d09b0939dbd461822477449dca611417316e8e8d8268fd795debb068edcbb5",
+        placement="packages/mesquite",
+        when="+mesquite @12.12.1:12.16",
+    )
+    resource(
+        name="mesquite",
+        git="https://github.com/trilinos/mesquite.git",
+        commit="20a679679b5cdf15bf573d66c5dc2b016e8b9ca1",  # branch trilinos-release-12-12-1
+        placement="packages/mesquite",
+        when="+mesquite @12.18.1:12.18",
+    )
+    resource(
+        name="mesquite",
+        git="https://github.com/trilinos/mesquite.git",
+        tag="develop",
+        placement="packages/mesquite",
+        when="+mesquite @master",
+    )
 
     # ###################### Conflicts ##########################
 
     # Epetra packages
-    with when('~epetra'):
-        conflicts('+amesos')
-        conflicts('+aztec')
-        conflicts('+epetraext')
-        conflicts('+ifpack')
-        conflicts('+isorropia')
-        conflicts('+ml', when='@13.2:')
-    with when('~epetraext'):
-        conflicts('+isorropia')
-        conflicts('+teko')
-        conflicts('+epetraextbtf')
-        conflicts('+epetraextexperimental')
-        conflicts('+epetraextgraphreorderings')
+    with when("~epetra"):
+        conflicts("+amesos")
+        conflicts("+aztec")
+        conflicts("+epetraext")
+        conflicts("+ifpack")
+        conflicts("+isorropia")
+        conflicts("+ml", when="@13.2:")
+    with when("~epetraext"):
+        conflicts("+isorropia")
+        conflicts("+teko")
+        conflicts("+epetraextbtf")
+        conflicts("+epetraextexperimental")
+        conflicts("+epetraextgraphreorderings")
 
     # Tpetra packages
-    with when('~kokkos'):
-        conflicts('+cuda')
-        conflicts('+tpetra')
-        conflicts('+intrepid2')
-        conflicts('+phalanx')
-    with when('~tpetra'):
-        conflicts('+amesos2')
-        conflicts('+dtk')
-        conflicts('+ifpack2')
-        conflicts('+muelu')
-        conflicts('+teko')
-        conflicts('+zoltan2')
+    with when("~kokkos"):
+        conflicts("+cuda")
+        conflicts("+tpetra")
+        conflicts("+intrepid2")
+        conflicts("+phalanx")
+    with when("~tpetra"):
+        conflicts("+amesos2")
+        conflicts("+dtk")
+        conflicts("+ifpack2")
+        conflicts("+muelu")
+        conflicts("+teko")
+        conflicts("+zoltan2")
 
-    with when('+teko'):
-        conflicts('~amesos')
-        conflicts('~anasazi')
-        conflicts('~aztec')
-        conflicts('~ifpack')
-        conflicts('~ml')
-        conflicts('~stratimikos')
-        conflicts('@:12 gotype=long')
+    with when("+teko"):
+        conflicts("~amesos")
+        conflicts("~anasazi")
+        conflicts("~aztec")
+        conflicts("~ifpack")
+        conflicts("~ml")
+        conflicts("~stratimikos")
+        conflicts("@:12 gotype=long")
 
     # Known requirements from tribits dependencies
-    conflicts('+aztec', when='~fortran')
-    conflicts('+basker', when='~amesos2')
-    conflicts('+minitensor', when='~boost')
-    conflicts('+ifpack2', when='~belos')
-    conflicts('+intrepid', when='~sacado')
-    conflicts('+intrepid', when='~shards')
-    conflicts('+intrepid2', when='~shards')
-    conflicts('+isorropia', when='~zoltan')
-    conflicts('+phalanx', when='~sacado')
-    conflicts('+scorec', when='~mpi')
-    conflicts('+scorec', when='~shards')
-    conflicts('+scorec', when='~stk')
-    conflicts('+scorec', when='~zoltan')
-    conflicts('+tempus', when='~nox')
-    conflicts('+zoltan2', when='~zoltan')
+    conflicts("+aztec", when="~fortran")
+    conflicts("+basker", when="~amesos2")
+    conflicts("+minitensor", when="~boost")
+    conflicts("+ifpack2", when="~belos")
+    conflicts("+intrepid", when="~sacado")
+    conflicts("+intrepid", when="~shards")
+    conflicts("+intrepid2", when="~shards")
+    conflicts("+isorropia", when="~zoltan")
+    conflicts("+phalanx", when="~sacado")
+    conflicts("+scorec", when="~mpi")
+    conflicts("+scorec", when="~shards")
+    conflicts("+scorec", when="~stk")
+    conflicts("+scorec", when="~zoltan")
+    conflicts("+tempus", when="~nox")
+    conflicts("+zoltan2", when="~zoltan")
 
     # Only allow DTK with Trilinos 12.14, 12.18
-    conflicts('+dtk', when='~boost')
-    conflicts('+dtk', when='~intrepid2')
-    conflicts('+dtk', when='@:12.12,13:')
+    conflicts("+dtk", when="~boost")
+    conflicts("+dtk", when="~intrepid2")
+    conflicts("+dtk", when="@:12.12,13:")
 
     # Installed FindTrilinos are broken in SEACAS if Fortran is disabled
     # see https://github.com/trilinos/Trilinos/issues/3346
-    conflicts('+exodus', when='@:13.0.1 ~fortran')
+    conflicts("+exodus", when="@:13.0.1 ~fortran")
     # Only allow Mesquite with Trilinos 12.12 and up, and master
-    conflicts('+mesquite', when='@:12.10,master')
+    conflicts("+mesquite", when="@:12.10,master")
     # Strumpack is only available as of mid-2021
-    conflicts('+strumpack', when='@:13.0')
+    conflicts("+strumpack", when="@:13.0")
     # Can only use one type of SuperLU
-    conflicts('+superlu-dist', when='+superlu')
+    conflicts("+superlu-dist", when="+superlu")
     # For Trilinos v11 we need to force SuperLUDist=OFF, since only the
     # deprecated SuperLUDist v3.3 together with an Amesos patch is working.
-    conflicts('+superlu-dist', when='@11.4.1:11.14.3')
+    conflicts("+superlu-dist", when="@11.4.1:11.14.3")
     # see https://github.com/trilinos/Trilinos/issues/3566
-    conflicts('+superlu-dist', when='+float+amesos2+explicit_template_instantiation^superlu-dist@5.3.0:')
+    conflicts(
+        "+superlu-dist", when="+float+amesos2+explicit_template_instantiation^superlu-dist@5.3.0:"
+    )
     # Amesos, conflicting types of double and complex SLU_D
     # see https://trilinos.org/pipermail/trilinos-users/2015-March/004731.html
     # and https://trilinos.org/pipermail/trilinos-users/2015-March/004802.html
-    conflicts('+superlu-dist', when='+complex+amesos2')
+    conflicts("+superlu-dist", when="+complex+amesos2")
     # https://github.com/trilinos/Trilinos/issues/2994
     conflicts(
-        '+shared', when='+stk platform=darwin',
-        msg='Cannot build Trilinos with STK as a shared library on Darwin.'
+        "+shared",
+        when="+stk platform=darwin",
+        msg="Cannot build Trilinos with STK as a shared library on Darwin.",
     )
-    conflicts('+adios2', when='@:12.14.1')
-    conflicts('cxxstd=11', when='@master:')
-    conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
-    conflicts('cxxstd=14', when='+wrapper ^cuda@6.5.14:8.0.61')
-    conflicts('cxxstd=17', when='+wrapper ^cuda@6.5.14:10.2.89')
+    conflicts("+adios2", when="@:12.14.1")
+    conflicts("cxxstd=11", when="@master:")
+    conflicts("cxxstd=11", when="+wrapper ^cuda@6.5.14")
+    conflicts("cxxstd=14", when="+wrapper ^cuda@6.5.14:8.0.61")
+    conflicts("cxxstd=17", when="+wrapper ^cuda@6.5.14:10.2.89")
 
     # Multi-value gotype only applies to trilinos through 12.14
-    conflicts('gotype=all', when='@12.15:')
+    conflicts("gotype=all", when="@12.15:")
 
     # CUDA without wrapper requires clang
     for _compiler in spack.compilers.supported_compilers():
-        if _compiler != 'clang':
-            conflicts('+cuda', when='~wrapper %' + _compiler,
-                      msg='trilinos~wrapper+cuda can only be built with the '
-                      'Clang compiler')
-    conflicts('+cuda_rdc', when='~cuda')
-    conflicts('+wrapper', when='~cuda')
-    conflicts('+wrapper', when='%clang')
+        if _compiler != "clang":
+            conflicts(
+                "+cuda",
+                when="~wrapper %" + _compiler,
+                msg="trilinos~wrapper+cuda can only be built with the " "Clang compiler",
+            )
+    conflicts("+cuda_rdc", when="~cuda")
+    conflicts("+wrapper", when="~cuda")
+    conflicts("+wrapper", when="%clang")
 
     # Old trilinos fails with new CUDA (see #27180)
-    conflicts('@:13.0.1 +cuda', when='^cuda@11:')
+    conflicts("@:13.0.1 +cuda", when="^cuda@11:")
 
     # stokhos fails on xl/xl_r
-    conflicts('+stokhos', when='%xl')
-    conflicts('+stokhos', when='%xl_r')
+    conflicts("+stokhos", when="%xl")
+    conflicts("+stokhos", when="%xl_r")
 
     # Fortran mangling fails on Apple M1 (see spack/spack#25900)
-    conflicts('@:13.0.1 +fortran', when='target=m1')
+    conflicts("@:13.0.1 +fortran", when="target=m1")
 
     # ###################### Dependencies ##########################
 
-    depends_on('adios2', when='+adios2')
-    depends_on('blas')
-    depends_on('boost', when='+boost')
-    depends_on('cgns', when='+exodus')
-    depends_on('hdf5+hl', when='+hdf5')
-    depends_on('hypre~internal-superlu~int64', when='+hypre')
-    depends_on('kokkos-nvcc-wrapper', when='+wrapper')
-    depends_on('lapack')
+    depends_on("adios2", when="+adios2")
+    depends_on("blas")
+    depends_on("boost", when="+boost")
+    depends_on("cgns", when="+exodus")
+    depends_on("hdf5+hl", when="+hdf5")
+    depends_on("hypre~internal-superlu~int64", when="+hypre")
+    depends_on("kokkos-nvcc-wrapper", when="+wrapper")
+    depends_on("lapack")
     # depends_on('perl', type=('build',)) # TriBITS finds but doesn't use...
-    depends_on('libx11', when='+x11')
-    depends_on('matio', when='+exodus')
-    depends_on('metis', when='+zoltan')
-    depends_on('mpi', when='+mpi')
-    depends_on('netcdf-c', when="+exodus")
-    depends_on('parallel-netcdf', when='+exodus+mpi')
-    depends_on('parmetis', when='+mpi +zoltan')
-    depends_on('parmetis', when='+scorec')
-    depends_on('py-mpi4py', when='+mpi+python', type=('build', 'run'))
-    depends_on('py-numpy', when='+python', type=('build', 'run'))
-    depends_on('python', when='+python')
-    depends_on('python', when='@13.2: +ifpack +hypre', type='build')
-    depends_on('python', when='@13.2: +ifpack2 +hypre', type='build')
-    depends_on('scalapack', when='+mumps')
-    depends_on('scalapack', when='+strumpack+mpi')
-    depends_on('strumpack+shared', when='+strumpack')
-    depends_on('suite-sparse', when='+suite-sparse')
-    depends_on('superlu-dist', when='+superlu-dist')
-    depends_on('superlu@4.3 +pic', when='+superlu')
-    depends_on('swig', when='+python')
-    depends_on('zlib', when='+zoltan')
+    depends_on("libx11", when="+x11")
+    depends_on("matio", when="+exodus")
+    depends_on("metis", when="+zoltan")
+    depends_on("mpi", when="+mpi")
+    depends_on("netcdf-c", when="+exodus")
+    depends_on("parallel-netcdf", when="+exodus+mpi")
+    depends_on("parmetis", when="+mpi +zoltan")
+    depends_on("parmetis", when="+scorec")
+    depends_on("py-mpi4py", when="+mpi+python", type=("build", "run"))
+    depends_on("py-numpy", when="+python", type=("build", "run"))
+    depends_on("python", when="+python")
+    depends_on("python", when="@13.2: +ifpack +hypre", type="build")
+    depends_on("python", when="@13.2: +ifpack2 +hypre", type="build")
+    depends_on("scalapack", when="+mumps")
+    depends_on("scalapack", when="+strumpack+mpi")
+    depends_on("strumpack+shared", when="+strumpack")
+    depends_on("suite-sparse", when="+suite-sparse")
+    depends_on("superlu-dist", when="+superlu-dist")
+    depends_on("superlu@4.3 +pic", when="+superlu")
+    depends_on("swig", when="+python")
+    depends_on("zlib", when="+zoltan")
 
     # Trilinos' Tribits config system is limited which makes it very tricky to
     # link Amesos with static MUMPS, see
@@ -334,59 +377,61 @@ class Trilinos(CMakePackage, CudaPackage):
     # (or alike) and adding results to -DTrilinos_EXTRA_LINK_FLAGS together
     # with Blas and Lapack and ScaLAPACK and Blacs and -lgfortran and it may
     # work at the end. But let's avoid all this by simply using shared libs
-    depends_on('mumps@5.0:+shared', when='+mumps')
+    depends_on("mumps@5.0:+shared", when="+mumps")
 
-    for _flag in ('~mpi', '+mpi'):
-        depends_on('hdf5' + _flag, when='+hdf5' + _flag)
-        depends_on('mumps' + _flag, when='+mumps' + _flag)
-    for _flag in ('~openmp', '+openmp'):
-        depends_on('mumps' + _flag, when='+mumps' + _flag)
+    for _flag in ("~mpi", "+mpi"):
+        depends_on("hdf5" + _flag, when="+hdf5" + _flag)
+        depends_on("mumps" + _flag, when="+mumps" + _flag)
+    for _flag in ("~openmp", "+openmp"):
+        depends_on("mumps" + _flag, when="+mumps" + _flag)
 
-    depends_on('hwloc', when='@13: +kokkos')
-    depends_on('hwloc+cuda', when='@13: +kokkos+cuda')
-    depends_on('hypre@develop', when='@master: +hypre')
-    depends_on('netcdf-c+mpi+parallel-netcdf', when="+exodus+mpi@12.12.1:")
-    depends_on('superlu-dist@4.4:5.3', when='@12.6.2:12.12.1+superlu-dist')
-    depends_on('superlu-dist@5.4:6.2.0', when='@12.12.2:13.0.0+superlu-dist')
-    depends_on('superlu-dist@6.3.0:', when='@13.0.1:99 +superlu-dist')
-    depends_on('superlu-dist@:4.3', when='@11.14.1:12.6.1+superlu-dist')
-    depends_on('superlu-dist@develop', when='@master: +superlu-dist')
+    depends_on("hwloc", when="@13: +kokkos")
+    depends_on("hwloc+cuda", when="@13: +kokkos+cuda")
+    depends_on("hypre@develop", when="@master: +hypre")
+    depends_on("netcdf-c+mpi+parallel-netcdf", when="+exodus+mpi@12.12.1:")
+    depends_on("superlu-dist@4.4:5.3", when="@12.6.2:12.12.1+superlu-dist")
+    depends_on("superlu-dist@5.4:6.2.0", when="@12.12.2:13.0.0+superlu-dist")
+    depends_on("superlu-dist@6.3.0:", when="@13.0.1:99 +superlu-dist")
+    depends_on("superlu-dist@:4.3", when="@11.14.1:12.6.1+superlu-dist")
+    depends_on("superlu-dist@develop", when="@master: +superlu-dist")
 
     # ###################### Patches ##########################
 
-    patch('umfpack_from_suitesparse.patch', when='@11.14.1:12.8.1')
-    for _compiler in ['xl', 'xl_r', 'clang']:
-        patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %' + _compiler)
-        patch('xlf_tpetra.patch', when='@12.12.1 %' + _compiler)
-    patch('fix_clang_errors_12_18_1.patch', when='@12.18.1%clang')
-    patch('cray_secas_12_12_1.patch', when='@12.12.1%cce')
-    patch('cray_secas.patch', when='@12.14.1:%cce')
+    patch("umfpack_from_suitesparse.patch", when="@11.14.1:12.8.1")
+    for _compiler in ["xl", "xl_r", "clang"]:
+        patch("xlf_seacas.patch", when="@12.10.1:12.12.1 %" + _compiler)
+        patch("xlf_tpetra.patch", when="@12.12.1 %" + _compiler)
+    patch("fix_clang_errors_12_18_1.patch", when="@12.18.1%clang")
+    patch("cray_secas_12_12_1.patch", when="@12.12.1%cce")
+    patch("cray_secas.patch", when="@12.14.1:%cce")
 
     # workaround an NVCC bug with c++14 (https://github.com/trilinos/Trilinos/issues/6954)
     # avoid calling deprecated functions with CUDA-11
-    patch('fix_cxx14_cuda11.patch', when='@13.0.0:13.0.1 cxxstd=14 ^cuda@11:')
+    patch("fix_cxx14_cuda11.patch", when="@13.0.0:13.0.1 cxxstd=14 ^cuda@11:")
     # Allow building with +teko gotype=long
-    patch('https://github.com/trilinos/Trilinos/commit/b17f20a0b91e0b9fc5b1b0af3c8a34e2a4874f3f.patch',
-          sha256='dee6c55fe38eb7f6367e1896d6bc7483f6f9ab8fa252503050cc0c68c6340610',
-          when='@13.0.0:13.0.1 +teko gotype=long')
+    patch(
+        "https://github.com/trilinos/Trilinos/commit/b17f20a0b91e0b9fc5b1b0af3c8a34e2a4874f3f.patch",
+        sha256="dee6c55fe38eb7f6367e1896d6bc7483f6f9ab8fa252503050cc0c68c6340610",
+        when="@13.0.0:13.0.1 +teko gotype=long",
+    )
 
     def flag_handler(self, name, flags):
-        is_cce = self.spec.satisfies('%cce')
+        is_cce = self.spec.satisfies("%cce")
 
-        if name == 'cxxflags':
+        if name == "cxxflags":
             spec = self.spec
-            if '+mumps' in spec:
+            if "+mumps" in spec:
                 # see https://github.com/trilinos/Trilinos/blob/master/packages/amesos/README-MUMPS
-                flags.append('-DMUMPS_5_0')
-            if '+stk platform=darwin' in spec:
-                flags.append('-DSTK_NO_BOOST_STACKTRACE')
-            if '+stk%intel' in spec:
+                flags.append("-DMUMPS_5_0")
+            if "+stk platform=darwin" in spec:
+                flags.append("-DSTK_NO_BOOST_STACKTRACE")
+            if "+stk%intel" in spec:
                 # Workaround for Intel compiler segfaults with STK and IPO
-                flags.append('-no-ipo')
-            if '+wrapper' in spec:
-                flags.append('--expt-extended-lambda')
-        elif name == 'ldflags' and is_cce:
-            flags.append('-fuse-ld=gold')
+                flags.append("-no-ipo")
+            if "+wrapper" in spec:
+                flags.append("--expt-extended-lambda")
+        elif name == "ldflags" and is_cce:
+            flags.append("-fuse-ld=gold")
 
         if is_cce:
             return (None, None, flags)
@@ -397,27 +442,27 @@ class Trilinos(CMakePackage, CudaPackage):
         return url.format(version.dashed)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        if '+cuda' in self.spec:
+        if "+cuda" in self.spec:
             # currently Trilinos doesn't perform the memory fence so
             # it relies on blocking CUDA kernel launch. This is needed
             # in case the dependent app also run a CUDA backend via Trilinos
-            env.set('CUDA_LAUNCH_BLOCKING', '1')
+            env.set("CUDA_LAUNCH_BLOCKING", "1")
 
     def setup_dependent_package(self, module, dependent_spec):
-        if '+wrapper' in self.spec:
+        if "+wrapper" in self.spec:
             self.spec.kokkos_cxx = self.spec["kokkos-nvcc-wrapper"].kokkos_cxx
         else:
             self.spec.kokkos_cxx = spack_cxx
 
     def setup_build_environment(self, env):
         spec = self.spec
-        if '+cuda' in spec and '+wrapper' in spec:
-            if '+mpi' in spec:
-                env.set('OMPI_CXX', spec["kokkos-nvcc-wrapper"].kokkos_cxx)
-                env.set('MPICH_CXX', spec["kokkos-nvcc-wrapper"].kokkos_cxx)
-                env.set('MPICXX_CXX', spec["kokkos-nvcc-wrapper"].kokkos_cxx)
+        if "+cuda" in spec and "+wrapper" in spec:
+            if "+mpi" in spec:
+                env.set("OMPI_CXX", spec["kokkos-nvcc-wrapper"].kokkos_cxx)
+                env.set("MPICH_CXX", spec["kokkos-nvcc-wrapper"].kokkos_cxx)
+                env.set("MPICXX_CXX", spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             else:
-                env.set('CXX', spec["kokkos-nvcc-wrapper"].kokkos_cxx)
+                env.set("CXX", spec["kokkos-nvcc-wrapper"].kokkos_cxx)
 
     def cmake_args(self):
         options = []
@@ -436,6 +481,7 @@ class Trilinos(CMakePackage, CudaPackage):
                     # Explicit true/false
                     return define(key, value)
                 return define_from_variant(key, value)
+
             return define_enable
 
         # Return "Trilinos_ENABLE_XXX" for spec "+xxx" or boolean value
@@ -445,162 +491,179 @@ class Trilinos(CMakePackage, CudaPackage):
 
         # #################### Base Settings #######################
 
-        options.extend([
-            define('Trilinos_VERBOSE_CONFIGURE', False),
-            define_from_variant('BUILD_SHARED_LIBS', 'shared'),
-            define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'),
-            define_trilinos_enable('ALL_OPTIONAL_PACKAGES', False),
-            define_trilinos_enable('ALL_PACKAGES', False),
-            define_trilinos_enable('CXX11', True),
-            define_trilinos_enable('DEBUG', 'debug'),
-            define_trilinos_enable('EXAMPLES', False),
-            define_trilinos_enable('SECONDARY_TESTED_CODE', True),
-            define_trilinos_enable('TESTS', False),
-            define_trilinos_enable('Fortran'),
-            define_trilinos_enable('OpenMP'),
-            define_trilinos_enable('EXPLICIT_INSTANTIATION',
-                                   'explicit_template_instantiation')
-        ])
+        options.extend(
+            [
+                define("Trilinos_VERBOSE_CONFIGURE", False),
+                define_from_variant("BUILD_SHARED_LIBS", "shared"),
+                define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+                define_trilinos_enable("ALL_OPTIONAL_PACKAGES", False),
+                define_trilinos_enable("ALL_PACKAGES", False),
+                define_trilinos_enable("CXX11", True),
+                define_trilinos_enable("DEBUG", "debug"),
+                define_trilinos_enable("EXAMPLES", False),
+                define_trilinos_enable("SECONDARY_TESTED_CODE", True),
+                define_trilinos_enable("TESTS", False),
+                define_trilinos_enable("Fortran"),
+                define_trilinos_enable("OpenMP"),
+                define_trilinos_enable(
+                    "EXPLICIT_INSTANTIATION", "explicit_template_instantiation"
+                ),
+            ]
+        )
 
         # ################## Trilinos Packages #####################
 
-        options.extend([
-            define_trilinos_enable('Amesos'),
-            define_trilinos_enable('Amesos2'),
-            define_trilinos_enable('Anasazi'),
-            define_trilinos_enable('AztecOO', 'aztec'),
-            define_trilinos_enable('Belos'),
-            define_trilinos_enable('Epetra'),
-            define_trilinos_enable('EpetraExt'),
-            define_trilinos_enable('FEI', False),
-            define_trilinos_enable('Gtest'),
-            define_trilinos_enable('Ifpack'),
-            define_trilinos_enable('Ifpack2'),
-            define_trilinos_enable('Intrepid'),
-            define_trilinos_enable('Intrepid2'),
-            define_trilinos_enable('Isorropia'),
-            define_trilinos_enable('Kokkos'),
-            define_trilinos_enable('MiniTensor'),
-            define_trilinos_enable('Mesquite'),
-            define_trilinos_enable('ML'),
-            define_trilinos_enable('MueLu'),
-            define_trilinos_enable('NOX'),
-            define_trilinos_enable('Pamgen', False),
-            define_trilinos_enable('Panzer', False),
-            define_trilinos_enable('Pike', False),
-            define_trilinos_enable('Piro'),
-            define_trilinos_enable('Phalanx'),
-            define_trilinos_enable('PyTrilinos', 'python'),
-            define_trilinos_enable('ROL'),
-            define_trilinos_enable('Rythmos'),
-            define_trilinos_enable('Sacado'),
-            define_trilinos_enable('SCOREC'),
-            define_trilinos_enable('Shards'),
-            define_trilinos_enable('ShyLU'),
-            define_trilinos_enable('STK'),
-            define_trilinos_enable('Stokhos'),
-            define_trilinos_enable('Stratimikos'),
-            define_trilinos_enable('Teko'),
-            define_trilinos_enable('Tempus'),
-            define_trilinos_enable('Tpetra'),
-            define_trilinos_enable('TrilinosCouplings'),
-            define_trilinos_enable('Zoltan'),
-            define_trilinos_enable('Zoltan2'),
-            define_tpl_enable('Cholmod', False),
-            define_from_variant('EpetraExt_BUILD_BTF', 'epetraextbtf'),
-            define_from_variant('EpetraExt_BUILD_EXPERIMENTAL',
-                                'epetraextexperimental'),
-            define_from_variant('EpetraExt_BUILD_GRAPH_REORDERINGS',
-                                'epetraextgraphreorderings'),
-            define_from_variant('Amesos2_ENABLE_Basker', 'basker'),
-        ])
+        options.extend(
+            [
+                define_trilinos_enable("Amesos"),
+                define_trilinos_enable("Amesos2"),
+                define_trilinos_enable("Anasazi"),
+                define_trilinos_enable("AztecOO", "aztec"),
+                define_trilinos_enable("Belos"),
+                define_trilinos_enable("Epetra"),
+                define_trilinos_enable("EpetraExt"),
+                define_trilinos_enable("FEI", False),
+                define_trilinos_enable("Gtest"),
+                define_trilinos_enable("Ifpack"),
+                define_trilinos_enable("Ifpack2"),
+                define_trilinos_enable("Intrepid"),
+                define_trilinos_enable("Intrepid2"),
+                define_trilinos_enable("Isorropia"),
+                define_trilinos_enable("Kokkos"),
+                define_trilinos_enable("MiniTensor"),
+                define_trilinos_enable("Mesquite"),
+                define_trilinos_enable("ML"),
+                define_trilinos_enable("MueLu"),
+                define_trilinos_enable("NOX"),
+                define_trilinos_enable("Pamgen", False),
+                define_trilinos_enable("Panzer", False),
+                define_trilinos_enable("Pike", False),
+                define_trilinos_enable("Piro"),
+                define_trilinos_enable("Phalanx"),
+                define_trilinos_enable("PyTrilinos", "python"),
+                define_trilinos_enable("ROL"),
+                define_trilinos_enable("Rythmos"),
+                define_trilinos_enable("Sacado"),
+                define_trilinos_enable("SCOREC"),
+                define_trilinos_enable("Shards"),
+                define_trilinos_enable("ShyLU"),
+                define_trilinos_enable("STK"),
+                define_trilinos_enable("Stokhos"),
+                define_trilinos_enable("Stratimikos"),
+                define_trilinos_enable("Teko"),
+                define_trilinos_enable("Tempus"),
+                define_trilinos_enable("Tpetra"),
+                define_trilinos_enable("TrilinosCouplings"),
+                define_trilinos_enable("Zoltan"),
+                define_trilinos_enable("Zoltan2"),
+                define_tpl_enable("Cholmod", False),
+                define_from_variant("EpetraExt_BUILD_BTF", "epetraextbtf"),
+                define_from_variant("EpetraExt_BUILD_EXPERIMENTAL", "epetraextexperimental"),
+                define_from_variant(
+                    "EpetraExt_BUILD_GRAPH_REORDERINGS", "epetraextgraphreorderings"
+                ),
+                define_from_variant("Amesos2_ENABLE_Basker", "basker"),
+            ]
+        )
 
-        if '+dtk' in spec:
-            options.extend([
-                define('Trilinos_EXTRA_REPOSITORIES', 'DataTransferKit'),
-                define_trilinos_enable('DataTransferKit', True),
-            ])
+        if "+dtk" in spec:
+            options.extend(
+                [
+                    define("Trilinos_EXTRA_REPOSITORIES", "DataTransferKit"),
+                    define_trilinos_enable("DataTransferKit", True),
+                ]
+            )
 
-        if '+exodus' in spec:
-            options.extend([
-                define_trilinos_enable('SEACAS', True),
-                define_trilinos_enable('SEACASExodus', True),
-                define_trilinos_enable('SEACASIoss', True),
-                define_trilinos_enable('SEACASEpu', True),
-                define_trilinos_enable('SEACASExodiff', True),
-                define_trilinos_enable('SEACASNemspread', True),
-                define_trilinos_enable('SEACASNemslice', True),
-            ])
+        if "+exodus" in spec:
+            options.extend(
+                [
+                    define_trilinos_enable("SEACAS", True),
+                    define_trilinos_enable("SEACASExodus", True),
+                    define_trilinos_enable("SEACASIoss", True),
+                    define_trilinos_enable("SEACASEpu", True),
+                    define_trilinos_enable("SEACASExodiff", True),
+                    define_trilinos_enable("SEACASNemspread", True),
+                    define_trilinos_enable("SEACASNemslice", True),
+                ]
+            )
         else:
-            options.extend([
-                define_trilinos_enable('SEACASExodus', False),
-                define_trilinos_enable('SEACASIoss', False),
-            ])
+            options.extend(
+                [
+                    define_trilinos_enable("SEACASExodus", False),
+                    define_trilinos_enable("SEACASIoss", False),
+                ]
+            )
 
-        if '+chaco' in spec:
-            options.extend([
-                define_trilinos_enable('SEACAS', True),
-                define_trilinos_enable('SEACASChaco', True),
-            ])
+        if "+chaco" in spec:
+            options.extend(
+                [
+                    define_trilinos_enable("SEACAS", True),
+                    define_trilinos_enable("SEACASChaco", True),
+                ]
+            )
         else:
             # don't disable SEACAS, could be needed elsewhere
-            options.extend([
-                define_trilinos_enable('SEACASChaco', False),
-                define_trilinos_enable('SEACASNemslice', False)
-            ])
+            options.extend(
+                [
+                    define_trilinos_enable("SEACASChaco", False),
+                    define_trilinos_enable("SEACASNemslice", False),
+                ]
+            )
 
-        if '+stratimikos' in spec:
+        if "+stratimikos" in spec:
             # Explicitly enable Thyra (ThyraCore is required). If you don't do
             # this, then you get "NOT setting ${pkg}_ENABLE_Thyra=ON since
             # Thyra is NOT enabled at this point!" leading to eventual build
             # errors if using MueLu because `Xpetra_ENABLE_Thyra` is set to
             # off.
-            options.append(define_trilinos_enable('Thyra', True))
+            options.append(define_trilinos_enable("Thyra", True))
 
             # Add thyra adapters based on package enables
             options.extend(
-                define_trilinos_enable('Thyra' + pkg + 'Adapters', pkg.lower())
-                for pkg in ['Epetra', 'EpetraExt', 'Tpetra'])
+                define_trilinos_enable("Thyra" + pkg + "Adapters", pkg.lower())
+                for pkg in ["Epetra", "EpetraExt", "Tpetra"]
+            )
 
         # ######################### TPLs #############################
 
         def define_tpl(trilinos_name, spack_name, have_dep):
-            options.append(define('TPL_ENABLE_' + trilinos_name, have_dep))
+            options.append(define("TPL_ENABLE_" + trilinos_name, have_dep))
             if not have_dep:
                 return
             depspec = spec[spack_name]
             libs = depspec.libs
             try:
-                options.extend([
-                    define(trilinos_name + '_INCLUDE_DIRS',
-                           depspec.headers.directories),
-                ])
+                options.extend(
+                    [define(trilinos_name + "_INCLUDE_DIRS", depspec.headers.directories)]
+                )
             except NoHeadersError:
                 # Handle case were depspec does not have headers
                 pass
 
-            options.extend([
-                define(trilinos_name + '_ROOT', depspec.prefix),
-                define(trilinos_name + '_LIBRARY_NAMES', libs.names),
-                define(trilinos_name + '_LIBRARY_DIRS', libs.directories),
-            ])
+            options.extend(
+                [
+                    define(trilinos_name + "_ROOT", depspec.prefix),
+                    define(trilinos_name + "_LIBRARY_NAMES", libs.names),
+                    define(trilinos_name + "_LIBRARY_DIRS", libs.directories),
+                ]
+            )
 
         # Enable these TPLs explicitly from variant options.
         # Format is (TPL name, variant name, Spack spec name)
         tpl_variant_map = [
-            ('ADIOS2', 'adios2', 'adios2'),
-            ('Boost', 'boost', 'boost'),
-            ('CUDA', 'cuda', 'cuda'),
-            ('HDF5', 'hdf5', 'hdf5'),
-            ('HYPRE', 'hypre', 'hypre'),
-            ('MUMPS', 'mumps', 'mumps'),
-            ('UMFPACK', 'suite-sparse', 'suite-sparse'),
-            ('SuperLU', 'superlu', 'superlu'),
-            ('SuperLUDist', 'superlu-dist', 'superlu-dist'),
-            ('X11', 'x11', 'libx11'),
+            ("ADIOS2", "adios2", "adios2"),
+            ("Boost", "boost", "boost"),
+            ("CUDA", "cuda", "cuda"),
+            ("HDF5", "hdf5", "hdf5"),
+            ("HYPRE", "hypre", "hypre"),
+            ("MUMPS", "mumps", "mumps"),
+            ("UMFPACK", "suite-sparse", "suite-sparse"),
+            ("SuperLU", "superlu", "superlu"),
+            ("SuperLUDist", "superlu-dist", "superlu-dist"),
+            ("X11", "x11", "libx11"),
         ]
-        if spec.satisfies('@13.0.2:'):
-            tpl_variant_map.append(('STRUMPACK', 'strumpack', 'strumpack'))
+        if spec.satisfies("@13.0.2:"):
+            tpl_variant_map.append(("STRUMPACK", "strumpack", "strumpack"))
 
         for tpl_name, var_name, spec_name in tpl_variant_map:
             define_tpl(tpl_name, spec_name, spec.variants[var_name].value)
@@ -608,154 +671,164 @@ class Trilinos(CMakePackage, CudaPackage):
         # Enable these TPLs based on whether they're in our spec; prefer to
         # require this way so that packages/features disable availability
         tpl_dep_map = [
-            ('BLAS', 'blas'),
-            ('CGNS', 'cgns'),
-            ('LAPACK', 'lapack'),
-            ('Matio', 'matio'),
-            ('METIS', 'metis'),
-            ('Netcdf', 'netcdf-c'),
-            ('SCALAPACK', 'scalapack'),
-            ('Zlib', 'zlib'),
+            ("BLAS", "blas"),
+            ("CGNS", "cgns"),
+            ("LAPACK", "lapack"),
+            ("Matio", "matio"),
+            ("METIS", "metis"),
+            ("Netcdf", "netcdf-c"),
+            ("SCALAPACK", "scalapack"),
+            ("Zlib", "zlib"),
         ]
-        if spec.satisfies('@12.12.1:'):
-            tpl_dep_map.append(('Pnetcdf', 'parallel-netcdf'))
-        if spec.satisfies('@13:'):
-            tpl_dep_map.append(('HWLOC', 'hwloc'))
+        if spec.satisfies("@12.12.1:"):
+            tpl_dep_map.append(("Pnetcdf", "parallel-netcdf"))
+        if spec.satisfies("@13:"):
+            tpl_dep_map.append(("HWLOC", "hwloc"))
 
         for tpl_name, dep_name in tpl_dep_map:
             define_tpl(tpl_name, dep_name, dep_name in spec)
 
         # MPI settings
-        options.append(define_tpl_enable('MPI'))
-        if '+mpi' in spec:
+        options.append(define_tpl_enable("MPI"))
+        if "+mpi" in spec:
             # Force Trilinos to use the MPI wrappers instead of raw compilers
             # to propagate library link flags for linkers that require fully
             # resolved symbols in shared libs (such as macOS and some newer
             # Ubuntu)
-            options.extend([
-                define('CMAKE_C_COMPILER', spec['mpi'].mpicc),
-                define('CMAKE_CXX_COMPILER', spec['mpi'].mpicxx),
-                define('CMAKE_Fortran_COMPILER', spec['mpi'].mpifc),
-                define('MPI_BASE_DIR', spec['mpi'].prefix),
-            ])
+            options.extend(
+                [
+                    define("CMAKE_C_COMPILER", spec["mpi"].mpicc),
+                    define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx),
+                    define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc),
+                    define("MPI_BASE_DIR", spec["mpi"].prefix),
+                ]
+            )
 
         # ParMETIS dependencies have to be transitive explicitly
-        have_parmetis = 'parmetis' in spec
-        options.append(define_tpl_enable('ParMETIS', have_parmetis))
+        have_parmetis = "parmetis" in spec
+        options.append(define_tpl_enable("ParMETIS", have_parmetis))
         if have_parmetis:
-            options.extend([
-                define('ParMETIS_LIBRARY_DIRS', [
-                    spec['parmetis'].prefix.lib, spec['metis'].prefix.lib
-                ]),
-                define('ParMETIS_LIBRARY_NAMES', ['parmetis', 'metis']),
-                define('TPL_ParMETIS_INCLUDE_DIRS',
-                       spec['parmetis'].headers.directories +
-                       spec['metis'].headers.directories),
-            ])
+            options.extend(
+                [
+                    define(
+                        "ParMETIS_LIBRARY_DIRS",
+                        [spec["parmetis"].prefix.lib, spec["metis"].prefix.lib],
+                    ),
+                    define("ParMETIS_LIBRARY_NAMES", ["parmetis", "metis"]),
+                    define(
+                        "TPL_ParMETIS_INCLUDE_DIRS",
+                        spec["parmetis"].headers.directories + spec["metis"].headers.directories,
+                    ),
+                ]
+            )
 
-        if spec.satisfies('^superlu-dist@4.0:'):
-            options.extend([
-                define('HAVE_SUPERLUDIST_LUSTRUCTINIT_2ARG', True),
-            ])
+        if spec.satisfies("^superlu-dist@4.0:"):
+            options.extend([define("HAVE_SUPERLUDIST_LUSTRUCTINIT_2ARG", True)])
 
-        if spec.satisfies('^parallel-netcdf'):
-            options.extend([
-                define('TPL_Netcdf_Enables_Netcdf4', True),
-                define('TPL_Netcdf_PARALLEL', True),
-                define('PNetCDF_ROOT', spec['parallel-netcdf'].prefix),
-            ])
+        if spec.satisfies("^parallel-netcdf"):
+            options.extend(
+                [
+                    define("TPL_Netcdf_Enables_Netcdf4", True),
+                    define("TPL_Netcdf_PARALLEL", True),
+                    define("PNetCDF_ROOT", spec["parallel-netcdf"].prefix),
+                ]
+            )
 
         # ################# Explicit template instantiation #################
 
-        complex_s = spec.variants['complex'].value
-        float_s = spec.variants['float'].value
+        complex_s = spec.variants["complex"].value
+        float_s = spec.variants["float"].value
 
-        options.extend([
-            define('Teuchos_ENABLE_COMPLEX', complex_s),
-            define('Teuchos_ENABLE_FLOAT', float_s),
-        ])
+        options.extend(
+            [define("Teuchos_ENABLE_COMPLEX", complex_s), define("Teuchos_ENABLE_FLOAT", float_s)]
+        )
 
-        if '+tpetra +explicit_template_instantiation' in spec:
-            options.append(define_from_variant('Tpetra_INST_OPENMP', 'openmp'))
-            options.extend([
-                define('Tpetra_INST_DOUBLE', True),
-                define('Tpetra_INST_COMPLEX_DOUBLE', complex_s),
-                define('Tpetra_INST_COMPLEX_FLOAT', float_s and complex_s),
-                define('Tpetra_INST_FLOAT', float_s),
-                define('Tpetra_INST_SERIAL', True),
-            ])
+        if "+tpetra +explicit_template_instantiation" in spec:
+            options.append(define_from_variant("Tpetra_INST_OPENMP", "openmp"))
+            options.extend(
+                [
+                    define("Tpetra_INST_DOUBLE", True),
+                    define("Tpetra_INST_COMPLEX_DOUBLE", complex_s),
+                    define("Tpetra_INST_COMPLEX_FLOAT", float_s and complex_s),
+                    define("Tpetra_INST_FLOAT", float_s),
+                    define("Tpetra_INST_SERIAL", True),
+                ]
+            )
 
-            gotype = spec.variants['gotype'].value
-            if gotype == 'all':
+            gotype = spec.variants["gotype"].value
+            if gotype == "all":
                 # default in older Trilinos versions to enable multiple GOs
-                options.extend([
-                    define('Tpetra_INST_INT_INT', True),
-                    define('Tpetra_INST_INT_LONG', True),
-                    define('Tpetra_INST_INT_LONG_LONG', True),
-                ])
+                options.extend(
+                    [
+                        define("Tpetra_INST_INT_INT", True),
+                        define("Tpetra_INST_INT_LONG", True),
+                        define("Tpetra_INST_INT_LONG_LONG", True),
+                    ]
+                )
             else:
-                options.extend([
-                    define('Tpetra_INST_INT_INT', gotype == 'int'),
-                    define('Tpetra_INST_INT_LONG', gotype == 'long'),
-                    define('Tpetra_INST_INT_LONG_LONG', gotype == 'long_long'),
-                ])
+                options.extend(
+                    [
+                        define("Tpetra_INST_INT_INT", gotype == "int"),
+                        define("Tpetra_INST_INT_LONG", gotype == "long"),
+                        define("Tpetra_INST_INT_LONG_LONG", gotype == "long_long"),
+                    ]
+                )
 
         # ################# Kokkos ######################
 
-        if '+kokkos' in spec:
+        if "+kokkos" in spec:
             arch = Kokkos.get_microarch(spec.target)
             if arch:
                 options.append(define("Kokkos_ARCH_" + arch.upper(), True))
 
             define_kok_enable = _make_definer("Kokkos_ENABLE_")
-            options.extend([
-                define_kok_enable('CUDA'),
-                define_kok_enable('OPENMP' if spec.version >= Version('13')
-                                  else 'OpenMP'),
-            ])
-            if '+cuda' in spec:
-                options.extend([
-                    define_kok_enable('CUDA_UVM', True),
-                    define_kok_enable('CUDA_LAMBDA', True),
-                    define_kok_enable('CUDA_RELOCATABLE_DEVICE_CODE', 'cuda_rdc')
-                ])
+            options.extend(
+                [
+                    define_kok_enable("CUDA"),
+                    define_kok_enable("OPENMP" if spec.version >= Version("13") else "OpenMP"),
+                ]
+            )
+            if "+cuda" in spec:
+                options.extend(
+                    [
+                        define_kok_enable("CUDA_UVM", True),
+                        define_kok_enable("CUDA_LAMBDA", True),
+                        define_kok_enable("CUDA_RELOCATABLE_DEVICE_CODE", "cuda_rdc"),
+                    ]
+                )
                 arch_map = Kokkos.spack_cuda_arch_map
                 options.extend(
                     define("Kokkos_ARCH_" + arch_map[arch].upper(), True)
-                    for arch in spec.variants['cuda_arch'].value
+                    for arch in spec.variants["cuda_arch"].value
                 )
 
         # ################# System-specific ######################
 
         # Fortran lib (assumes clang is built with gfortran!)
-        if ('+fortran' in spec
-                and spec.compiler.name in ['gcc', 'clang', 'apple-clang']):
-            fc = Executable(spec['mpi'].mpifc) if (
-                '+mpi' in spec) else Executable(spack_fc)
-            libgfortran = fc('--print-file-name',
-                             'libgfortran.' + dso_suffix,
-                             output=str).strip()
+        if "+fortran" in spec and spec.compiler.name in ["gcc", "clang", "apple-clang"]:
+            fc = Executable(spec["mpi"].mpifc) if ("+mpi" in spec) else Executable(spack_fc)
+            libgfortran = fc("--print-file-name", "libgfortran." + dso_suffix, output=str).strip()
             # if libgfortran is equal to "libgfortran.<dso_suffix>" then
             # print-file-name failed, use static library instead
-            if libgfortran == 'libgfortran.' + dso_suffix:
-                libgfortran = fc('--print-file-name',
-                                 'libgfortran.a',
-                                 output=str).strip()
+            if libgfortran == "libgfortran." + dso_suffix:
+                libgfortran = fc("--print-file-name", "libgfortran.a", output=str).strip()
             # -L<libdir> -lgfortran required for OSX
             # https://github.com/spack/spack/pull/25823#issuecomment-917231118
             options.append(
-                define('Trilinos_EXTRA_LINK_FLAGS',
-                       '-L%s/ -lgfortran' % os.path.dirname(libgfortran)))
+                define(
+                    "Trilinos_EXTRA_LINK_FLAGS", "-L%s/ -lgfortran" % os.path.dirname(libgfortran)
+                )
+            )
 
-        if sys.platform == 'darwin' and macos_version() >= Version('10.12'):
+        if sys.platform == "darwin" and macos_version() >= Version("10.12"):
             # use @rpath on Sierra due to limit of dynamic loader
-            options.append(define('CMAKE_MACOSX_RPATH', True))
+            options.append(define("CMAKE_MACOSX_RPATH", True))
         else:
-            options.append(define('CMAKE_INSTALL_NAME_DIR', self.prefix.lib))
+            options.append(define("CMAKE_INSTALL_NAME_DIR", self.prefix.lib))
 
         return options
 
-    @run_after('install')
+    @run_after("install")
     def filter_python(self):
         # When trilinos is built with Python, libpytrilinos is included
         # through cmake configure files. Namely, Trilinos_LIBRARIES in
@@ -767,20 +840,19 @@ class Trilinos(CMakePackage, CudaPackage):
         # https://github.com/trilinos/Trilinos/issues/866
         # A workaround is to remove PyTrilinos from the COMPONENTS_LIST
         # and to remove -lpytrilonos from Makefile.export.Trilinos
-        if '+python' in self.spec:
-            filter_file(r'(SET\(COMPONENTS_LIST.*)(PyTrilinos;)(.*)',
-                        (r'\1\3'),
-                        '%s/cmake/Trilinos/TrilinosConfig.cmake' %
-                        self.prefix.lib)
-            filter_file(r'-lpytrilinos', '',
-                        '%s/Makefile.export.Trilinos' %
-                        self.prefix.include)
+        if "+python" in self.spec:
+            filter_file(
+                r"(SET\(COMPONENTS_LIST.*)(PyTrilinos;)(.*)",
+                (r"\1\3"),
+                "%s/cmake/Trilinos/TrilinosConfig.cmake" % self.prefix.lib,
+            )
+            filter_file(r"-lpytrilinos", "", "%s/Makefile.export.Trilinos" % self.prefix.include)
 
     def setup_run_environment(self, env):
-        if '+exodus' in self.spec:
-            env.prepend_path('PYTHONPATH', self.prefix.lib)
+        if "+exodus" in self.spec:
+            env.prepend_path("PYTHONPATH", self.prefix.lib)
 
-        if '+cuda' in self.spec:
+        if "+cuda" in self.spec:
             # currently Trilinos doesn't perform the memory fence so
             # it relies on blocking CUDA kernel launch.
-            env.set('CUDA_LAUNCH_BLOCKING', '1')
+            env.set("CUDA_LAUNCH_BLOCKING", "1")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -23,7 +23,7 @@ from spack.parser import (
 
 FAIL_ON_WINDOWS = pytest.mark.xfail(
     sys.platform == "win32",
-    raises=(SpecTokenizationError, spack.spec.NoSuchHashError),
+    raises=(SpecTokenizationError, spack.spec.InvalidHashError),
     reason="Unix style path on Windows",
 )
 
@@ -631,21 +631,34 @@ def test_spec_by_hash_tokens(text, tokens):
 
 
 @pytest.mark.db
-def test_spec_by_hash(database):
+def test_spec_by_hash(database, monkeypatch, config):
     mpileaks = database.query_one("mpileaks ^zmpi")
+    b = spack.spec.Spec("b").concretized()
+    monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [b])
 
     hash_str = f"/{mpileaks.dag_hash()}"
-    assert str(SpecParser(hash_str).next_spec()) == str(mpileaks)
+    parsed_spec = SpecParser(hash_str).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == mpileaks
 
     short_hash_str = f"/{mpileaks.dag_hash()[:5]}"
-    assert str(SpecParser(short_hash_str).next_spec()) == str(mpileaks)
+    parsed_spec = SpecParser(short_hash_str).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == mpileaks
 
     name_version_and_hash = f"{mpileaks.name}@{mpileaks.version} /{mpileaks.dag_hash()[:5]}"
-    assert str(SpecParser(name_version_and_hash).next_spec()) == str(mpileaks)
+    parsed_spec = SpecParser(name_version_and_hash).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == mpileaks
+
+    b_hash = f"/{b.dag_hash()}"
+    parsed_spec = SpecParser(b_hash).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == b
 
 
 @pytest.mark.db
-def test_dep_spec_by_hash(database):
+def test_dep_spec_by_hash(database, config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     zmpi = database.query_one("zmpi")
     fake = database.query_one("fake")
@@ -653,26 +666,25 @@ def test_dep_spec_by_hash(database):
     assert "fake" in mpileaks_zmpi
     assert "zmpi" in mpileaks_zmpi
 
-    mpileaks_hash_fake = SpecParser(f"mpileaks ^/{fake.dag_hash()}").next_spec()
+    mpileaks_hash_fake = SpecParser(f"mpileaks ^/{fake.dag_hash()} ^zmpi").next_spec()
+    mpileaks_hash_fake.replace_hash()
     assert "fake" in mpileaks_hash_fake
     assert mpileaks_hash_fake["fake"] == fake
+    assert "zmpi" in mpileaks_hash_fake
+    assert mpileaks_hash_fake["zmpi"] == spack.spec.Spec("zmpi")
 
     mpileaks_hash_zmpi = SpecParser(
         f"mpileaks %{mpileaks_zmpi.compiler} ^ /{zmpi.dag_hash()}"
     ).next_spec()
+    mpileaks_hash_zmpi.replace_hash()
     assert "zmpi" in mpileaks_hash_zmpi
     assert mpileaks_hash_zmpi["zmpi"] == zmpi
-
-    # notice: the round-trip str -> Spec loses specificity when
-    # since %gcc@=x gets printed as %gcc@x. So stick to satisfies
-    # here, unless/until we want to differentiate between ranges
-    # and specific versions in the future.
-    # assert mpileaks_hash_zmpi.compiler == mpileaks_zmpi.compiler
     assert mpileaks_zmpi.compiler.satisfies(mpileaks_hash_zmpi.compiler)
 
     mpileaks_hash_fake_and_zmpi = SpecParser(
         f"mpileaks ^/{fake.dag_hash()[:4]} ^ /{zmpi.dag_hash()[:5]}"
     ).next_spec()
+    mpileaks_hash_fake_and_zmpi.replace_hash()
     assert "zmpi" in mpileaks_hash_fake_and_zmpi
     assert mpileaks_hash_fake_and_zmpi["zmpi"] == zmpi
 
@@ -681,7 +693,7 @@ def test_dep_spec_by_hash(database):
 
 
 @pytest.mark.db
-def test_multiple_specs_with_hash(database):
+def test_multiple_specs_with_hash(database, config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     callpath_mpich2 = database.query_one("callpath ^mpich2")
 
@@ -713,7 +725,7 @@ def test_multiple_specs_with_hash(database):
 
 
 @pytest.mark.db
-def test_ambiguous_hash(mutable_database, default_mock_concretization):
+def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
     x1 = default_mock_concretization("a")
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
@@ -723,31 +735,43 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization):
 
     # ambiguity in first hash character
     with pytest.raises(spack.spec.AmbiguousHashError):
-        SpecParser("/x").next_spec()
+        parsed_spec = SpecParser("/x").next_spec()
+        parsed_spec.replace_hash()
 
     # ambiguity in first hash character AND spec name
     with pytest.raises(spack.spec.AmbiguousHashError):
-        SpecParser("a/x").next_spec()
+        parsed_spec = SpecParser("a/x").next_spec()
+        parsed_spec.replace_hash()
 
 
 @pytest.mark.db
-def test_invalid_hash(database):
+def test_invalid_hash(database, config):
     zmpi = database.query_one("zmpi")
     mpich = database.query_one("mpich")
 
     # name + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
-        SpecParser(f"zmpi /{mpich.dag_hash()}").next_spec()
+        parsed_spec = SpecParser(f"zmpi /{mpich.dag_hash()}").next_spec()
+        parsed_spec.replace_hash()
     with pytest.raises(spack.spec.InvalidHashError):
-        SpecParser(f"mpich /{zmpi.dag_hash()}").next_spec()
+        parsed_spec = SpecParser(f"mpich /{zmpi.dag_hash()}").next_spec()
+        parsed_spec.replace_hash()
 
     # name + dep + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
-        SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
+        parsed_spec = SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
+        parsed_spec.replace_hash()
+
+
+def test_invalid_hash_dep(database, config):
+    mpich = database.query_one("mpich")
+    hash = mpich.dag_hash()
+    with pytest.raises(spack.spec.InvalidHashError):
+        spack.spec.Spec(f"callpath ^zlib/{hash}").replace_hash()
 
 
 @pytest.mark.db
-def test_nonexistent_hash(database):
+def test_nonexistent_hash(database, config):
     """Ensure we get errors for non existent hashes."""
     specs = database.query()
 
@@ -756,26 +780,40 @@ def test_nonexistent_hash(database):
     hashes = [s._hash for s in specs]
     assert no_such_hash not in [h[: len(no_such_hash)] for h in hashes]
 
-    with pytest.raises(spack.spec.NoSuchHashError):
-        SpecParser(f"/{no_such_hash}").next_spec()
+    with pytest.raises(spack.spec.InvalidHashError):
+        parsed_spec = SpecParser(f"/{no_such_hash}").next_spec()
+        parsed_spec.replace_hash()
 
 
-@pytest.mark.db
 @pytest.mark.parametrize(
-    "query_str,text_fmt",
+    "spec1,spec2,constraint",
     [
-        ("mpileaks ^zmpi", r"/{hash}%{0.compiler}"),
-        ("callpath ^zmpi", r"callpath /{hash} ^libelf"),
-        ("dyninst", r'/{hash} cflags="-O3 -fPIC"'),
-        ("mpileaks ^mpich2", r"mpileaks/{hash} @{0.version}"),
+        ("zlib", "hdf5", None),
+        ("zlib+shared", "zlib~shared", "+shared"),
+        ("hdf5+mpi^zmpi", "hdf5~mpi", "^zmpi"),
+        ("hdf5+mpi^mpich+debug", "hdf5+mpi^mpich~debug", "^mpich+debug"),
     ],
 )
-def test_redundant_spec(query_str, text_fmt, database):
-    """Check that redundant spec constraints raise errors."""
-    spec = database.query_one(query_str)
-    text = text_fmt.format(spec, hash=spec.dag_hash())
-    with pytest.raises(spack.spec.RedundantSpecError):
-        SpecParser(text).next_spec()
+def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monkeypatch, config):
+    spec1_concrete = spack.spec.Spec(spec1).concretized()
+    spec2_concrete = spack.spec.Spec(spec2).concretized()
+
+    spec1_concrete._hash = "spec1"
+    spec2_concrete._hash = "spec2"
+
+    monkeypatch.setattr(
+        spack.binary_distribution,
+        "update_cache_and_get_specs",
+        lambda: [spec1_concrete, spec2_concrete],
+    )
+
+    # Ordering is tricky -- for constraints we want after, for names we want before
+    if not constraint:
+        spec = spack.spec.Spec(spec1 + "/spec")
+    else:
+        spec = spack.spec.Spec("/spec" + constraint)
+
+    assert spec.lookup_hash() == spec1_concrete
 
 
 @pytest.mark.parametrize(
@@ -858,11 +896,13 @@ def test_error_conditions(text, exc_cls):
             "libfoo ^./libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS
         ),
         pytest.param(
-            "/bogus/path/libdwarf.yamlfoobar", spack.spec.SpecFilenameError, marks=FAIL_ON_WINDOWS
+            "/bogus/path/libdwarf.yamlfoobar",
+            spack.spec.NoSuchSpecFileError,
+            marks=FAIL_ON_WINDOWS,
         ),
         pytest.param(
             "libdwarf^/bogus/path/libelf.yamlfoobar ^/path/to/bogus.yaml",
-            spack.spec.SpecFilenameError,
+            spack.spec.NoSuchSpecFileError,
             marks=FAIL_ON_WINDOWS,
         ),
         pytest.param(
@@ -895,7 +935,7 @@ def test_error_conditions(text, exc_cls):
 )
 def test_specfile_error_conditions_windows(text, exc_cls):
     with pytest.raises(exc_cls):
-        SpecParser(text).next_spec()
+        SpecParser(text).all_specs()
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -18,7 +18,7 @@ EdgeAndDepth = namedtuple("EdgeAndDepth", ["edge", "depth"])
 
 
 def sort_edges(edges):
-    edges.sort(key=lambda edge: edge.spec.name)
+    edges.sort(key=lambda edge: (edge.spec.name or "", edge.spec.abstract_hash or ""))
     return edges
 
 

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -14,6 +14,26 @@ default:
     SPACK_TARGET_PLATFORM: "linux"
     SPACK_TARGET_ARCH: "x86_64_v3"
 
+.linux_skylake:
+  variables:
+    SPACK_TARGET_PLATFORM: "linux"
+    SPACK_TARGET_ARCH: "skylake_avx512"
+
+.linux_icelake:
+  variables:
+    SPACK_TARGET_PLATFORM: "linux"
+    SPACK_TARGET_ARCH: "icelake"
+
+.linux_neoverse_n1:
+  variables:
+    SPACK_TARGET_PLATFORM: "linux"
+    SPACK_TARGET_ARCH: "neoverse_n1"
+
+.linux_neoverse_v1:
+  variables:
+    SPACK_TARGET_PLATFORM: "linux"
+    SPACK_TARGET_ARCH: "neoverse_v1"
+
 .linux_aarch64:
   variables:
     SPACK_TARGET_PLATFORM: "linux"
@@ -762,3 +782,103 @@ deprecated-ci-build:
   needs:
     - artifacts: True
       job: deprecated-ci-generate
+
+########################################
+# AWS PCLUSTER
+########################################
+
+.aws-pcluster-generate-image:
+  image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:latest", "entrypoint": [""] }
+
+.aws-pcluster-generate:
+  before_script:
+      # Setup postinstall Spack as upstream installation
+    - - . "./share/spack/setup-env.sh"
+      - . /etc/profile.d/modules.sh
+      - if [[ -f /bootstrap/spack/etc/spack/packages.yaml ]]; then cp /bootstrap/spack/etc/spack/packages.yaml ./etc/spack/; fi
+      - if [[ -f /bootstrap/spack/etc/spack/config.yaml ]]; then cp /bootstrap/spack/etc/spack/config.yaml ./etc/spack/; fi
+      - if [[ -f /bootstrap/spack/etc/spack/modules.xyaml ]]; then cp /bootstrap/spack/etc/spack/modules.yaml ./etc/spack/; fi
+      - if [[ -f /bootstrap/spack/etc/spack/mirrors.yaml ]]; then cp /bootstrap/spack/etc/spack/mirrors.yaml ./etc/spack/; fi
+      - if [[ -d /bootstrap/spack/opt/spack ]]; then spack config add "upstreams:postinstall:install_tree:/bootstrap/spack/opt/spack"; fi
+      - cd "${CI_PROJECT_DIR}" && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh
+      - sed -i -e '/nohup/s/&$//' -e 's/nohup//' -e "s/spack arch -t/echo ${SPACK_TARGET_ARCH}/g" postinstall.sh
+      - /bin/bash postinstall.sh -fg
+      - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
+  after_script:
+    - - mv "${CI_PROJECT_DIR}/postinstall.sh" "${CI_PROJECT_DIR}/jobs_scratch_dir/"
+
+# Icelake (one pipeline per target)
+.aws-pcluster-icelake:
+  variables:
+    SPACK_CI_STACK_NAME: aws-pcluster-icelake
+
+aws-pcluster-generate-icelake:
+  extends: [ ".linux_icelake", ".aws-pcluster-icelake", ".generate", ".tags-x86_64_v4", ".aws-pcluster-generate", ".aws-pcluster-generate-image" ]
+
+aws-pcluster-build-icelake:
+  extends: [ ".linux_icelake", ".aws-pcluster-icelake", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: aws-pcluster-generate-icelake
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: aws-pcluster-generate-icelake
+
+# Skylake_avx512 (one pipeline per target)
+.aws-pcluster-skylake:
+  variables:
+    SPACK_CI_STACK_NAME: aws-pcluster-skylake
+
+aws-pcluster-generate-skylake:
+  extends: [ ".linux_skylake", ".aws-pcluster-skylake", ".generate", ".tags-x86_64_v4", ".aws-pcluster-generate", ".aws-pcluster-generate-image" ]
+
+aws-pcluster-build-skylake:
+  extends: [ ".linux_skylake", ".aws-pcluster-skylake", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: aws-pcluster-generate-skylake
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: aws-pcluster-generate-skylake
+
+# Neoverse_n1 (one pipeline per target)
+.aws-pcluster-neoverse_n1:
+  variables:
+    SPACK_CI_STACK_NAME: aws-pcluster-neoverse_n1
+
+aws-pcluster-generate-neoverse_n1:
+  extends: [ ".linux_neoverse_n1", ".aws-pcluster-neoverse_n1", ".generate-aarch64", ".aws-pcluster-generate", ".aws-pcluster-generate-image" ]
+
+aws-pcluster-build-neoverse_n1:
+  extends: [  ".linux_neoverse_n1", ".aws-pcluster-neoverse_n1", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: aws-pcluster-generate-neoverse_n1
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: aws-pcluster-generate-neoverse_n1
+
+# Neoverse_v1 (one pipeline per target)
+.aws-pcluster-neoverse_v1:
+  variables:
+    SPACK_CI_STACK_NAME: aws-pcluster-neoverse_v1
+
+aws-pcluster-generate-neoverse_v1:
+  extends: [ ".linux_neoverse_v1", ".aws-pcluster-neoverse_v1", ".generate-aarch64", ".aws-pcluster-generate", ".aws-pcluster-generate-image" ]
+
+aws-pcluster-build-neoverse_v1:
+  extends: [  ".linux_neoverse_v1", ".aws-pcluster-neoverse_v1", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: aws-pcluster-generate-neoverse_v1
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: aws-pcluster-generate-neoverse_v1

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -27,41 +27,47 @@ default:
 ########################################
 # Job templates
 ########################################
-
-.aws-pr-creds:
-  variables:
-    AWS_ACCESS_KEY_ID: ${PR_MIRRORS_AWS_ACCESS_KEY_ID}
-    AWS_SECRET_ACCESS_KEY: ${PR_MIRRORS_AWS_SECRET_ACCESS_KEY}
-
-.aws-protected-creds:
-  variables:
-    AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
-    AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
-
-.pr-refs:
-  only:
-  - /^pr[\d]+_.*$/
-
-.pr:
-  extends: [ ".pr-refs" ]
-  variables:
-    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
-    SPACK_PIPELINE_TYPE: "spack_pull_request"
-    SPACK_PRUNE_UNTOUCHED: "True"
-    SPACK_PRUNE_UNTOUCHED_DEPENDENT_DEPTH: "1"
-
-.protected-refs:
-  only:
-  - /^develop$/
-  - /^releases\/v.*/
-  - /^v.*/
-
-.protected:
-  extends: [ ".protected-refs" ]
+.base-job:
   variables:
     SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
-    SPACK_COPY_BUILDCACHE: "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
-    SPACK_PIPELINE_TYPE: "spack_protected_branch"
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "develop"
+      # Pipelines on develop only rebuild what is missing from the mirror
+      when: always
+      variables:
+        SPACK_PIPELINE_TYPE: "spack_protected_branch"
+        SPACK_COPY_BUILDCACHE: "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+        AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
+    - if: $CI_COMMIT_REF_NAME =~ /^releases\/v.*/
+      # Pipelines on release branches always rebuild everything
+      when: always
+      variables:
+        SPACK_PIPELINE_TYPE: "spack_protected_branch"
+        SPACK_COPY_BUILDCACHE: "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+        SPACK_PRUNE_UNTOUCHED: "False"
+        SPACK_PRUNE_UP_TO_DATE: "False"
+        AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
+    - if: $CI_COMMIT_TAG =~ /^develop-[\d]{4}-[\d]{2}-[\d]{2}$/ || $CI_COMMIT_TAG =~ /^v.*/
+      # Pipelines on tags (release or dev snapshots) only copy binaries from one mirror to another
+      when: always
+      variables:
+        SPACK_PIPELINE_TYPE: "spack_copy_only"
+        SPACK_SOURCE_MIRROR: "s3://spack-binaries/SPACK_REPLACE_VERSION/${SPACK_CI_STACK_NAME}"
+        SPACK_COPY_BUILDCACHE: "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+        AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
+    - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/
+      # Pipelines on PR branches rebuild only what's missing, and do extra pruning
+      when: always
+      variables:
+        SPACK_PIPELINE_TYPE: "spack_pull_request"
+        SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
+        SPACK_PRUNE_UNTOUCHED: "True"
+        SPACK_PRUNE_UNTOUCHED_DEPENDENT_DEPTH: "1"
+        AWS_ACCESS_KEY_ID: ${PR_MIRRORS_AWS_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY: ${PR_MIRRORS_AWS_SECRET_ACCESS_KEY}
 
 .generate-base:
   stage: generate
@@ -99,10 +105,11 @@ default:
       - always
 
 .generate:
-  extends: [ ".generate-base" ]
+  extends: [ ".base-job", ".generate-base" ]
   tags: ["spack", "public", "medium", "x86_64"]
 
 .generate-deprecated:
+  extends: [ ".base-job" ]
   stage: generate
   script:
     - uname -a || true
@@ -134,45 +141,30 @@ default:
   tags: ["spack", "public", "medium", "x86_64"]
 
 .generate-aarch64:
-  extends: [ ".generate" ]
+  extends: [ ".base-job", ".generate" ]
   tags: ["spack", "public", "medium", "aarch64"]
 
-.pr-generate:
-  extends: [ ".pr", ".generate" ]
-
-.pr-generate-deprecated:
-  extends: [ ".pr", ".generate-deprecated" ]
-
-.pr-generate-aarch64:
-  extends: [ ".pr", ".generate-aarch64" ]
-
-.protected-generate:
-  extends: [ ".protected", ".generate" ]
-
-.protected-generate-deprecated:
-  extends: [ ".protected", ".generate-deprecated" ]
-
-.protected-generate-aarch64:
-  extends: [ ".protected", ".generate-aarch64" ]
-
 .build:
+  extends: [ ".base-job" ]
   stage: build
 
-.pr-build:
-  extends: [ ".pr", ".build", ".aws-pr-creds" ]
-
-.protected-build:
-  extends: [ ".protected", ".build", ".aws-protected-creds" ]
-
 protected-publish:
+  # Copy binaries from stack-specific mirrors to a root mirror
   stage: publish
-  extends: [ ".protected", ".aws-protected-creds" ]
+  only:
+  - /^develop$/
+  - /^releases\/v.*/
+  - /^v.*/
+  - /^develop-[\d]{4}-[\d]{2}-[\d]{2}$/
   image: "ghcr.io/spack/python-aws-bash:0.0.1"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
   retry:
     max: 2
     when: ["runner_system_failure", "stuck_or_timeout_failure"]
   variables:
+    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
+    SPACK_COPY_BUILDCACHE: "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    SPACK_PIPELINE_TYPE: "spack_protected_branch"
     AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
     KUBERNETES_CPU_REQUEST: 4000m
@@ -182,7 +174,9 @@ protected-publish:
     - spack --version
     - export COPY_SPECS_DIR=${CI_PROJECT_DIR}/jobs_scratch_dir/specs_to_copy
     - spack buildcache sync --manifest-glob "${COPY_SPECS_DIR}/*.json"
-    - spack buildcache update-index "${SPACK_COPY_BUILDCACHE}"
+    - curl -fLsS https://spack.github.io/keys/spack-public-binary-key.pub -o /tmp/spack-public-binary-key.pub
+    - aws s3 cp /tmp/spack-public-binary-key.pub "${SPACK_COPY_BUILDCACHE}/build_cache/_pgp/spack-public-binary-key.pub"
+    - spack buildcache update-index --keys "${SPACK_COPY_BUILDCACHE}"
 
 ########################################
 # TEMPLATE FOR ADDING ANOTHER PIPELINE
@@ -208,33 +202,19 @@ protected-publish:
 #     SPACK_CI_STACK_NAME: my-super-cool-stack
 #     tags: [ "all", "tags", "your", "job", "needs"]
 #
-# my-super-cool-stack-pr-generate:
-#   extends: [ ".pr-generate", ".my-super-cool-stack" ]
+# my-super-cool-stack-generate:
+#   extends: [ ".generate", ".my-super-cool-stack" ]
 #
-# my-super-cool-stack-protected-generate:
-#   extends: [ ".protected-generate", ".my-super-cool-stack" ]
-#
-# my-super-cool-stack-pr-build:
-#   extends: [ ".pr-build", ".my-super-cool-stack" ]
+# my-super-cool-stack-build:
+#   extends: [ ".build", ".my-super-cool-stack" ]
 #   trigger:
 #     include:
 #       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-#         job: my-super-cool-stack-pr-generate
+#         job: my-super-cool-stack-generate
 #     strategy: depend
 #   needs:
 #     - artifacts: True
-#       job: my-super-cool-stack-pr-generate
-#
-# my-super-cool-stack-protected-build:
-#   extends: [ ".protected-build", ".my-super-cool-stack" ]
-#   trigger:
-#     include:
-#       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-#         job: my-super-cool-stack-protected-generate
-#     strategy: depend
-#   needs:
-#     - artifacts: True
-#       job: my-super-cool-stack-protected-generate
+#       job: my-super-cool-stack-generate
 
 ########################################
 #          E4S Mac Stack
@@ -362,35 +342,20 @@ protected-publish:
   variables:
     SPACK_CI_STACK_NAME: e4s
 
-e4s-pr-generate:
-  extends: [ ".e4s", ".pr-generate"]
+e4s-generate:
+  extends: [ ".e4s", ".generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
 
-e4s-protected-generate:
-  extends: [ ".e4s", ".protected-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
-
-e4s-pr-build:
-  extends: [ ".e4s", ".pr-build" ]
+e4s-build:
+  extends: [ ".e4s", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-pr-generate
+        job: e4s-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: e4s-pr-generate
-
-e4s-protected-build:
-  extends: [ ".e4s", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: e4s-protected-generate
+      job: e4s-generate
 
 ########################################
 # GPU Testing Pipeline
@@ -400,35 +365,20 @@ e4s-protected-build:
   variables:
     SPACK_CI_STACK_NAME: gpu-tests
 
-gpu-tests-pr-generate:
-  extends: [ ".gpu-tests", ".pr-generate"]
+gpu-tests-generate:
+  extends: [ ".gpu-tests", ".generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
 
-gpu-tests-protected-generate:
-  extends: [ ".gpu-tests", ".protected-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
-
-gpu-tests-pr-build:
-  extends: [ ".gpu-tests", ".pr-build" ]
+gpu-tests-build:
+  extends: [ ".gpu-tests", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: gpu-tests-pr-generate
+        job: gpu-tests-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: gpu-tests-pr-generate
-
-gpu-tests-protected-build:
-  extends: [ ".gpu-tests", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: gpu-tests-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: gpu-tests-protected-generate
+      job: gpu-tests-generate
 
 ########################################
 # E4S OneAPI Pipeline
@@ -438,35 +388,20 @@ gpu-tests-protected-build:
   variables:
     SPACK_CI_STACK_NAME: e4s-oneapi
 
-e4s-oneapi-pr-generate:
-  extends: [ ".e4s-oneapi", ".pr-generate"]
+e4s-oneapi-generate:
+  extends: [ ".e4s-oneapi", ".generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
 
-e4s-oneapi-protected-generate:
-  extends: [ ".e4s-oneapi", ".protected-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
-
-e4s-oneapi-pr-build:
-  extends: [ ".e4s-oneapi", ".pr-build" ]
+e4s-oneapi-build:
+  extends: [ ".e4s-oneapi", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-oneapi-pr-generate
+        job: e4s-oneapi-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: e4s-oneapi-pr-generate
-
-e4s-oneapi-protected-build:
-  extends: [ ".e4s-oneapi", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-oneapi-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: e4s-oneapi-protected-generate
+      job: e4s-oneapi-generate
 
 ########################################
 # E4S on Power
@@ -480,33 +415,19 @@ e4s-oneapi-protected-build:
   variables:
     SPACK_CI_STACK_NAME: e4s-power
 
-e4s-power-pr-generate:
-  extends: [ ".e4s-power", ".pr-generate", ".e4s-power-generate-tags-and-image"]
+e4s-power-generate:
+  extends: [ ".e4s-power", ".generate", ".e4s-power-generate-tags-and-image"]
 
-e4s-power-protected-generate:
-  extends: [ ".e4s-power", ".protected-generate", ".e4s-power-generate-tags-and-image"]
-
-e4s-power-pr-build:
-  extends: [ ".e4s-power", ".pr-build" ]
+e4s-power-build:
+  extends: [ ".e4s-power", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-power-pr-generate
+        job: e4s-power-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: e4s-power-pr-generate
-
-e4s-power-protected-build:
-  extends: [ ".e4s-power", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-power-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: e4s-power-protected-generate
+      job: e4s-power-generate
 
 #########################################
 # Build tests for different build-systems
@@ -516,33 +437,19 @@ e4s-power-protected-build:
   variables:
     SPACK_CI_STACK_NAME: build_systems
 
-build_systems-pr-generate:
-  extends: [ ".build_systems", ".pr-generate"]
+build_systems-generate:
+  extends: [ ".build_systems", ".generate"]
 
-build_systems-protected-generate:
-  extends: [ ".build_systems", ".protected-generate"]
-
-build_systems-pr-build:
-  extends: [ ".build_systems", ".pr-build" ]
+build_systems-build:
+  extends: [ ".build_systems", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: build_systems-pr-generate
+        job: build_systems-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: build_systems-pr-generate
-
-build_systems-protected-build:
-  extends: [ ".build_systems", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: build_systems-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: build_systems-protected-generate
+      job: build_systems-generate
 
 #########################################
 # RADIUSS
@@ -552,35 +459,19 @@ build_systems-protected-build:
   variables:
     SPACK_CI_STACK_NAME: radiuss
 
-# ---------  PRs ---------
-radiuss-pr-generate:
-  extends: [ ".radiuss", ".pr-generate" ]
+radiuss-generate:
+  extends: [ ".radiuss", ".generate" ]
 
-radiuss-pr-build:
-  extends: [ ".radiuss", ".pr-build" ]
+radiuss-build:
+  extends: [ ".radiuss", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: radiuss-pr-generate
+        job: radiuss-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: radiuss-pr-generate
-
-# --------- Protected ---------
-radiuss-protected-generate:
-  extends: [ ".radiuss", ".protected-generate" ]
-
-radiuss-protected-build:
-  extends: [ ".radiuss", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: radiuss-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: radiuss-protected-generate
+      job: radiuss-generate
 
 ########################################
 # RADIUSS for AWS
@@ -600,33 +491,19 @@ radiuss-protected-build:
   variables:
     SPACK_CI_STACK_NAME: radiuss-aws
 
-radiuss-aws-pr-generate:
-  extends: [ ".radiuss-aws", ".pr-generate", ".radiuss-aws-overrides", ".tags-x86_64_v4" ]
+radiuss-aws-generate:
+  extends: [ ".radiuss-aws", ".generate", ".radiuss-aws-overrides", ".tags-x86_64_v4" ]
 
-radiuss-aws-protected-generate:
-  extends: [ ".radiuss-aws", ".protected-generate", ".radiuss-aws-overrides", ".tags-x86_64_v4" ]
-
-radiuss-aws-pr-build:
-  extends: [ ".radiuss-aws", ".pr-build" ]
+radiuss-aws-build:
+  extends: [ ".radiuss-aws", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: radiuss-aws-pr-generate
+        job: radiuss-aws-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: radiuss-aws-pr-generate
-
-radiuss-aws-protected-build:
-  extends: [ ".radiuss-aws", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: radiuss-aws-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: radiuss-aws-protected-generate
+      job: radiuss-aws-generate
 
 
 # Parallel Pipeline for aarch64 (reuses override image, but generates and builds on aarch64)
@@ -636,33 +513,19 @@ radiuss-aws-protected-build:
   variables:
     SPACK_CI_STACK_NAME: radiuss-aws-aarch64
 
-radiuss-aws-aarch64-pr-generate:
-  extends: [ ".radiuss-aws-aarch64", ".pr-generate-aarch64", ".radiuss-aws-overrides" ]
+radiuss-aws-aarch64-generate:
+  extends: [ ".radiuss-aws-aarch64", ".generate-aarch64", ".radiuss-aws-overrides" ]
 
-radiuss-aws-aarch64-protected-generate:
-  extends: [ ".radiuss-aws-aarch64", ".protected-generate-aarch64", ".radiuss-aws-overrides" ]
-
-radiuss-aws-aarch64-pr-build:
-  extends: [ ".radiuss-aws-aarch64", ".pr-build" ]
+radiuss-aws-aarch64-build:
+  extends: [ ".radiuss-aws-aarch64", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: radiuss-aws-aarch64-pr-generate
+        job: radiuss-aws-aarch64-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: radiuss-aws-aarch64-pr-generate
-
-radiuss-aws-aarch64-protected-build:
-  extends: [ ".radiuss-aws-aarch64", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: radiuss-aws-aarch64-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: radiuss-aws-aarch64-protected-generate
+      job: radiuss-aws-aarch64-generate
 
 ########################################
 # ECP Data & Vis SDK
@@ -672,35 +535,20 @@ radiuss-aws-aarch64-protected-build:
   variables:
     SPACK_CI_STACK_NAME: data-vis-sdk
 
-data-vis-sdk-pr-generate:
-  extends: [ ".data-vis-sdk", ".pr-generate"]
+data-vis-sdk-generate:
+  extends: [ ".data-vis-sdk", ".generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
 
-data-vis-sdk-protected-generate:
-  extends: [ ".data-vis-sdk", ".protected-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
-
-data-vis-sdk-pr-build:
-  extends: [ ".data-vis-sdk", ".pr-build" ]
+data-vis-sdk-build:
+  extends: [ ".data-vis-sdk", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: data-vis-sdk-pr-generate
+        job: data-vis-sdk-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: data-vis-sdk-pr-generate
-
-data-vis-sdk-protected-build:
-  extends: [ ".data-vis-sdk", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: data-vis-sdk-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: data-vis-sdk-protected-generate
+      job: data-vis-sdk-generate
 
 ########################################
 # AWS AHUG Applications (x86_64)
@@ -717,34 +565,19 @@ data-vis-sdk-protected-build:
   variables:
     SPACK_CI_STACK_NAME: aws-ahug
 
-aws-ahug-pr-generate:
-  extends: [ ".aws-ahug", ".pr-generate", ".aws-ahug-overrides", ".tags-x86_64_v4" ]
+aws-ahug-generate:
+  extends: [ ".aws-ahug", ".generate", ".aws-ahug-overrides", ".tags-x86_64_v4" ]
 
-aws-ahug-protected-generate:
-  extends: [ ".aws-ahug", ".protected-generate", ".aws-ahug-overrides", ".tags-x86_64_v4" ]
-
-aws-ahug-pr-build:
-  extends: [ ".aws-ahug", ".pr-build" ]
+aws-ahug-build:
+  extends: [ ".aws-ahug", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-ahug-pr-generate
+        job: aws-ahug-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: aws-ahug-pr-generate
-
-aws-ahug-protected-build:
-  extends: [ ".aws-ahug", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-ahug-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: aws-ahug-protected-generate
-
+      job: aws-ahug-generate
 
 # Parallel Pipeline for aarch64 (reuses override image, but generates and builds on aarch64)
 .aws-ahug-aarch64:
@@ -752,33 +585,19 @@ aws-ahug-protected-build:
   variables:
     SPACK_CI_STACK_NAME: aws-ahug-aarch64
 
-aws-ahug-aarch64-pr-generate:
-  extends: [ ".aws-ahug-aarch64", ".pr-generate-aarch64", ".aws-ahug-overrides" ]
+aws-ahug-aarch64-generate:
+  extends: [ ".aws-ahug-aarch64", ".generate-aarch64", ".aws-ahug-overrides" ]
 
-aws-ahug-aarch64-protected-generate:
-  extends: [ ".aws-ahug-aarch64", ".protected-generate-aarch64", ".aws-ahug-overrides" ]
-
-aws-ahug-aarch64-pr-build:
-  extends: [ ".aws-ahug-aarch64", ".pr-build" ]
+aws-ahug-aarch64-build:
+  extends: [ ".aws-ahug-aarch64", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-ahug-aarch64-pr-generate
+        job: aws-ahug-aarch64-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: aws-ahug-aarch64-pr-generate
-
-aws-ahug-aarch64-protected-build:
-  extends: [ ".aws-ahug-aarch64", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-ahug-aarch64-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: aws-ahug-aarch64-protected-generate
+      job: aws-ahug-aarch64-generate
 
 ########################################
 # AWS ISC Applications (x86_64)
@@ -795,34 +614,19 @@ aws-ahug-aarch64-protected-build:
   variables:
     SPACK_CI_STACK_NAME: aws-isc
 
-aws-isc-pr-generate:
-  extends: [ ".aws-isc", ".pr-generate", ".aws-isc-overrides", ".tags-x86_64_v4" ]
+aws-isc-generate:
+  extends: [ ".aws-isc", ".generate", ".aws-isc-overrides", ".tags-x86_64_v4" ]
 
-aws-isc-protected-generate:
-  extends: [ ".aws-isc", ".protected-generate", ".aws-isc-overrides", ".tags-x86_64_v4" ]
-
-aws-isc-pr-build:
-  extends: [ ".aws-isc", ".pr-build" ]
+aws-isc-build:
+  extends: [ ".aws-isc", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-isc-pr-generate
+        job: aws-isc-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: aws-isc-pr-generate
-
-aws-isc-protected-build:
-  extends: [ ".aws-isc", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-isc-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: aws-isc-protected-generate
-
+      job: aws-isc-generate
 
 # Parallel Pipeline for aarch64 (reuses override image, but generates and builds on aarch64)
 
@@ -831,33 +635,19 @@ aws-isc-protected-build:
   variables:
     SPACK_CI_STACK_NAME: aws-isc-aarch64
 
-aws-isc-aarch64-pr-generate:
-  extends: [ ".aws-isc-aarch64", ".pr-generate-aarch64", ".aws-isc-overrides" ]
+aws-isc-aarch64-generate:
+  extends: [ ".aws-isc-aarch64", ".generate-aarch64", ".aws-isc-overrides" ]
 
-aws-isc-aarch64-protected-generate:
-  extends: [ ".aws-isc-aarch64", ".protected-generate-aarch64", ".aws-isc-overrides" ]
-
-aws-isc-aarch64-pr-build:
-  extends: [ ".aws-isc-aarch64", ".pr-build" ]
+aws-isc-aarch64-build:
+  extends: [ ".aws-isc-aarch64", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-isc-aarch64-pr-generate
+        job: aws-isc-aarch64-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: aws-isc-aarch64-pr-generate
-
-aws-isc-aarch64-protected-build:
-  extends: [ ".aws-isc-aarch64", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: aws-isc-aarch64-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: aws-isc-aarch64-protected-generate
+      job: aws-isc-aarch64-generate
 
 
 ########################################
@@ -868,35 +658,20 @@ aws-isc-aarch64-protected-build:
   variables:
     SPACK_CI_STACK_NAME: tutorial
 
-tutorial-pr-generate:
-  extends: [ ".tutorial", ".pr-generate"]
+tutorial-generate:
+  extends: [ ".tutorial", ".generate"]
   image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-05-07
 
-tutorial-protected-generate:
-  extends: [ ".tutorial", ".protected-generate"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-05-07
-
-tutorial-pr-build:
-  extends: [ ".tutorial", ".pr-build" ]
+tutorial-build:
+  extends: [ ".tutorial", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: tutorial-pr-generate
+        job: tutorial-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: tutorial-pr-generate
-
-tutorial-protected-build:
-  extends: [ ".tutorial", ".protected-build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: tutorial-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: tutorial-protected-generate
+      job: tutorial-generate
 
 #######################################
 # Machine Learning - Linux x86_64 (CPU)
@@ -906,37 +681,20 @@ tutorial-protected-build:
   variables:
     SPACK_CI_STACK_NAME: ml-linux-x86_64-cpu
 
-.ml-linux-x86_64-cpu-generate:
-  extends: [ .ml-linux-x86_64-cpu, ".tags-x86_64_v4" ]
+ml-linux-x86_64-cpu-generate:
+  extends: [ ".generate", .ml-linux-x86_64-cpu, ".tags-x86_64_v4" ]
   image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
 
-ml-linux-x86_64-cpu-pr-generate:
-  extends: [ ".pr-generate", ".ml-linux-x86_64-cpu-generate" ]
-
-ml-linux-x86_64-cpu-protected-generate:
-  extends: [ ".protected-generate", ".ml-linux-x86_64-cpu-generate" ]
-
-ml-linux-x86_64-cpu-pr-build:
-  extends: [ ".pr-build", ".ml-linux-x86_64-cpu" ]
+ml-linux-x86_64-cpu-build:
+  extends: [ ".build", ".ml-linux-x86_64-cpu" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: ml-linux-x86_64-cpu-pr-generate
+        job: ml-linux-x86_64-cpu-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: ml-linux-x86_64-cpu-pr-generate
-
-ml-linux-x86_64-cpu-protected-build:
-  extends: [ ".protected-build", ".ml-linux-x86_64-cpu" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: ml-linux-x86_64-cpu-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: ml-linux-x86_64-cpu-protected-generate
+      job: ml-linux-x86_64-cpu-generate
 
 ########################################
 # Machine Learning - Linux x86_64 (CUDA)
@@ -946,37 +704,20 @@ ml-linux-x86_64-cpu-protected-build:
   variables:
     SPACK_CI_STACK_NAME: ml-linux-x86_64-cuda
 
-.ml-linux-x86_64-cuda-generate:
-  extends: [ .ml-linux-x86_64-cuda, ".tags-x86_64_v4" ]
+ml-linux-x86_64-cuda-generate:
+  extends: [ ".generate", .ml-linux-x86_64-cuda, ".tags-x86_64_v4" ]
   image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
 
-ml-linux-x86_64-cuda-pr-generate:
-  extends: [ ".pr-generate", ".ml-linux-x86_64-cuda-generate" ]
-
-ml-linux-x86_64-cuda-protected-generate:
-  extends: [ ".protected-generate", ".ml-linux-x86_64-cuda-generate" ]
-
-ml-linux-x86_64-cuda-pr-build:
-  extends: [ ".pr-build", ".ml-linux-x86_64-cuda" ]
+ml-linux-x86_64-cuda-build:
+  extends: [ ".build", ".ml-linux-x86_64-cuda"  ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: ml-linux-x86_64-cuda-pr-generate
+        job: ml-linux-x86_64-cuda-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: ml-linux-x86_64-cuda-pr-generate
-
-ml-linux-x86_64-cuda-protected-build:
-  extends: [ ".protected-build", ".ml-linux-x86_64-cuda"  ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: ml-linux-x86_64-cuda-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: ml-linux-x86_64-cuda-protected-generate
+      job: ml-linux-x86_64-cuda-generate
 
 ########################################
 # Machine Learning - Linux x86_64 (ROCm)
@@ -986,38 +727,20 @@ ml-linux-x86_64-cuda-protected-build:
   variables:
     SPACK_CI_STACK_NAME: ml-linux-x86_64-rocm
 
-.ml-linux-x86_64-rocm-generate:
-  extends: [ .ml-linux-x86_64-rocm, ".tags-x86_64_v4" ]
+ml-linux-x86_64-rocm-generate:
+  extends: [ ".generate", .ml-linux-x86_64-rocm, ".tags-x86_64_v4" ]
   image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
 
-ml-linux-x86_64-rocm-pr-generate:
-  extends: [ ".pr-generate", ".ml-linux-x86_64-rocm-generate" ]
-
-ml-linux-x86_64-rocm-protected-generate:
-  extends: [ ".protected-generate", ".ml-linux-x86_64-rocm-generate" ]
-
-ml-linux-x86_64-rocm-pr-build:
-  extends: [ ".pr-build", ".ml-linux-x86_64-rocm"  ]
+ml-linux-x86_64-rocm-build:
+  extends: [ ".build", ".ml-linux-x86_64-rocm" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: ml-linux-x86_64-rocm-pr-generate
+        job: ml-linux-x86_64-rocm-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: ml-linux-x86_64-rocm-pr-generate
-
-ml-linux-x86_64-rocm-protected-build:
-  extends: [ ".protected-build", ".ml-linux-x86_64-rocm" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: ml-linux-x86_64-rocm-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: ml-linux-x86_64-rocm-protected-generate
-
+      job: ml-linux-x86_64-rocm-generate
 
 ########################################
 # Deprecated CI testing
@@ -1026,30 +749,16 @@ ml-linux-x86_64-rocm-protected-build:
   variables:
     SPACK_CI_STACK_NAME: deprecated
 
-deprecated-ci-pr-generate:
-  extends: [ ".pr-generate-deprecated", ".deprecated-ci" ]
+deprecated-ci-generate:
+  extends: [ ".generate-deprecated", ".deprecated-ci" ]
 
-deprecated-ci-protected-generate:
-  extends: [ ".protected-generate-deprecated", ".deprecated-ci" ]
-
-deprecated-ci-pr-build:
-  extends: [ ".pr-build", ".deprecated-ci" ]
+deprecated-ci-build:
+  extends: [ ".build", ".deprecated-ci" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: deprecated-ci-pr-generate
+        job: deprecated-ci-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: deprecated-ci-pr-generate
-
-deprecated-ci-protected-build:
-  extends: [ ".protected-build", ".deprecated-ci" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: deprecated-ci-protected-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: deprecated-ci-protected-generate
+      job: deprecated-ci-generate

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -36,6 +36,34 @@ ci:
         - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
         - aws s3 cp /tmp/public_keys ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/_pgp --recursive --exclude "*" --include "*.pub"
 
+  - copy-job:
+      tags: ["service", "x86_64"]
+      image: "ghcr.io/spack/python-aws-bash:0.0.1"
+      before_script:
+      - - if [[ $CI_COMMIT_TAG == "v"* ]]; then export SPACK_REPLACE_VERSION=$(echo "$CI_COMMIT_TAG" | sed 's/\(v[[:digit:]]\+\.[[:digit:]]\+\).*/releases\/\1/'); fi
+        - if [[ $CI_COMMIT_TAG == "develop-"* ]]; then export SPACK_REPLACE_VERSION=develop; fi
+        - export SPACK_BUILDCACHE_SOURCE=${SPACK_SOURCE_MIRROR//SPACK_REPLACE_VERSION/${SPACK_REPLACE_VERSION}}
+      script:
+      - - cd ${SPACK_CONCRETE_ENV_DIR}
+        - spack env activate --without-view .
+        - echo Copying environment specs from ${SRC_MIRROR} to ${SPACK_BUILDCACHE_DESTINATION}
+        - spack buildcache sync "${SPACK_BUILDCACHE_SOURCE}" "${SPACK_BUILDCACHE_DESTINATION}"
+        - curl -fLsS https://spack.github.io/keys/spack-public-binary-key.pub -o /tmp/spack-public-binary-key.pub
+        - aws s3 cp /tmp/spack-public-binary-key.pub "${SPACK_BUILDCACHE_DESTINATION}/build_cache/_pgp/spack-public-binary-key.pub"
+        - spack buildcache update-index --keys "${SPACK_BUILDCACHE_DESTINATION}"
+      when: "always"
+      retry:
+        max: 2
+        when:
+        - "runner_system_failure"
+        - "stuck_or_timeout_failure"
+        - "script_failure"
+      interruptible: true
+      variables:
+        CI_JOB_SIZE: "medium"
+        KUBERNETES_CPU_REQUEST: "4000m"
+        KUBERNETES_MEMORY_REQUEST: "16G"
+
   - reindex-job:
       tags: ["service"]
       variables:

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/icelake/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/icelake/ci.yaml
@@ -1,0 +1,11 @@
+ci:
+  pipeline-gen:
+  - any-job:
+      variables:
+        SPACK_TARGET_ARCH: icelake
+  - build-job:
+      before_script:
+      - - curl -LfsS "https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz" -o gmake.tar.gz
+        - printf "fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz" | sha256sum --check --strict --quiet
+        - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+      tags: ["x86_64_v4"]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_n1/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_n1/ci.yaml
@@ -1,0 +1,7 @@
+ci:
+  pipeline-gen:
+  - any-job:
+      variables:
+        SPACK_TARGET_ARCH: neoverse_n1
+  - build-job:
+      tags: ["aarch64", "graviton2"]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_v1/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_v1/ci.yaml
@@ -1,0 +1,7 @@
+ci:
+  pipeline-gen:
+  - any-job:
+      variables:
+        SPACK_TARGET_ARCH: neoverse_v1
+  - build-job:
+      tags: ["aarch64", "graviton3"]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/skylake_avx512/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/skylake_avx512/ci.yaml
@@ -1,0 +1,11 @@
+ci:
+  pipeline-gen:
+  - any-job:
+      variables:
+        SPACK_TARGET_ARCH: skylake_avx512
+  - build-job:
+      before_script:
+      - - curl -LfsS "https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz" -o gmake.tar.gz
+        - printf "fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz" | sha256sum --check --strict --quiet
+        - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+      tags: ["x86_64_v4"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
@@ -1,0 +1,58 @@
+spack:
+  view: false
+
+  definitions:
+  - compiler_specs:
+    - gcc
+    - gettext
+
+  - compiler_target:
+    - '%gcc@7.3.1 target=x86_64_v3'
+
+  - optimized_configs:
+    # - gromacs
+    - lammps
+    # - mpas-model
+    - openfoam
+    # - palace
+    # - py-devito
+    # - quantum-espresso
+    # - wrf
+
+  - optimized_libs:
+    - mpich
+    - openmpi
+
+  specs:
+  - matrix:
+    - - $compiler_specs
+    - - $compiler_target
+  - $optimized_configs
+  # - $optimized_libs
+
+  mirrors: { "mirror": "s3://spack-binaries/develop/aws-pcluster-icelake" }
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:latest", "entrypoint": [""] }
+        before_script:
+        - - . "./share/spack/setup-env.sh"
+          - . /etc/profile.d/modules.sh
+          - spack --version
+          - spack arch
+        # Setup postinstall Spack as upstream installation
+        - - if [[ -f /bootstrap/spack/etc/spack/packages.yaml ]]; then cp /bootstrap/spack/etc/spack/packages.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/config.yaml ]]; then cp /bootstrap/spack/etc/spack/config.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/modules.yaml ]]; then cp /bootstrap/spack/etc/spack/modules.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/mirrors.yaml ]]; then cp /bootstrap/spack/etc/spack/mirrors.yaml ./etc/spack/; fi
+          - if [[ -d /bootstrap/spack/opt/spack ]]; then spack config add "upstreams:postinstall:install_tree:/bootstrap/spack/opt/spack"; fi
+        - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
+          - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
+    - signing-job:
+        before_script:
+          # Do not distribute Intel & ARM binaries
+          - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+            - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+  cdash:
+    build-group: AWS Packages

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
@@ -1,0 +1,61 @@
+spack:
+  view: false
+
+  definitions:
+  - compiler_specs:
+    - gcc
+    - gettext
+
+  - compiler_target:
+    - '%gcc@7.3.1 target=aarch64'
+
+  - optimized_configs:
+    - gromacs
+    # - lammps
+    # - mpas-model
+    - openfoam
+    - palace
+    # - py-devito
+    - quantum-espresso
+    # - wrf
+
+  - optimized_libs:
+    - mpich
+    - openmpi
+
+  specs:
+  - matrix:
+    - - $compiler_specs
+    - - $compiler_target
+  - $optimized_configs
+  - $optimized_libs
+
+
+  mirrors: { "mirror": "s3://spack-binaries/develop/aws-pcluster-neoverse_n1" }
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:latest", "entrypoint": [""] }
+        tags: ["aarch64"]
+        before_script:
+        - - . "./share/spack/setup-env.sh"
+          - . /etc/profile.d/modules.sh
+          - spack --version
+          - spack arch
+        # Setup postinstall Spack as upstream installation
+        - - if [[ -f /bootstrap/spack/etc/spack/packages.yaml ]]; then cp /bootstrap/spack/etc/spack/packages.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/config.yaml ]]; then cp /bootstrap/spack/etc/spack/config.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/modules.yaml ]]; then cp /bootstrap/spack/etc/spack/modules.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/mirrors.yaml ]]; then cp /bootstrap/spack/etc/spack/mirrors.yaml ./etc/spack/; fi
+          - if [[ -d /bootstrap/spack/opt/spack ]]; then spack config add "upstreams:postinstall:install_tree:/bootstrap/spack/opt/spack"; fi
+        - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
+          - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
+    - signing-job:
+        before_script:
+          # Do not distribute Intel & ARM binaries
+          - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+            - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+
+  cdash:
+    build-group: AWS Packages

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -1,0 +1,61 @@
+spack:
+  view: false
+
+  definitions:
+  - compiler_specs:
+    - gcc
+    - gettext
+
+  - compiler_target:
+    - '%gcc@7.3.1 target=aarch64'
+
+  - optimized_configs:
+    - gromacs
+    # - lammps
+    # - mpas-model
+    - openfoam
+    - palace
+    # - py-devito
+    - quantum-espresso
+    # - wrf
+
+  - optimized_libs:
+    - mpich
+    - openmpi
+
+  specs:
+  - matrix:
+    - - $compiler_specs
+    - - $compiler_target
+  - $optimized_configs
+  - $optimized_libs
+
+
+  mirrors: { "mirror": "s3://spack-binaries/develop/aws-pcluster-neoverse_v1" }
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:latest", "entrypoint": [""] }
+        tags: ["aarch64"]
+        before_script:
+        - - . "./share/spack/setup-env.sh"
+          - . /etc/profile.d/modules.sh
+          - spack --version
+          - spack arch
+        # Setup postinstall Spack as upstream installation
+        - - if [[ -f /bootstrap/spack/etc/spack/packages.yaml ]]; then cp /bootstrap/spack/etc/spack/packages.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/config.yaml ]]; then cp /bootstrap/spack/etc/spack/config.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/modules.yaml ]]; then cp /bootstrap/spack/etc/spack/modules.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/mirrors.yaml ]]; then cp /bootstrap/spack/etc/spack/mirrors.yaml ./etc/spack/; fi
+          - if [[ -d /bootstrap/spack/opt/spack ]]; then spack config add "upstreams:postinstall:install_tree:/bootstrap/spack/opt/spack"; fi
+        - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
+          - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
+    - signing-job:
+        before_script:
+          # Do not distribute Intel & ARM binaries
+          - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+            - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+
+  cdash:
+    build-group: AWS Packages

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
@@ -1,0 +1,58 @@
+spack:
+  view: false
+
+  definitions:
+  - compiler_specs:
+    - gcc
+    - gettext
+
+  - compiler_target:
+    - '%gcc@7.3.1 target=x86_64_v3'
+
+  - optimized_configs:
+    # - gromacs
+    - lammps
+    # - mpas-model
+    - openfoam
+    # - palace
+    # - py-devito
+    # - quantum-espresso
+    # - wrf
+
+  - optimized_libs:
+    - mpich
+    - openmpi
+
+  specs:
+  - matrix:
+    - - $compiler_specs
+    - - $compiler_target
+  - $optimized_configs
+  # - $optimized_libs
+
+  mirrors: { "mirror": "s3://spack-binaries/develop/aws-pcluster-skylake" }
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:latest", "entrypoint": [""] }
+        before_script:
+        - - . "./share/spack/setup-env.sh"
+          - . /etc/profile.d/modules.sh
+          - spack --version
+          - spack arch
+        # Setup postinstall Spack as upstream installation
+        - - if [[ -f /bootstrap/spack/etc/spack/packages.yaml ]]; then cp /bootstrap/spack/etc/spack/packages.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/config.yaml ]]; then cp /bootstrap/spack/etc/spack/config.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/modules.yaml ]]; then cp /bootstrap/spack/etc/spack/modules.yaml ./etc/spack/; fi
+          - if [[ -f /bootstrap/spack/etc/spack/mirrors.yaml ]]; then cp /bootstrap/spack/etc/spack/mirrors.yaml ./etc/spack/; fi
+          - if [[ -d /bootstrap/spack/opt/spack ]]; then spack config add "upstreams:postinstall:install_tree:/bootstrap/spack/opt/spack"; fi
+        - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
+          - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
+    - signing-job:
+        before_script:
+          # Do not distribute Intel & ARM binaries
+          - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+            - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+  cdash:
+    build-group: AWS Packages

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -24,4 +24,4 @@ spack:
   mirrors: { "mirror": "s3://spack-binaries/develop/build_systems" }
 
   cdash:
-    build-group: Build tests for different build systems
+    build-group: Build Systems

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -6,9 +6,9 @@ spack:
     mesa:
       require: "+glx +osmesa +opengl ~opengles +llvm"
     libosmesa:
-      require: ^mesa +osmesa
+      require: "mesa +osmesa"
     libglx:
-      require: ^mesa +glx
+      require: "mesa +glx"
     ospray:
       require: "@2.8.0 +denoiser +mpi"
     llvm:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -269,6 +269,10 @@ spack:
     pipeline-gen:
     - build-job:
         image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
+        before_script:
+        - - . /bootstrap/runner/view/lmod/lmod/init/bash
+          - module use /opt/intel/oneapi/modulefiles
+          - module load compiler
 
   cdash:
     build-group: E4S OneAPI

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -81,6 +81,8 @@ spack:
   - gptune
   - h5bench
   - hdf5-vol-async
+  - hdf5-vol-cache
+  - hdf5-vol-log
   - heffte +fftw
   - hpctoolkit
   - hpx max_cpu_count=512 networking=mpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -71,7 +71,7 @@ spack:
   - conduit
   - datatransferkit
   - dyninst
-  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc +visit +vtkm +zfp
+  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc ~visit +vtkm +zfp ^hdf5@1.14
   - exaworks
   - flecsi
   - flit
@@ -165,7 +165,7 @@ spack:
   - chai ~benchmarks ~tests +cuda ^umpire ~shared
   - cusz +cuda
   - dealii +cuda
-  - ecp-data-vis-sdk +cuda +adios2 +hdf5 +paraview +vtkm +zfp # Removing ascent because Dray is hung in CI. +ascent
+  - ecp-data-vis-sdk +cuda ~ascent +adios2 +hdf5 +paraview +sz +vtkm +zfp  ^hdf5@1.14 # Removing ascent because RAJA build failure
   - flecsi +cuda
   - flux-core +cuda
   - ginkgo +cuda
@@ -199,7 +199,7 @@ spack:
   - cabana +rocm
   - caliper +rocm
   - chai ~benchmarks +rocm
-  - ecp-data-vis-sdk +paraview +vtkm +rocm
+  - ecp-data-vis-sdk +adios2 +hdf5 +paraview +pnetcdf +sz +vtkm +zfp +rocm ^hdf5@1.14 # Excludes ascent for now due to C++ standard issues
   - gasnet +rocm
   - ginkgo +rocm
   - heffte +rocm

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -85,6 +85,8 @@ spack:
   - gptune
   - h5bench
   - hdf5-vol-async
+  - hdf5-vol-cache
+  - hdf5-vol-log
   - heffte +fftw
   - hpctoolkit
   - hpx max_cpu_count=512 networking=mpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -217,7 +217,7 @@ spack:
   - superlu-dist +rocm
   - tasmanian ~openmp +rocm
   - tau +mpi +rocm
-  - "trilinos@13.4.0: ~belos ~ifpack2 ~stokhos +rocm"
+  - "trilinos@13.4.0: +belos ~ifpack2 ~stokhos +rocm"
   - umpire +rocm
   - upcxx +rocm
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -734,7 +734,7 @@ _spack_compilers() {
 }
 
 _spack_concretize() {
-    SPACK_COMPREPLY="-h --help -f --force --test -q --quiet -U --fresh --reuse --reuse-deps"
+    SPACK_COMPREPLY="-h --help -f --force --test -q --quiet -U --fresh --reuse --reuse-deps -j --jobs"
 }
 
 _spack_config() {

--- a/var/spack/repos/builtin.mock/packages/python/package.py
+++ b/var/spack/repos/builtin.mock/packages/python/package.py
@@ -14,6 +14,7 @@ class Python(Package):
 
     extendable = True
 
+    version("3.7.1", md5="aaabbbcccdddeeefffaaabbbcccddd12")
     version("3.5.1", md5="be78e48cdfc1a7ad90efff146dce6cfe")
     version("3.5.0", md5="a56c0c0b45d75a0ec9c6dee933c41c36")
     version("2.7.11", md5="6b6076ec9e93f05dd63e47eb9c15728b", preferred=True)

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -7,16 +7,24 @@ from spack.package import *
 
 
 class SimpleStandaloneTest(Package):
-    """This package has a simple stand-alone test features."""
+    """This package has simple stand-alone test features."""
 
     homepage = "http://www.example.com/simple_test"
     url = "http://www.unit-test-should-replace-this-url/simple_test-1.0.tar.gz"
 
-    version("1.0", md5="0123456789abcdef0123456789abcdef")
+    version("1.0", md5="123456789abcdef0123456789abcdefg")
+    version("0.9", md5="0123456789abcdef0123456789abcdef")
 
-    provides("standalone-test")
+    provides("standalone-ifc")
 
     def test_echo(self):
         """simple stand-alone test"""
         echo = which("echo")
         echo("testing echo", output=str.split, error=str.split)
+
+    def test_skip(self):
+        """simple skip test"""
+        if self.spec.satisfies("@1.0:"):
+            raise SkipTest("This test is not available from v1.0 on")
+
+        print("Ran test_skip")

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -18,6 +18,7 @@ class Actsvg(CMakePackage):
 
     maintainers("HadrienG2", "wdconinc")
 
+    version("0.4.33", sha256="25c93b8382bdb1864b4d8de64b146fe8ea86eec84048d594c375700d2fff1d1d")
     version("0.4.30", sha256="f7ffea39b3132914fcbb0fac6ab7395bef295cd6078dfd1c2509fd2d9aab0acb")
     version("0.4.29", sha256="971f4f344c3143b654e6a86422534c6916f785f2c2c3785664c4ae7ddf2f5e4b")
     version("0.4.28", sha256="12c6f0c41b1aeb21164c949498819976bf91a395968debcb400539713bdfc6b0")

--- a/var/spack/repos/builtin/packages/alluxio/package.py
+++ b/var/spack/repos/builtin/packages/alluxio/package.py
@@ -17,6 +17,7 @@ class Alluxio(Package):
     list_url = "https://downloads.alluxio.io/downloads/files"
     list_depth = 1
 
+    version("2.9.3", sha256="c71abc5e852d37cfd6b1dea076f056c6997e3f60fbb940bf005acb3a6354a369")
     version("2.9.1", sha256="e9456db7a08488af22dee3a44e4135bc03a0444e31c7753bf00f72465f68ffb9")
 
     # https://nvd.nist.gov/vuln/detail/CVE-2022-23848

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -25,6 +25,7 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
     maintainers("bvanessen")
 
     version("master", branch="master")
+    version("1.3.1", sha256="28ce0af6c6f29f97b7f19c5e45184bd2f8a0b1428f1e898b027d96d47cb74b0b")
     version("1.3.0", sha256="d0442efbebfdfb89eec793ae65eceb8f1ba65afa9f2e48df009f81985a4c27e3")
     version("1.2.3", sha256="9b214bdf30f9b7e8e017f83e6615db6be2631f5be3dd186205dbe3aa62f4018a")
     version(

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -109,15 +109,13 @@ class Aml(AutotoolsPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(self.smoke_test_src)
 
-    def run_install_tutorial_check(self):
-        """Run tutorial tests as install checks"""
-
-        src = join_path(self.test_suite.current_test_cache_dir, self.smoke_test_src)
-        cc_exe = os.environ["CC"]
+    def test_check_tutorial(self):
+        """Compile and run the tutorial tests as install checks"""
+        cc = which(os.environ["CC"])
         cc_options = [
             "-o",
             self.smoke_test,
-            src,
+            join_path(self.test_suite.current_test_cache_dir, self.smoke_test_src),
             "-I{0}".format(self.prefix.include),
             "-I{0}".format(self.spec["numactl"].prefix.include),
             "-L{0}".format(self.prefix.lib),
@@ -125,11 +123,8 @@ class Aml(AutotoolsPackage):
             "-lexcit",
             "-lpthread",
         ]
+        cc(*cc_options)
 
-        self.run_test(
-            cc_exe, cc_options, purpose="test: compile {0} tutorial".format(self.smoke_test)
-        )
-        self.run_test(self.smoke_test, purpose="test: run {0} tutorial".format(self.smoke_test))
-
-    def test(self):
-        self.run_install_tutorial_check()
+        smoke_test = which(self.smoke_test)
+        out = smoke_test(output=str.split, error=str.split)
+        assert "Hello world" in out

--- a/var/spack/repos/builtin/packages/amrfinder/package.py
+++ b/var/spack/repos/builtin/packages/amrfinder/package.py
@@ -18,6 +18,7 @@ class Amrfinder(MakefilePackage):
     homepage = "https://github.com/ncbi/amr/wiki"
     url = "https://github.com/ncbi/amr/archive/refs/tags/amrfinder_v3.10.30.tar.gz"
 
+    version("3.11.8", sha256="8aac87595f28d0ba54ed3e97a1c033f9769a9b03e0aba78bc29cf6aff0cf45d1")
     version("3.10.42", sha256="97254f8d6217a4618b7f29c05acbcfe0240ee5e98458f8da7df3840b4be39c1b")
     version("3.10.30", sha256="2f1e30b86935a27cee740bd7229a41fbce278f2f60b33b8e51592bab8bdf23f1")
     version("3.10.24", sha256="fce299c980cda740dcc4f53f9b2dc9061c856213e5bdbc2c339185a5fb7dcf6a")

--- a/var/spack/repos/builtin/packages/armcomputelibrary/package.py
+++ b/var/spack/repos/builtin/packages/armcomputelibrary/package.py
@@ -30,7 +30,7 @@ class Armcomputelibrary(SConsPackage):
     url = "https://github.com/ARM-software/ComputeLibrary/archive/refs/tags/v23.02.zip"
     git = "https://github.com/ARM-software/ComputeLibrary.git"
 
-    maintainers = ["annop-w"]
+    maintainers("annop-w")
 
     version("23.02", sha256="bed1b24047ce00155e552204bc3983e86f46775414c554a34a7ece931d67ec62")
     version("22.11", sha256="2f70f54d84390625222503ea38650c00c49d4b70bc86a6b9aeeebee9d243865f")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -183,6 +183,8 @@ class Ascent(CMakePackage, CudaPackage):
     depends_on("vtk-m+cuda", when="@0.9.0: +vtkh+cuda")
     depends_on("vtk-m+fpic", when="@0.8.0: +vtkh")
     depends_on("vtk-m~shared+fpic", when="@0.8.0: +vtkh~shared")
+    # Ascent defaults to C++11
+    depends_on("kokkos std=11", when="+vtkh ^vtk-m +kokkos")
 
     #######################
     # VTK-h

--- a/var/spack/repos/builtin/packages/audit-userspace/package.py
+++ b/var/spack/repos/builtin/packages/audit-userspace/package.py
@@ -12,6 +12,7 @@ class AuditUserspace(AutotoolsPackage):
     homepage = "https://github.com/linux-audit/audit-userspace"
     url = "https://github.com/linux-audit/audit-userspace/archive/v2.8.5.tar.gz"
 
+    version("3.1.1", sha256="6a97cc472920639d736e9927353be05e323f351067fcf6e5d34439cafa0e9006")
     version("2.8.5", sha256="835ffdd65056ba0c26509dbf48882713b00dbe70e1d8cf25d538501136c2e3e9")
     version("2.8.4", sha256="089dfdceb38edf056202a6de4892fd0c9aaa964c08bd7806c5d0c7c33f09e18d")
     version("2.8.3", sha256="c239e3813b84bc264aaf2f796c131c1fe02960244f789ec2bd8d88aad4561b29")

--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -25,7 +25,7 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage):
     version("4.0", sha256="a9cd39277fb15d977d468435eb9b894f79f468233f0131509aa540ffda4f5953")
     version("main", branch="main")
     version("develop", branch="develop")
-    maintainers = ["tomdeakin", "kaanolgu" "tom91136", "robj0nes"]
+    maintainers("tomdeakin", "kaanolgu" "tom91136", "robj0nes")
 
     # Languages
     # Also supported variants are cuda and rocm (for HIP)

--- a/var/spack/repos/builtin/packages/babl/package.py
+++ b/var/spack/repos/builtin/packages/babl/package.py
@@ -19,6 +19,7 @@ class Babl(MesonPackage):
 
     maintainers("benkirk")
 
+    version("0.1.106", sha256="d325135d3304f088c134cc620013acf035de2e5d125a50a2d91054e7377c415f")
     version("0.1.102", sha256="a88bb28506575f95158c8c89df6e23686e50c8b9fea412bf49fe8b80002d84f0")
     version("0.1.98", sha256="f3b222f84e462735de63fa9c3651942f2b78fd314c73a22e05ff7c73afd23af1")
     version("0.1.96", sha256="33673fe459a983f411245a49f81fd7f1966af1ea8eca9b095a940c542b8545f6")

--- a/var/spack/repos/builtin/packages/bat/package.py
+++ b/var/spack/repos/builtin/packages/bat/package.py
@@ -12,6 +12,7 @@ class Bat(Package):
     homepage = "https://github.com/sharkdp/bat"
     url = "https://github.com/sharkdp/bat/archive/v0.13.0.tar.gz"
 
+    version("0.23.0", sha256="30b6256bea0143caebd08256e0a605280afbbc5eef7ce692f84621eb232a9b31")
     version("0.21.0", sha256="3dff1e52d577d0a105f4afe3fe7722a4a2b8bb2eb3e7a6a5284ac7add586a3ee")
     version("0.13.0", sha256="f4aee370013e2a3bc84c405738ed0ab6e334d3a9f22c18031a7ea008cd5abd2a")
     version("0.12.1", sha256="1dd184ddc9e5228ba94d19afc0b8b440bfc1819fef8133fe331e2c0ec9e3f8e2")

--- a/var/spack/repos/builtin/packages/bdii/package.py
+++ b/var/spack/repos/builtin/packages/bdii/package.py
@@ -17,6 +17,7 @@ class Bdii(MakefilePackage):
     homepage = "https://github.com/EGI-Foundation/bdii"
     url = "https://github.com/EGI-Foundation/bdii/archive/v5.2.25.tar.gz"
 
+    version("6.0.1", sha256="ac292559004881c4d5254517207a5da82d7a48af746194a380145dcedef507ce")
     version("5.2.25", sha256="6abc3ed872538a12dc470a1d30bf4ae1ca4d6302eb6b50370413940f9e9259ca")
     version("5.2.24", sha256="5d09ed06b8b09ce372b3489fab93e25302f68ca80d8fcc600c2535648c861a3a")
 

--- a/var/spack/repos/builtin/packages/beast-tracer/package.py
+++ b/var/spack/repos/builtin/packages/beast-tracer/package.py
@@ -15,6 +15,7 @@ class BeastTracer(Package):
     homepage = "https://beast.community/tracer"
     url = "https://github.com/beast-dev/tracer/archive/v1.7.1.tar.gz"
 
+    version("1.7.2", sha256="fd891e2244445fef71ab8010d8fab924abff2e5436e035bb335834e7c2e6d83b")
     version("1.7.1", sha256="947d51c5afa52354099b9b182ba6036e352356bd62df94031f33cdcb7e8effd3")
 
     depends_on("ant", type="build")

--- a/var/spack/repos/builtin/packages/c-raft/package.py
+++ b/var/spack/repos/builtin/packages/c-raft/package.py
@@ -14,7 +14,7 @@ class CRaft(AutotoolsPackage):
     git = "https://github.com/canonical/raft.git"
     url = "https://github.com/canonical/raft/archive/refs/tags/v0.17.1.tar.gz"
 
-    maintainers = ["mdorier"]
+    maintainers("mdorier")
 
     version("master", branch="master")
     version("0.17.1", sha256="e31c7fafbdd5f94913161c5d64341a203364e512524b47295c97a91e83c4198b")

--- a/var/spack/repos/builtin/packages/canal/package.py
+++ b/var/spack/repos/builtin/packages/canal/package.py
@@ -13,6 +13,7 @@ class Canal(MavenPackage):
     homepage = "https://github.com/alibaba/canal/wiki"
     url = "https://github.com/alibaba/canal/archive/canal-1.1.4.tar.gz"
 
+    version("1.1.6", sha256="2dd0997a69811a464e3d963e444760696931beb9326726b0064ad42f8a00c71b")
     version("1.1.4", sha256="740e0adac56d7f281cba21eca173eef3e8d42aa3e0fb49709f92cb6a1451dfbc")
     version("1.1.3", sha256="3fe75ca5eb5cb97eb35818426c1427542ccddb0de052cf154e948ef321822cbc")
     version("1.1.2", sha256="097190f952bdf09b835ed68966f5a98fa8308322a6aab11c1bfd16cec1800cf2")

--- a/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
@@ -17,7 +17,7 @@ class CbtfArgonavisGui(QMakePackage):
     homepage = "https://sourceforge.net/p/cbtf/wiki/Home/"
     git = "https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git"
 
-    maintainers = ["jgalarowicz"]
+    maintainers("jgalarowicz")
 
     version("develop", branch="master")
     version("1.3.0.0", branch="1.3.0.0")

--- a/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
@@ -15,7 +15,7 @@ class CbtfArgonavis(CMakePackage):
     homepage = "https://sourceforge.net/p/cbtf/wiki/Home/"
     git = "https://github.com/OpenSpeedShop/cbtf-argonavis.git"
 
-    maintainers = ["jgalarowicz"]
+    maintainers("jgalarowicz")
 
     version("develop", branch="master")
     version("1.9.4.1", branch="1.9.4.1")

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -18,7 +18,7 @@ class CbtfKrell(CMakePackage):
     homepage = "https://sourceforge.net/p/cbtf/wiki/Home/"
     git = "https://github.com/OpenSpeedShop/cbtf-krell.git"
 
-    maintainers = ["jgalarowicz"]
+    maintainers("jgalarowicz")
 
     version("develop", branch="master")
     version("1.9.4.1", branch="1.9.4.1")

--- a/var/spack/repos/builtin/packages/cbtf-lanl/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-lanl/package.py
@@ -13,7 +13,7 @@ class CbtfLanl(CMakePackage):
     homepage = "https://sourceforge.net/p/cbtf/wiki/Home/"
     git = "https://github.com/OpenSpeedShop/cbtf-lanl.git"
 
-    maintainers = ["jgalarowicz"]
+    maintainers("jgalarowicz")
 
     version("develop", branch="master")
     version("1.9.4.1", branch="1.9.4.1")

--- a/var/spack/repos/builtin/packages/cbtf/package.py
+++ b/var/spack/repos/builtin/packages/cbtf/package.py
@@ -18,7 +18,7 @@ class Cbtf(CMakePackage):
     homepage = "https://sourceforge.net/p/cbtf/wiki/Home"
     git = "https://github.com/OpenSpeedShop/cbtf.git"
 
-    maintainers = ["jgalarowicz"]
+    maintainers("jgalarowicz")
 
     version("develop", branch="master")
     version("1.9.4.1", branch="1.9.4.1")

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -17,7 +17,12 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
 
     maintainers("sethrj")
 
-    version("0.2.1", sha256="b3717b43f70dd0da848139da4171ca7a887bb6777908845b6d953d47b1f4db41")
+    version("0.2.2", sha256="ba5e341d636e00e3d7dbac13a2016b97014917489f46b8b387a2adf9d9563872")
+    version(
+        "0.2.1",
+        sha256="b3717b43f70dd0da848139da4171ca7a887bb6777908845b6d953d47b1f4db41",
+        deprecated=True,
+    )
     version(
         "0.2.0",
         sha256="12af28fda0e482a9eba89781b4ead445cf6f170bc1b8d88cc814e49b1ec09e9f",

--- a/var/spack/repos/builtin/packages/circos/package.py
+++ b/var/spack/repos/builtin/packages/circos/package.py
@@ -14,6 +14,7 @@ class Circos(Package):
     homepage = "http://circos.ca/"
     url = "http://circos.ca/distribution/circos-0.69-6.tgz"
 
+    version("0.69-9", sha256="34d8d7ebebf3f553d62820f8f4a0a57814b610341f836b4740c46c3057f789d2")
     version("0.69-6", sha256="52d29bfd294992199f738a8d546a49754b0125319a1685a28daca71348291566")
 
     depends_on("perl", type="run")

--- a/var/spack/repos/builtin/packages/code-server/package.py
+++ b/var/spack/repos/builtin/packages/code-server/package.py
@@ -13,6 +13,7 @@ class CodeServer(Package):
     homepage = "https://coder.com/docs/code-server/latest"
     url = "https://github.com/coder/code-server/releases/download/v4.4.0/code-server-4.4.0-linux-amd64.tar.gz"
 
+    version("4.12.0", sha256="d50ee947c4144a6ff2656e664ecbb3f70b75168b8a6e8c3eef47787f3c240c26")
     version("4.11.0", sha256="4eb233054941ec298caec6fc84dfba0a72c1bc5fadc0fe4896b10f3f4a291d51")
     version("4.10.1", sha256="f34ce611a9c058982a5e9d200fdf009788e3a564e970b053f4145574bce21b09")
     version("4.4.0", sha256="e3dd265acb18c2230c72d19bbce619ac5c1bd800ebb26e5e169c4d613069500d")

--- a/var/spack/repos/builtin/packages/codec2/package.py
+++ b/var/spack/repos/builtin/packages/codec2/package.py
@@ -14,5 +14,6 @@ class Codec2(CMakePackage):
     homepage = "https://www.rowetel.com/?page_id=452"
     url = "https://github.com/drowe67/codec2/archive/v0.9.2.tar.gz"
 
+    version("1.1.0", sha256="d56ba661008a780b823d576a5a2742c94d0b0507574643a7d4f54c76134826a3")
     version("1.0.5", sha256="cd9a065dd1c3477f6172a0156294f767688847e4d170103d1f08b3a075f82826")
     version("0.9.2", sha256="19181a446f4df3e6d616b50cabdac4485abb9cd3242cf312a0785f892ed4c76c")

--- a/var/spack/repos/builtin/packages/coin3d/package.py
+++ b/var/spack/repos/builtin/packages/coin3d/package.py
@@ -7,16 +7,23 @@ from spack.package import *
 from spack.pkg.builtin.boost import Boost
 
 
-class Coin3d(AutotoolsPackage):
+class Coin3d(AutotoolsPackage, CMakePackage):
     """Coin is an OpenGL-based, 3D graphics library that has its roots in the
     Open Inventor 2.1 API, which Coin still is compatible with."""
 
     homepage = "https://github.com/coin3d/coin"
-    url = "https://github.com/coin3d/coin/archive/Coin-4.0.0.tar.gz"
+    url = "https://github.com/coin3d/coin/releases/download/Coin-4.0.0/coin-4.0.0-src.tar.gz"
 
+    version("4.0.0", sha256="e4f4bd57804b8ed0e017424ad2e45c112912a928b83f86c89963df9015251476")
     version("3.1.0", sha256="70dd5ef39406e1d9e05eeadd54a5b51884a143e127530876a97744ca54173dc3")
     version("3.0.0", sha256="d5c2eb0ecaa5c83d93daf0e9e275e58a6a8dfadc74c873d51b0c939011f81bfa")
     version("2.0.0", sha256="6d26435aa962d085b7accd306a0b478069a7de1bc5ca24e22344971852dd097c")
+
+    build_system(
+        conditional("cmake", when="@4.0.0:"),
+        conditional("autotools", when="@:3.1.0"),
+        default="cmake",
+    )
 
     depends_on("boost@1.45.0:", type="build")
 
@@ -40,9 +47,31 @@ class Coin3d(AutotoolsPackage):
 
     variant("framework", default=False, description="Do 'UNIX-style' installation on Mac OS X")
     variant("shared", default=True, description="Build shared library (off: build static library)")
-    variant("debug", default=False, description="Make debug build")
-    variant("symbols", default=False, description="Enable debug symbols")
+    variant("debug", default=False, description="Make debug build", when="build_system=autotools")
+    variant(
+        "symbols", default=False, description="Enable debug symbols", when="build_system=autotools"
+    )
 
+    def url_for_version(self, version):
+        if version >= Version("4.0.0"):
+            url = "https://github.com/coin3d/coin/releases/download/Coin-{0}/coin-{0}-src.tar.gz"
+        else:
+            url = "https://github.com/coin3d/coin/archive/Coin-{0}.tar.gz"
+        return url.format(version.dotted)
+
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("COIN_BUILD_DOCUMENTATION_MAN", "man"),
+            self.define_from_variant("COIN_BUILD_DOCUMENTATION_CHM", "html"),
+            self.define_from_variant("COIN_BUILD_MAC_FRAMEWORK", "framework"),
+            self.define_from_variant("COIN_BUILD_SHARED_LIBS", "shared"),
+        ]
+        return args
+
+
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         args += self.enable_or_disable("framework")

--- a/var/spack/repos/builtin/packages/coinutils/package.py
+++ b/var/spack/repos/builtin/packages/coinutils/package.py
@@ -14,6 +14,7 @@ class Coinutils(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Coinutils"
     url = "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
 
+    version("2.11.9", sha256="15d572ace4cd3b7c8ce117081b65a2bd5b5a4ebaba54fadc99c7a244160f88b8")
     version("2.11.6", sha256="6ea31d5214f7eb27fa3ffb2bdad7ec96499dd2aaaeb4a7d0abd90ef852fc79ca")
     version("2.11.4", sha256="d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81")
 

--- a/var/spack/repos/builtin/packages/cpp-httplib/package.py
+++ b/var/spack/repos/builtin/packages/cpp-httplib/package.py
@@ -12,6 +12,7 @@ class CppHttplib(CMakePackage):
     homepage = "https://github.com/yhirose/cpp-httplib/"
     url = "https://github.com/yhirose/cpp-httplib/archive/v0.5.10.tar.gz"
 
+    version("0.12.3", sha256="175ced3c9cdaf221e9edf210297568d8f7d402a41d6db01254ac9e0b25487c54")
     version("0.5.9", sha256="c9e7aef3b0d4e80ee533d10413508d8a6e09a67d0d59646c43111f3993de006e")
     version("0.5.8", sha256="184d4fe79fc836ee26aa8635b3240879af4c6f17257fc7063d0b77a0cf856dfc")
     version("0.5.7", sha256="27b7f6346bdeb1ead9d17bd7cea89d9ad491f50f0479081053cc6e5742a89e64")

--- a/var/spack/repos/builtin/packages/cronie/package.py
+++ b/var/spack/repos/builtin/packages/cronie/package.py
@@ -13,6 +13,7 @@ class Cronie(AutotoolsPackage):
     homepage = "https://github.com/cronie-crond/cronie"
     url = "https://github.com/cronie-crond/cronie/archive/cronie-1.5.5.tar.gz"
 
+    version("1.6.1", sha256="1ddbc8f8d07dfe1d45998b0a0cbd9a216cd4d7bc64d1626b2bc8b3a69e4641d1")
     version("1.5.5", sha256="22c2a2b22577c0f776c1268d0e0f305c5c041e10155022a345b43b665da0ffe9")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -18,7 +18,7 @@ class CrtmFix(Package):
         "BenjaminTJohnson", "edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "climbfuji"
     )
 
-    version("2.4.0_emc", sha256="88d659ae5bc4434f7fafa232ff65b4c48442d2d1a25f8fc96078094fa572ac1a")
+    version("2.4.0_emc", sha256="d0f1b2ae2905457f4c3731746892aaa8f6b84ee0691f6228dfbe48917df1e85e")
     version("2.3.0_emc", sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924")
 
     variant("big_endian", default=True, description="Install big_endian fix files")

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -9,6 +9,24 @@ import platform
 from spack.package import *
 
 _versions = {
+    # cuDNN 8.7.0
+    "8.7.0.84-11.8": {
+        "Linux-x86_64": "976c4cba7233c97ae74006afab5172976300ba40f5b250a21f8cf71f59c9f76d",
+        "Linux-ppc64le": "0433d6d8b6841298e049e8a542750aa330a6e046a52ad95fae0c2f75dabe5575",
+        "Linux-aarch64": "cf967f78dbf6c075243cc83aa18759e370db3754aa15b12a0a14e8bf67a3a9d4",
+    },
+    # cuDNN 8.6.0
+    "8.6.0.163-11.8": {
+        "Linux-x86_64": "bbc396df47294c657edc09c600674d608cb1bfc80b82dcf4547060c21711159e",
+        "Linux-ppc64le": "c8a25e7e3df1bb9c4e18a4f24dd5f25cfd4bbe8b7054e34008e53b2be4f58a80",
+        "Linux-aarch64": "a0202278d3cbd4f3adc3f7816bff6071621cb042b0903698b477acac8928ac06",
+    },
+    # cuDNN 8.5.0
+    "8.5.0.96-11.7": {
+        "Linux-x86_64": "5454a6fd94f008728caae9adad993c4e85ef36302e26bce43bea7d458a5e7b6d",
+        "Linux-ppc64le": "00373c3d5e0b536a5557d0d0eb50706777f213a222b4030e1b71b1bec43d205f",
+        "Linux-aarch64": "86780abbecd4634e7363fad1d000ae23b7905a5f8383bddbf7332c6934791dde",
+    },
     # cuDNN 8.4.0
     "8.4.0.27-11.6": {
         "Linux-x86_64": "d19bdafd9800c79d29e6f6fffa9f9e2c10d1132d6c2ff10b1593e057e74dd050",
@@ -298,8 +316,12 @@ class Cudnn(Package):
             ver = version[:2]
             cuda = version[2:]
 
+        # 8.5.0 removed minor from cuda version
+        if version >= Version("8.5.0"):
+            url = "https://developer.download.nvidia.com/compute/redist/cudnn/v{0}/cudnn-{1}-{2}_cuda{3}-archive.tar.xz"
+            return url.format(directory, sys_key, ver, cuda.up_to(1))
         # 8.3.1 switched to xzip tarballs and reordered url parts.
-        if version >= Version("8.3.1"):
+        elif version >= Version("8.3.1"):
             url = "https://developer.download.nvidia.com/compute/redist/cudnn/v{0}/cudnn-{1}-{2}_cuda{3}-archive.tar.xz"
             return url.format(directory, sys_key, ver, cuda)
         else:

--- a/var/spack/repos/builtin/packages/cups/package.py
+++ b/var/spack/repos/builtin/packages/cups/package.py
@@ -16,6 +16,7 @@ class Cups(AutotoolsPackage):
     homepage = "https://www.cups.org/"
     url = "https://github.com/apple/cups/releases/download/v2.2.3/cups-2.2.3-source.tar.gz"
 
+    version("2.3.3", sha256="261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee")
     version("2.2.3", sha256="66701fe15838f2c892052c913bde1ba106bbee2e0a953c955a62ecacce76885f")
 
     depends_on("gnutls")

--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -12,6 +12,8 @@ class Davix(CMakePackage):
     homepage = "https://davix.web.cern.ch/davix/docs/devel/index.html"
     url = "https://github.com/cern-fts/davix/releases/download/R_0_8_1/davix-0.8.1.tar.gz"
 
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb")
+
     version("0.8.1", sha256="3f42f4eadaf560ab80984535ffa096d3e88287d631960b2193e84cf29a5fe3a6")
     version("0.8.0", sha256="2f108da0408a83fb5b9f0c68150d360ba733e4b3a0fe298d45b0d32d28ab7124")
     version("0.7.6", sha256="a2e7fdff29f7ba247a3bcdb08ab1db6d6ed745de2d3971b46526986caf360673")
@@ -33,8 +35,15 @@ class Davix(CMakePackage):
     depends_on("uuid")
     depends_on("openssl")
 
+    variant("thirdparty", default=False)
+    depends_on("gsoap", when="+thirdparty")
+
     def cmake_args(self):
-        cmake_args = ["-DCMAKE_CXX_STANDARD={0}".format(self.spec.variants["cxxstd"].value)]
+        cmake_args = [
+            self.define_from_variant("CMAKE_CXX_STANDARD", variant="cxxstd"),
+            self.define_from_variant("ENABLE_THIRD_PARTY_COPY", variant="thirdparty"),
+        ]
+
         if "darwin" in self.spec.architecture:
             cmake_args.append("-DCMAKE_MACOSX_RPATH=ON")
         return cmake_args

--- a/var/spack/repos/builtin/packages/diamond/package.py
+++ b/var/spack/repos/builtin/packages/diamond/package.py
@@ -14,6 +14,7 @@ class Diamond(CMakePackage):
     url = "https://github.com/bbuchfink/diamond/archive/v2.0.9.tar.gz"
     maintainers("snehring")
 
+    version("2.1.6", sha256="852d27c7535d53f1ce59db0625ff23ac3bf17e57f7a3b1c46c08718f77e19c54")
     version("2.0.15", sha256="cc8e1f3fd357d286cf6585b21321bd25af69aae16ae1a8f605ea603c1886ffa4")
     version("2.0.14", sha256="3eaef2b957e4ba845eac27a2ca3249aae4259ff1fe0ff5a21b094481328fdc53")
     version("2.0.11", sha256="41f3197aaafff9c42763fb7658b67f730ebc6dd3c0533c9c3d54bd3166e93f24")

--- a/var/spack/repos/builtin/packages/dlb/package.py
+++ b/var/spack/repos/builtin/packages/dlb/package.py
@@ -20,6 +20,7 @@ class Dlb(AutotoolsPackage):
     maintainers("vlopezh")
 
     version("main", branch="main")
+    version("3.3", sha256="55b87aea14f3954d8878912f3134938db235e6984fae26fdf5134148007eb722")
     version("3.2", sha256="b1c65ce3179b5275cfdf0bf921c0565a4a3ebcfdab72d7cef014957c17136c7e")
     version("3.1", sha256="d63ee89429fdb54af5510ed956f86d11561911a7860b46324f25200d32d0d333")
     version("3.0.2", sha256="75b6cf83ea24bb0862db4ed86d073f335200a0b54e8af8fee6dcf32da443b6b8")

--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -16,6 +16,7 @@ class Dos2unix(MakefilePackage):
 
     maintainers("cessenat")
 
+    version("7.4.4", sha256="28a841db0bd5827d645caba9d8015e3a71983dc6e398070b5287ee137ae4436e")
     version("7.4.2", sha256="6035c58df6ea2832e868b599dfa0d60ad41ca3ecc8aa27822c4b7a9789d3ae01")
     version("7.3.4", sha256="8ccda7bbc5a2f903dafd95900abb5bf5e77a769b572ef25150fde4056c5f30c5")
 

--- a/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
+++ b/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
@@ -17,7 +17,7 @@ class DoubleBatchedFftLibrary(CMakePackage):
     url = "https://github.com/intel/double-batched-fft-library/archive/refs/tags/v0.3.6.tar.gz"
     git = "https://github.com/intel/double-batched-fft-library.git"
 
-    maintainers = ["uphoffc"]
+    maintainers("uphoffc")
 
     version("main", branch="main")
     version("develop", branch="develop")

--- a/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
+++ b/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
@@ -21,6 +21,7 @@ class DoubleBatchedFftLibrary(CMakePackage):
 
     version("main", branch="main")
     version("develop", branch="develop")
+    version("0.4.0", sha256="f3518012b632c92c2a933d70a040d6b0eee2d631ab6b1881a192a8d1624f242d")
     version("0.3.6", sha256="ff163251d77d3c686563141e871c702bf4997c0302d53616add55d6cf9b02d28")
 
     variant("shared", default=True, description="Shared library")

--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -16,7 +16,7 @@ class Dpmjet(MakefilePackage):
     list_url = "https://github.com/DPMJET/DPMJET/tags"
     git = "https://github.com/DPMJET/DPMJET.git"
 
-    maintainers = ["wdconinc"]
+    maintainers("wdconinc")
 
     version("19.3.5", sha256="5a546ca20f86abaecda1828eb5b577aee8a532dffb2c5e7244667d5f25777909")
     version("19.3.4", sha256="646f520aa67ef6355c45cde155a5dd55f7c9d661314358a7668f6ff472f5d5f9")

--- a/var/spack/repos/builtin/packages/dust/package.py
+++ b/var/spack/repos/builtin/packages/dust/package.py
@@ -14,6 +14,7 @@ class Dust(Package):
 
     maintainers("fangohr")
 
+    version("0.8.6", sha256="feede818e814011207c5bfeaf06dd9fc95825c59ab70942aa9b9314791c5d6b6")
     version("0.7.5", sha256="f892aaf7a0a7852e12d01b2ced6c2484fb6dc5fe7562abdf0c44a2d08aa52618")
 
     depends_on("rust")

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -152,7 +152,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     # Fortran support with ascent is problematic on some Cray platforms so the
     # SDK is explicitly disabling it until the issues are resolved.
     dav_sdk_depends_on(
-        "ascent+mpi~fortran+openmp+python+shared+vtkh+dray~test",
+        "ascent+mpi~fortran+python+shared+vtkh+dray~test",
         when="+ascent",
         propagate=["adios2", "cuda"] + cuda_arch_variants,
     )

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import sys
 
 from spack.package import *
@@ -97,18 +98,32 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
 
         return args
 
-    def _test_check_versions(self):
-        """Perform version checks on installed package binaries."""
-        checks = ["ctags", "ebrowse", "emacs", "emacsclient", "etags"]
+    def run_version_check(self, bin):
+        """Runs and checks output of the installed binary."""
+        exe_path = join_path(self.prefix.bin, bin)
+        if not os.path.exists(exe_path):
+            raise SkipTest(f"{exe_path} is not installed")
 
-        for exe in checks:
-            expected = str(self.spec.version)
-            reason = "test version of {0} is {1}".format(exe, expected)
-            self.run_test(
-                exe, ["--version"], expected, installed=True, purpose=reason, skip_missing=True
-            )
+        exe = which(exe_path)
+        out = exe("--version", output=str.split, error=str.split)
+        assert str(self.spec.version) in out
 
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        # Simple version check tests on known binaries
-        self._test_check_versions()
+    def test_ctags(self):
+        """check ctags version"""
+        self.run_version_check("ctags")
+
+    def test_ebrowse(self):
+        """check ebrowse version"""
+        self.run_version_check("ebrowse")
+
+    def test_emacs(self):
+        """check emacs version"""
+        self.run_version_check("emacs")
+
+    def test_emacsclient(self):
+        """check emacsclient version"""
+        self.run_version_check("emacsclient")
+
+    def test_etags(self):
+        """check etags version"""
+        self.run_version_check("etags")

--- a/var/spack/repos/builtin/packages/entt/package.py
+++ b/var/spack/repos/builtin/packages/entt/package.py
@@ -14,6 +14,7 @@ class Entt(CMakePackage):
     homepage = "https://entt.docsforge.com"
     url = "https://github.com/skypjack/entt/archive/v3.5.2.tar.gz"
 
+    version("3.11.1", sha256="0ac010f232d3089200c5e545bcbd6480cf68b705de6930d8ff7cdb0a29f5b47b")
     version("3.5.2", sha256="f9271293c44518386c402c9a2188627819748f66302df48af4f6d08e30661036")
 
     depends_on("cmake@3.7.0:", type="build")

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -13,12 +13,13 @@ class EnvironmentModules(Package):
     """
 
     homepage = "https://cea-hpc.github.io/modules/"
-    url = "https://github.com/cea-hpc/modules/releases/download/v5.2.0/modules-5.2.0.tar.gz"
+    url = "https://github.com/cea-hpc/modules/releases/download/v5.3.0/modules-5.3.0.tar.gz"
     git = "https://github.com/cea-hpc/modules.git"
 
     maintainers("xdelaruelle")
 
     version("main", branch="main")
+    version("5.3.0", sha256="21b8daa0181044ef65097a1e3517af1f24e7c7343cc5bdaf70be11e3cb0edb51")
     version("5.2.0", sha256="48f9f10864303df628a48cab17074820a6251ad8cd7d66dd62aa7798af479254")
     version("5.1.1", sha256="1985f79e0337f63d6564b08db0238cf96a276a4184def822bb8ad37996dc8295")
     version("5.1.0", sha256="1ab1e859b9c8bca8a8d332945366567fae4cf8dd7e312a689daaff46e7ffa949")

--- a/var/spack/repos/builtin/packages/estarlight/package.py
+++ b/var/spack/repos/builtin/packages/estarlight/package.py
@@ -16,7 +16,7 @@ class Estarlight(CMakePackage):
     list_url = "https://github.com/eic/estarlight/tags"
     git = "https://github.com/eic/estarlight.git"
 
-    maintainers = ["wdconinc"]
+    maintainers("wdconinc")
 
     version("master", branch="master")
     version("1.0.1", sha256="b43c1dd3663d8f325f30b17dd7cf4b49f2eb8ceeed7319c5aabebec8676279fd")

--- a/var/spack/repos/builtin/packages/f3d/package.py
+++ b/var/spack/repos/builtin/packages/f3d/package.py
@@ -12,6 +12,7 @@ class F3d(CMakePackage):
     homepage = "https://f3d-app.github.io"
     url = "https://github.com/f3d-app/f3d/archive/refs/tags/v1.1.1.tar.gz"
 
+    version("2.0.0", sha256="5b335de78a9f68903d7023d947090d4b36fa15b9e165749906a82153e0f56d05")
     version("1.1.1", sha256="68bdbe3a90f2cd553d5e090a95d3c847e2a2f06abbe225ffecd47d3d29978b0a")
 
     depends_on("vtk@9:", type="link")

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -21,6 +21,7 @@ class Flann(CMakePackage):
     homepage = "https://github.com/mariusmuja/flann"
     url = "https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz"
 
+    version("1.9.2", sha256="e26829bb0017f317d9cc45ab83ddcb8b16d75ada1ae07157006c1e7d601c8824")
     version("1.9.1", sha256="b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3")
     version("1.8.5", sha256="59a9925dac0705b281496ae52b5dfd79d6b69316d37015e3d3b38c859bac4f2f")
     version("1.8.4", sha256="ed5843113150b3d6bc4c325fecb51337838a9fc09ad64bdb6aea79d6e610ee13")
@@ -61,6 +62,7 @@ class Flann(CMakePackage):
     depends_on("cuda", when="+cuda")
     depends_on("mpi", when="+mpi")
     depends_on("hdf5", when="+hdf5")
+    depends_on("lz4", when="@1.9.2:")
     # HDF5_IS_PARALLEL actually comes from hdf5+mpi
     # https://github.com/mariusmuja/flann/blob/06a49513138009d19a1f4e0ace67fbff13270c69/CMakeLists.txt#L108-L112
     depends_on(
@@ -77,7 +79,7 @@ class Flann(CMakePackage):
     depends_on("googletest", type="test")
 
     # See: https://github.com/mariusmuja/flann/issues/369
-    patch("linux-gcc-cmakev3.11-plus.patch", when="%gcc^cmake@3.11:")
+    patch("linux-gcc-cmakev3.11-plus.patch", when="@:1.9.1%gcc^cmake@3.11:")
 
     def patch(self):
         # Fix up the python setup.py call inside the install(CODE

--- a/var/spack/repos/builtin/packages/flux-security/package.py
+++ b/var/spack/repos/builtin/packages/flux-security/package.py
@@ -1,0 +1,61 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import spack.util.executable
+from spack.package import *
+
+
+class FluxSecurity(AutotoolsPackage):
+    """Independent project for Flux security code and APIs."""
+
+    homepage = "https://github.com/flux-framework/flux-security"
+    url = "https://github.com/flux-framework/flux-security/releases/download/v0.8.0/flux-security-0.8.0.tar.gz"
+    git = "https://github.com/flux-framework/flux-security.git"
+    tags = ["radiuss", "e4s"]
+
+    maintainers("grondo")
+
+    version("master", branch="master")
+    version("0.8.0", sha256="9963628063b4abdff6bece03208444c8f23fbfda33c20544c48b21e9f4819ce2")
+
+    # Need autotools when building on master:
+    depends_on("autoconf", type="build", when="@master")
+    depends_on("automake", type="build", when="@master")
+    depends_on("libtool", type="build", when="@master")
+
+    depends_on("pkgconfig")
+    depends_on("libsodium@1.0.14:")
+    depends_on("jansson")
+    depends_on("libuuid")
+    depends_on("munge")
+    depends_on("libpam")
+
+    def setup(self):
+        pass
+
+    @when("@master")
+    def setup(self):
+        with working_dir(self.stage.source_path):
+            # Allow git-describe to get last tag so flux-version works:
+            git = which("git")
+            # When using spack develop, this will already be unshallow
+            try:
+                git("fetch", "--unshallow")
+                git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+                git("fetch", "origin")
+            except spack.util.executable.ProcessError:
+                git("fetch")
+
+    def autoreconf(self, spec, prefix):
+        self.setup()
+        if os.path.exists(self.configure_abs_path):
+            return
+        # make sure configure doesn't get confused by the staging symlink
+        with working_dir(self.configure_directory):
+            # Bootstrap with autotools
+            bash = which("bash")
+            bash("./autogen.sh")

--- a/var/spack/repos/builtin/packages/fplll/package.py
+++ b/var/spack/repos/builtin/packages/fplll/package.py
@@ -14,6 +14,7 @@ class Fplll(AutotoolsPackage):
     homepage = "https://github.com/fplll/fplll"
     url = "https://github.com/fplll/fplll/releases/download/5.4.0/fplll-5.4.0.tar.gz"
 
+    version("5.4.4", sha256="0fd9d378f04ff886d8864728baf5d90b8b0b82c1e541e92550644fb54f75691d")
     version("5.4.1", sha256="7bd887957173aa592091772c1c36f6aa606b3b2ace0d14e2c26c7463dcf2deb7")
     version("5.4.0", sha256="fe192a65a56439b098e26e3b7ee224dda7c2c73a58f36ef2cc6f9185ae8c482b")
     version("5.3.3", sha256="5e7c46c30623795feeac19cf607583b7c82b0490ceb91498f0f712789be20ccd")

--- a/var/spack/repos/builtin/packages/freecad/package.py
+++ b/var/spack/repos/builtin/packages/freecad/package.py
@@ -1,0 +1,59 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Freecad(CMakePackage):
+    """FreeCAD is an open-source parametric 3D modeler made primarily
+    to design real-life objects of any size. Parametric modeling
+    allows you to easily modify your design by going back into your
+    model history to change its parameters."""
+
+    homepage = "https://www.freecad.org/"
+    url = "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.20.2.tar.gz"
+
+    maintainers("aweits")
+
+    version("0.20.2", sha256="46922f3a477e742e1a89cd5346692d63aebb2b67af887b3e463e094a4ae055da")
+
+    depends_on("opencascade")
+    depends_on("xerces-c")
+    depends_on("vtk")
+    depends_on("salome-med")
+    depends_on(
+        "boost+python+filesystem+date_time+graph+iostreams+program_options+regex+serialization+system+thread"  # noqa: E501
+    )
+    depends_on("qt@5:")
+    depends_on("swig", type="build")
+    depends_on("netgen")
+    depends_on("pcl")
+    depends_on("coin3d")
+    depends_on("python")
+    depends_on("gmsh+opencascade")
+    depends_on("py-pyside2@1.2.4:", type=("build", "run"))
+    depends_on("py-matplotlib@3.0.2:", type=("build", "run"))
+    depends_on("py-six@1.12.0:", type=("build", "run"))
+    depends_on("py-markdown@3.2.2:", type=("build", "run"))
+    depends_on("py-pivy", type=("build", "run"))
+    depends_on("py-pybind11", type="build")
+
+    def patch(self):
+        filter_file(
+            "# include <Standard_TooManyUsers.hxx>", "", "src/Mod/Part/App/OCCError.h", string=True
+        )
+        filter_file('putenv("PYTHONPATH=");', "", "src/Main/MainGui.cpp", string=True)
+        filter_file('_putenv("PYTHONPATH=");', "", "src/Main/MainGui.cpp", string=True)
+
+    def cmake_args(self):
+        args = []
+        # requires qt5 + webkit, which requires python2
+        args.append("-DBUILD_WEB=OFF")
+        args.append("-DFREECAD_USE_PYBIND11:BOOL=ON")
+        args.append("-DFREECAD_USE_PCL:BOOL=ON")
+        # TODO:
+        #       args.append("-DBUILD_FEM_NETGEN:BOOL=ON")
+        #       args.append("-DNETGEN_INCLUDEDIR={}".format(self.spec["netgen"].prefix.include))
+        return args

--- a/var/spack/repos/builtin/packages/fullock/package.py
+++ b/var/spack/repos/builtin/packages/fullock/package.py
@@ -14,6 +14,7 @@ class Fullock(AutotoolsPackage):
     homepage = "https://antpick.ax/"
     url = "https://github.com/yahoojapan/fullock/archive/v1.0.36.tar.gz"
 
+    version("1.0.50", sha256="7222976883289376c1b88fd30ecd3ab2f055316103b97df4aa71192954072848")
     version("1.0.39", sha256="0089d4446e3102b5de39e3d18c1b7e5c9567deb77a4e60963e15b5c1b23a594d")
     version("1.0.36", sha256="68d0dc9036c2c1871653b4626a594f57663973c159f083ec68647c60ddc919f7")
     version("1.0.35", sha256="613462155271bf7b90ce745bafb47d23855e1b4813d3b6caa238efffb7c42841")

--- a/var/spack/repos/builtin/packages/funwave/package.py
+++ b/var/spack/repos/builtin/packages/funwave/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class Funwave(MakefilePackage):
+    """
+    What is FUNWAVE-TVD?
+    FUNWAVE-TVD is the Total Variation Diminishing (TVD) version of the fully nonlinear Boussinesq
+    wave model (FUNWAVE) developed by Shi et al. (2012). The FUNWAVE model was initially developed
+    by Kirby et al. (1998) based on Wei et al. (1995). The development of the present version was
+    motivated by recent needs for modeling of surfzone--cale optical properties in a Boussinesq
+    model framework, and modeling of Tsunami waves in both a global/coastal scale for prediction
+    of coastal inundation and a basin scale for wave propagation.
+    """
+
+    homepage = "https://fengyanshi.github.io/build/html/index.html"
+    git = "https://github.com/fengyanshi/FUNWAVE-TVD"
+
+    maintainers("stevenrbrandt", "fengyanshi")
+
+    version("3.2", tag="v3.2")
+    version("3.1", tag="v3.1")
+    version("3.0", tag="v3.0")
+
+    depends_on("mpi")
+
+    parallel = False
+
+    def build(self, spec, prefix):
+        with working_dir("./src"):
+            make()
+
+    def install(self, spec, prefix):
+        bin = os.path.join(prefix, "bin")
+        os.makedirs(bin, exist_ok=True)
+        copy("./src/funwave_vessel", os.path.join(bin, "funwave"))
+
+    def edit(self, spec, prefix):
+        with working_dir("./src"):
+            makefile = FileFilter("Makefile")
+            makefile.filter("FLAG_8 = -DCOUPLING", "#FLAG_8 = -DCOUPLING")

--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -20,6 +20,7 @@ class G2c(CMakePackage):
     variant("jasper", default=True)
     variant("openjpeg", default=False)
 
+    version("1.7.0", sha256="73afba9da382fed73ed8692d77fa037bb313280879cd4012a5e5697dccf55175")
     version("1.6.4", sha256="5129a772572a358296b05fbe846bd390c6a501254588c6a223623649aefacb9d")
     version("1.6.2", sha256="b5384b48e108293d7f764cdad458ac8ce436f26be330b02c69c2a75bb7eb9a2c")
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -37,6 +37,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     version("13.1.0", sha256="61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86")
 
+    version("12.3.0", sha256="949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b")
     version("12.2.0", sha256="e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff")
     version("12.1.0", sha256="62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b")
 

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -30,6 +30,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
 
     maintainers("adamjstewart")
 
+    version("3.7.0", sha256="af4b26a6b6b3509ae9ccf1fcc5104f7fe015ef2110f5ba13220816398365adce")
     version("3.6.4", sha256="889894cfff348c04ac65b462f629d03efc53ea56cf04de7662fbe81a364e3df1")
     version("3.6.3", sha256="3cccbed883b1fb99b913966aa3a650ad930e7c3afc714f5823f9754176ee49ea")
     version("3.6.2", sha256="35f40d2e08061b342513cdcddc2b997b3814ef8254514f0ef1e8bc7aa56cf681")
@@ -204,7 +205,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
         when="@2.1:",
         description="Used for linear interpolation of gdal_grid",
     )
-    variant("rasdaman", default=False, description="Required for Rasdaman driver")
+    variant("rasdaman", default=False, when="@:3.6", description="Required for Rasdaman driver")
     variant(
         "rasterlite2", default=False, when="@2.2:", description="Required for RasterLite2 driver"
     )
@@ -380,6 +381,9 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     depends_on("swig", type="build", when="+perl")
     depends_on("php", type=("build", "link", "run"), when="+php")
     depends_on("swig", type="build", when="+php")
+
+    # https://gdal.org/development/rfc/rfc88_googletest.html
+    depends_on("googletest@1.10:", type="test")
 
     # https://trac.osgeo.org/gdal/wiki/SupportedCompilers
     msg = "GDAL requires C++11 support"

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -20,6 +20,7 @@ class Geant4Data(BundlePackage):
 
     version("11.1.0")
     version("11.0.0")
+    version("10.7.4")
     version("10.7.3")
     version("10.7.2")
     version("10.7.1")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -28,6 +28,7 @@ class Geant4(CMakePackage):
     version("11.0.2", sha256="661e1ab6f42e58910472d771e76ffd16a2b411398eed70f39808762db707799e")
     version("11.0.1", sha256="fa76d0774346b7347b1fb1424e1c1e0502264a83e185995f3c462372994f84fa")
     version("11.0.0", sha256="04d11d4d9041507e7f86f48eb45c36430f2b6544a74c0ccaff632ac51d9644f1")
+    version("10.7.4", sha256="7e381f8945c75388b79af98b95be31a0933641c1af8d74ab9b6cf39d5aa98317")
     version("10.7.3", sha256="8615d93bd4178d34f31e19d67bc81720af67cdab1c8425af8523858dcddcf65b")
     version("10.7.2", sha256="593fc85883a361487b17548ba00553501f66a811b0a79039276bb75ad59528cf")
     version("10.7.1", sha256="2aa7cb4b231081e0a35d84c707be8f35e4edc4e97aad2b233943515476955293")
@@ -79,6 +80,7 @@ class Geant4(CMakePackage):
         "10.7.1",
         "10.7.2",
         "10.7.3",
+        "10.7.4",
         "11.0.0:11.0",
         "11.1:",
     ]:

--- a/var/spack/repos/builtin/packages/gegl/package.py
+++ b/var/spack/repos/builtin/packages/gegl/package.py
@@ -18,6 +18,7 @@ class Gegl(MesonPackage):
 
     maintainers("benkirk")
 
+    version("0.4.44", sha256="0a4cdb41635e406a0849cd0d3f03caf7d97cab8aa13d28707d532d0089d56126")
     version("0.4.42", sha256="aba83a0cbaa6c56edc29ea22f2e8172950a53b96daa51592083d59222bdde02d")
     version("0.4.40", sha256="cdde80d15a49dab9a614ef98f804c8ce6e4cfe1339a3c240c34f3fb45436b85d")
     version("0.4.38", sha256="e4a33c8430a5042fba8439b595348e71870f0d95fbf885ff553f9020c1bed750")

--- a/var/spack/repos/builtin/packages/getorganelle/package.py
+++ b/var/spack/repos/builtin/packages/getorganelle/package.py
@@ -12,7 +12,7 @@ class Getorganelle(PythonPackage):
     homepage = "https://github.com/Kinggerm/GetOrganelle"
     url = "https://github.com/Kinggerm/GetOrganelle/archive/refs/tags/1.7.5.0.tar.gz"
 
-    maintainers = ["snehring"]
+    maintainers("snehring")
 
     version("1.7.7.0", sha256="dd351b5cd33688adfcd8bff9794ae0cc0ce01a572dac2bcf6c9d7db77b3e4883")
     version("1.7.5.0", sha256="c498196737726cb4c0158f23037bf301a069f5028ece729bb4d09c7d915df93d")

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -39,13 +39,25 @@ class Go(Package):
 
     maintainers("alecbcs")
 
+    version("1.20.4", sha256="9f34ace128764b7a3a4b238b805856cc1b2184304df9e5690825b0710f4202d6")
     version("1.20.3", sha256="e447b498cde50215c4f7619e5124b0fc4e25fb5d16ea47271c47f278e7aa763a")
-    version("1.20.2", sha256="4d0e2850d197b4ddad3bdb0196300179d095bb3aefd4dfbc3b36702c3728f8ab")
 
+    version("1.19.9", sha256="131190a4697a70c5b1d232df5d3f55a3f9ec0e78e40516196ffb3f09ae6a5744")
     version("1.19.8", sha256="1d7a67929dccafeaf8a29e55985bc2b789e0499cb1a17100039f084e3238da2f")
-    version("1.19.7", sha256="775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633")
 
     # Deprecated Versions
+    # https://nvd.nist.gov/vuln/detail/CVE-2023-24538
+    version(
+        "1.20.2",
+        sha256="4d0e2850d197b4ddad3bdb0196300179d095bb3aefd4dfbc3b36702c3728f8ab",
+        deprecated=True,
+    )
+    version(
+        "1.19.7",
+        sha256="775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633",
+        deprecated=True,
+    )
+
     # https://nvd.nist.gov/vuln/detail/CVE-2023-24532
     version(
         "1.20.1",

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -19,6 +19,7 @@ class Graphviz(AutotoolsPackage):
     git = "https://gitlab.com/graphviz/graphviz.git"
     url = "https://gitlab.com/graphviz/graphviz/-/archive/2.46.0/graphviz-2.46.0.tar.bz2"
 
+    version("8.0.5", sha256="c1901fe52483fad55fbf893ccd59a3dcaedd53f0d50b5aebbbf3deaba93b674d")
     version("8.0.1", sha256="19928f09f759676578b50101420b24475eb35f712ffbe8a97254f64b20fdbd03")
     version("7.1.0", sha256="7943c3fa0c55c779f595259f3b9e41c7ea6ed92f0aca0d24df917f631322dc01")
     version("2.49.0", sha256="b129555743bb9bfb7b63c55825da51763b2f1ee7c0eaa6234a42a61a3aff6cc9")

--- a/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
+++ b/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
@@ -12,7 +12,7 @@ class GsiNcdiag(CMakePackage):
     homepage = "https://github.com/NOAA-EMC/GSI-ncdiag"
     url = "https://github.com/NOAA-EMC/GSI-ncdiag/archive/refs/tags/v1.0.0.tar.gz"
 
-    maintainers = ["ulmononian"]
+    maintainers("ulmononian")
 
     version("1.0.0", sha256="7251d6139c2bc1580db5f7f019e10a4c73d188ddd52ccf21ecc9e39d50a6af51")
 

--- a/var/spack/repos/builtin/packages/gsl-lite/package.py
+++ b/var/spack/repos/builtin/packages/gsl-lite/package.py
@@ -17,6 +17,7 @@ class GslLite(CMakePackage):
 
     maintainers("AlexanderRichert-NOAA", "climbfuji", "edwardhartnett", "Hang-Lei-NOAA")
 
+    version("0.41.0", sha256="4682d8a60260321b92555760be3b9caab60e2a71f95eddbdfb91e557ee93302a")
     version("0.40.0", commit="d6c8af99a1d95b3db36f26b4f22dc3bad89952de")
     version("0.39.0", commit="d0903fa87ff579c30f608bc363582e6563570342")
     version("0.38.1", sha256="c2fa2315fff312f3897958903ed4d4e027f73fa44235459ecb467ad7b7d62b18")

--- a/var/spack/repos/builtin/packages/gsoap/package.py
+++ b/var/spack/repos/builtin/packages/gsoap/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gsoap(AutotoolsPackage, SourceforgePackage):
+    """The gSOAP toolkit is an extensive suite of portable C and C++
+    software to develop XML Web services with powerful type-safe XML
+    data bindings."""
+
+    homepage = "https://www.genivia.com/products.html"
+
+    sourceforge_mirror_path = "gsoap2/gsoap_2.8.127.zip"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    version("2.8.127", sha256="25ecad1bbc363494eb7ea95a68508e4c93cc20596fad9ebc196c6572bbbd3c08")
+    version("2.8.124", sha256="4b798780989338f665ef8e171bbcc422a271004d62d5852666d5eeca33a6a636")
+    version("2.8.119", sha256="8997c43b599a2bfe4a788e303a5dd24bbf5992fd06d56f606ca680ca5b0070cf")
+    version("2.8.114", sha256="aa70a999258100c170a3f8750c1f91318a477d440f6a28117f68bc1ded32327f")
+    version("2.8.113", sha256="e73782b618303cf55ea6a45751b75ba96797a7a12967ed9d02e6d5761977e73a")
+    version("2.8.112", sha256="05345312e0bb4d81c98ae63b97cff9eb097f38dafe09356189f9d8e235c54095")
+    version("2.8.111", sha256="f1670c7e3aeaa66bc5658539fbd162e5099f022666855ef2b2c2bac07fec4bd3")
+
+    depends_on("openssl")
+    depends_on("pkgconfig", type="build")
+    depends_on("bison", type="build")
+    depends_on("flex", type="build")
+
+    def configure_args(self):
+        return ["--enable-ipv6"]
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path("PKG_CONFIG_PATH", "%s/lib/ldconfig" % self.prefix)
+
+    def flag_handler(self, name, flags):
+        if name in ["cflags", "cxxflags", "cppflags"]:
+            flags.append(self.compiler.cc_pic_flag)
+
+        return self.build_system_flags(name, flags)

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -18,6 +18,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
         conditional("autotools", when="@:2.9"), conditional("meson", when="@3:"), default="meson"
     )
 
+    version("7.2.0", sha256="fc5560c807eae0efd5f95b5aa4c65800c7a8eed6642008a6b1e7e3ffff7873cc")
     version("6.0.0", sha256="1d1010a1751d076d5291e433c138502a794d679a7498d1268ee21e2d4a140eb4")
     version(
         "5.3.1",

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -46,6 +46,11 @@ class Hdf5(CMakePackage):
 
     # Even versions are maintenance versions
     version(
+        "1.14.1-2",
+        sha256="cbe93f275d5231df28ced9549253793e40cd2b555e3d288df09d7b89a9967b07",
+        preferred=True,
+    )
+    version(
         "1.14.0",
         sha256="a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4",
         preferred=True,

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -687,24 +687,6 @@ class Hdf5(CMakePackage):
                         symlink(src_filename, tgt_filename)
 
     @run_after("install")
-    def fix_showconfig(self):
-        # The 'Extra libraries' entry of the 'h5cc -showconfig' command is a space-separated list
-        # of linker flags if the package is installed with Autotools, and a semicolon-separated
-        # list of library names if the package is installed with CMake. There are use cases that
-        # rely on the old Autotools behavior. Here, we make sure that the output of the command
-        # looks like it was before we switch to CMake.
-        filter_file(
-            r"^(\s*Extra libraries: )(.*)",
-            lambda match: "{0}{1}".format(
-                match.group(1),
-                " ".join("-l{0}".format(name) for name in filter(None, match.group(2).split(";"))),
-            ),
-            self.prefix.lib.join("libhdf5.settings"),
-            backup=False,
-            ignore_absent=True,
-        )
-
-    @run_after("install")
     @on_package_attributes(run_tests=True)
     def check_install(self):
         self._check_install()

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -687,6 +687,24 @@ class Hdf5(CMakePackage):
                         symlink(src_filename, tgt_filename)
 
     @run_after("install")
+    def fix_showconfig(self):
+        # The 'Extra libraries' entry of the 'h5cc -showconfig' command is a space-separated list
+        # of linker flags if the package is installed with Autotools, and a semicolon-separated
+        # list of library names if the package is installed with CMake. There are use cases that
+        # rely on the old Autotools behavior. Here, we make sure that the output of the command
+        # looks like it was before we switch to CMake.
+        filter_file(
+            r"^(\s*Extra libraries: )(.*)",
+            lambda match: "{0}{1}".format(
+                match.group(1),
+                " ".join("-l{0}".format(name) for name in filter(None, match.group(2).split(";"))),
+            ),
+            self.prefix.lib.join("libhdf5.settings"),
+            backup=False,
+            ignore_absent=True,
+        )
+
+    @run_after("install")
     @on_package_attributes(run_tests=True)
     def check_install(self):
         self._check_install()

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -176,9 +176,7 @@ class Hwloc(AutotoolsPackage, CudaPackage, ROCmPackage):
             args.append("--with-rocm={0}".format(self.spec["hip"].prefix))
             args.append("--with-rocm-version={0}".format(self.spec["hip"].version))
 
-        if "+netloc" in self.spec:
-            args.append("--enable-netloc")
-
+        args.extend(self.enable_or_disable("netloc"))
         args.extend(self.enable_or_disable("cairo"))
         args.extend(self.enable_or_disable("nvml"))
         args.extend(self.enable_or_disable("gl"))

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -167,7 +167,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         if "threads=tbb" in self.spec:
             libs.append("libmkl_tbb_thread")
         elif "threads=openmp" in self.spec:
-            libs.append("libmkl_intel_thread")
+            if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
+                libs.append("libmkl_intel_thread")
+            else:
+                libs.append("libmkl_gnu_thread")
         else:
             libs.append("libmkl_sequential")
 

--- a/var/spack/repos/builtin/packages/intel-pin/package.py
+++ b/var/spack/repos/builtin/packages/intel-pin/package.py
@@ -17,6 +17,66 @@ class IntelPin(Package):
     maintainers("matthiasdiener")
 
     version(
+        "3.27",
+        sha256="e7d44d25668632007d5a109e5033415e91db543b8ce9e665893a05e852b67707",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.27-98718-gbeaa5d51e-gcc-linux.tar.gz",
+    )
+    version(
+        "3.26",
+        sha256="92ef29a2616b63105b8081157c24c50236e34ea6fc13e4a06fe6894bdc700478",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.26-98690-g1fc9d60e6-gcc-linux.tar.gz",
+    )
+    version(
+        "3.25",
+        sha256="43c0f441234b0e5cb65caf9714e61d3316f1e4ddf77865731121930a05865fa1",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.25-98650-g8f6168173-gcc-linux.tar.gz",
+    )
+    version(
+        "3.24",
+        sha256="0b5183155d86a8aa7cbf7da968fbb37840c48cada94faadb9053489b75d373c8",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.24-98612-g6bd5931f2-gcc-linux.tar.gz",
+    )
+    version(
+        "3.23",
+        sha256="996090dfeec7dd58db1babbc3c95f8e4abfcb9b0e1014b02ffdbc09224bb48c0",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.23-98579-gb15ab7903-gcc-linux.tar.gz",
+    )
+    version(
+        "3.22",
+        sha256="550fdc15e02d03acc6a65a918887467945b7413089fb1080e238380aad3b95eb",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.22-98547-g7a303a835-gcc-linux.tar.gz",
+    )
+    version(
+        "3.21",
+        sha256="a0bd6640d7b4a53f78cf0a2df843b034f2e2ec38e77f018d8e3ef032360b0c5c",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.21-98484-ge7cd811fd-gcc-linux.tar.gz",
+    )
+    version(
+        "3.20",
+        sha256="ca2f542eee2013471961bb683d06ccb20ef5dd8ed0d02537cf4d47f09bd616bf",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.20-98437-gf02b61307-gcc-linux.tar.gz",
+    )
+    version(
+        "3.19",
+        sha256="3af8a86c229a28ecbabba3180bd6a35e013cc3d44a7496087c15db76fd43f86f",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.19-98425-gd666b2bee-gcc-linux.tar.gz",
+    )
+    version(
+        "3.18",
+        sha256="de8ef1a0cb301764a774aa9bcaae8cba997a7dde3155ed271e52d00acceb230b",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.18-98332-gaebd7b1e6-gcc-linux.tar.gz",
+    )
+    version(
+        "3.17",
+        sha256="a9cc3df7667b70dd44e51f66ed506bcdc31d942bb7698e1d4e1f8fe5d01c80bb",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.17-98314-g0c048d619-gcc-linux.tar.gz",
+    )
+    version(
+        "3.16",
+        sha256="c61abc4a3de48016cdbac9b567630557ec3dfa9b0394cc03ee7ed17d15c791b6",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.16-98275-ge0db48c31-gcc-linux.tar.gz",
+    )
+    version(
         "3.15",
         sha256="51ab5a381ff477335050b20943133965c5c515d074ad6afb801a898dae8af642",
         url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz",

--- a/var/spack/repos/builtin/packages/iso-codes/package.py
+++ b/var/spack/repos/builtin/packages/iso-codes/package.py
@@ -13,6 +13,7 @@ class IsoCodes(AutotoolsPackage):
     homepage = "https://salsa.debian.org/iso-codes-team/iso-codes"
     url = "https://deb.debian.org/debian/pool/main/i/iso-codes/iso-codes_4.3.orig.tar.xz"
 
+    version("4.15.0", sha256="3d50750bf1d62d83b6085f5815ceb8392df34266a15f16bcf8d4cf7eb15d245c")
     version("4.13.0", sha256="2d4d0e5c02327f52cf7c029202da72f2074348472c26904b7104d2be3e0750ef")
     version("4.3", sha256="643eb83b2d714e8650ed7112706968d057bf5b101ba71c8ef219e20f1737b141")
 

--- a/var/spack/repos/builtin/packages/jwt-cpp/package.py
+++ b/var/spack/repos/builtin/packages/jwt-cpp/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class JwtCpp(CMakePackage):
+    """A header only library for creating and validating JSON Web Tokens in C++11."""
+
+    homepage = "https://thalhammer.github.io/jwt-cpp/"
+    url = "https://github.com/Thalhammer/jwt-cpp/archive/refs/tags/v0.4.0.tar.gz"
+
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb")
+
+    version("0.6.0", sha256="0227bd6e0356b211341075c7997c837f0b388c01379bd256aa525566a5553f03")
+    version("0.5.2", sha256="d3188f9611597eb1bb285169879e1d87202bf10a08e4e7734c9f2097bfd4a850")
+    version("0.5.1", sha256="d8f5ffb361824630b3b6f4aad26c730c915081071040c232ac57947d6177ef4f")
+    version("0.5.0", sha256="079a273f070dd11213e301712319a65881e51ab81535cc436d5313191df852a2")
+    version("0.4.0", sha256="f0dcc7b0e8bef8f9c3f434e7121f9941145042c9fe3055a5bdd709085a4f2be4")
+
+    # TODO: jwt-cpp>=0.6.0 supports wolfSSL for which there is currently
+    # no Spack recipe.
+    variant(
+        "ssl",
+        default="openssl",
+        values=("openssl", "libressl"),
+        multi=False,
+        when="@0.5.0:",
+        description="SSL library to use",
+    )
+
+    depends_on("openssl@1.0.2:", when="@0.4.0:0.4.99")
+    depends_on("openssl@1.0.2:", when="@0.5.0:0.5.99 ssl=openssl")
+    depends_on("openssl@1.0.1:", when="@0.6.0: ssl=openssl")
+    depends_on("libressl@3:", when="@0.5.0: ssl=libressl")
+
+    def cmake_args(self):
+        spec = self.spec
+        define = self.define
+        args = []
+        if spec.satisfies("@0.5.0:"):
+            ssl_library_dict = {"openssl": "OpenSSL", "libressl": "LibreSSL"}
+            args.append(define("JWT_SSL_LIBRARY", ssl_library_dict[spec.variants["ssl"].value]))
+            args += [define("JWT_BUILD_TESTS", False), define("JWT_BUILD_EXAMPLES", False)]
+        else:
+            args.append(define("BUILD_TESTS", False))
+        return args

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -207,6 +207,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant("std", default="17", values=stds, multi=False)
     variant("pic", default=False, description="Build position independent code")
 
+    conflicts("std=11", when="@3.7:")
+
     conflicts("+cuda", when="std=17 ^cuda@:10")
     conflicts("+cuda", when="std=20 ^cuda@:12")
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -25,6 +25,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("4.0.01", sha256="bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0")
     version("4.0.00", sha256="1829a423883d4b44223c7c3a53d3c51671145aad57d7d23e6a1a4bebf710dcf6")
     version("3.7.01", sha256="0481b24893d1bcc808ec68af1d56ef09b82a1138a1226d6be27c3b3c3da65ceb")
     version("3.7.00", sha256="62e3f9f51c798998f6493ed36463f66e49723966286ef70a9dcba329b8443040")
@@ -93,6 +94,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "thunderx2": "THUNDERX2",
         "zen": "ZEN",
         "zen2": "ZEN2",
+        "zen3": "ZEN3",
         "steamroller": "KAVERI",
         "excavator": "CARIZO",
         "power7": "POWER7",
@@ -133,6 +135,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "75": "turing75",
         "80": "ampere80",
         "86": "ampere86",
+        "89": "ada89",
         "90": "hopper90",
     }
     cuda_arches = spack_cuda_arch_map.values()
@@ -144,6 +147,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "gfx908": "vega908",
         "gfx90a": "vega90A",
         "gfx1030": "navi1030",
+        "gfx1100": "navi1100",
     }
     amd_support_conflict_msg = (
         "{0} is not supported; "
@@ -203,9 +207,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant("std", default="17", values=stds, multi=False)
     variant("pic", default=False, description="Build position independent code")
 
-    # nvcc does not currently work with C++17 or C++20
     conflicts("+cuda", when="std=17 ^cuda@:10")
-    conflicts("+cuda", when="std=20")
+    conflicts("+cuda", when="std=20 ^cuda@:12")
 
     # SYCL and OpenMPTarget require C++17 or higher
     for stdver in stds[: stds.index("17")]:

--- a/var/spack/repos/builtin/packages/krakenuniq/package.py
+++ b/var/spack/repos/builtin/packages/krakenuniq/package.py
@@ -12,6 +12,7 @@ class Krakenuniq(Package):
     homepage = "https://genomebiology.biomedcentral.com/articles/10.1186/s13059-018-1568-0"
     url = "https://github.com/fbreitwieser/krakenuniq/archive/refs/tags/v0.7.3.tar.gz"
 
+    version("1.0.4", sha256="5e2ef21878c1c4ce92be9925e47b9ccae0ecb59a79d71cc4cbb53d057e0de9ec")
     version("0.7.3", sha256="140dccbabec00153c8231ac3c92eb8aecc0277c8947055d4d41abe949ae658c3")
     version("0.7.2", sha256="e6b4c04dbe8276c44fa9e2613cca78429439d75d59e22303094e6577ba333627")
     version("0.7.1", sha256="7f3da1efa1377f8615ad3587c4028fa462e7d802fa3f676b9c4e05d15215fad4")

--- a/var/spack/repos/builtin/packages/lcov/package.py
+++ b/var/spack/repos/builtin/packages/lcov/package.py
@@ -14,7 +14,7 @@ class Lcov(MakefilePackage):
 
     homepage = "http://ltp.sourceforge.net/coverage/lcov.php"
     url = "https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-1.14.tar.gz"
-    maintainers = ["KineticTheory"]
+    maintainers("KineticTheory")
 
     version("1.16", sha256="987031ad5528c8a746d4b52b380bc1bffe412de1f2b9c2ba5224995668e3240b")
     version("1.15", sha256="c1cda2fa33bec9aa2c2c73c87226cfe97de0831887176b45ee523c5e30f8053a")

--- a/var/spack/repos/builtin/packages/libconfuse/package.py
+++ b/var/spack/repos/builtin/packages/libconfuse/package.py
@@ -12,6 +12,7 @@ class Libconfuse(AutotoolsPackage):
     homepage = "https://github.com/martinh/libconfuse"
     url = "https://github.com/martinh/libconfuse/archive/v3.2.2.tar.gz"
 
+    version("3.3", sha256="cb90c06f2dbec971792af576d5b9a382fb3c4ca2b1deea55ea262b403f4e641e")
     version("3.2.2", sha256="2cf7e032980aff8f488efba61510dc3fb95e9a4b9183f985dea457a5651b0e2c")
     version("3.2.1", sha256="2eff8e3c300c4ed1d67fdb13f9d31a72a68e31874b4640db15334305bc40cebd")
 

--- a/var/spack/repos/builtin/packages/libfyaml/package.py
+++ b/var/spack/repos/builtin/packages/libfyaml/package.py
@@ -13,6 +13,7 @@ class Libfyaml(AutotoolsPackage):
     homepage = "https://github.com/pantoniou/libfyaml"
     url = "https://github.com/pantoniou/libfyaml/releases/download/v0.5.7/libfyaml-0.5.7.tar.gz"
 
+    version("0.8", sha256="dc4d4348eedca68e8e2394556d57f71410e7d61791a71cbe178302ebe5f26b99")
     version("0.7.12", sha256="485342c6920e9fdc2addfe75e5c3e0381793f18b339ab7393c1b6edf78bf8ca8")
     version("0.5.7", sha256="3221f31bb3feba97e544a82d0d5e4711ff0e4101cca63923dc5a1a001c187590")
 

--- a/var/spack/repos/builtin/packages/libluv/package.py
+++ b/var/spack/repos/builtin/packages/libluv/package.py
@@ -14,6 +14,7 @@ class Libluv(CMakePackage):
     homepage = "https://github.com/luvit/luv"
     url = "https://github.com/luvit/luv/releases/download/1.36.0-0/luv-1.36.0-0.tar.gz"
 
+    version("1.44.2-1", sha256="3eb5c7bc44f61fbc4148ea30e3221d410263e0ffa285672851fc19debf9e5c30")
     version("1.43.0-0", sha256="567a6f3dcdcf8a9b54ddc57ffef89d1e950d72832b85ee81c8c83a9d4e0e9de2")
     version("1.42.0-1", sha256="4b6fbaa89d2420edf6070ad9e522993e132bd7eb2540ff754c2b9f1497744db2")
     version("1.42.0-0", sha256="b5228a9d0eaacd9f862b6270c732d5c90773a28ce53b6d9e32a14050e7947f36")

--- a/var/spack/repos/builtin/packages/libnsl/package.py
+++ b/var/spack/repos/builtin/packages/libnsl/package.py
@@ -13,6 +13,7 @@ class Libnsl(AutotoolsPackage):
     homepage = "https://github.com/thkukuk/libnsl"
     url = "https://github.com/thkukuk/libnsl/archive/v1.3.0.tar.gz"
 
+    version("2.0.0", sha256="eb37be57c1cf650b3a8a4fc7cd66c8b3dfc06215b41956a16325a9388171bc40")
     version("1.3.0", sha256="8e88017f01dd428f50386186b0cd82ad06c9b2a47f9c5ea6b3023fc6e08a6b0f")
     version("1.2.0", sha256="a5a28ef17c4ca23a005a729257c959620b09f8c7f99d0edbfe2eb6b06bafd3f8")
     version(

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -41,9 +41,12 @@ class Libpng(CMakePackage):
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
-        return [
+        args = [
             self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
             self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
             self.define("PNG_SHARED", "shared" in self.spec.variants["libs"].value),
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
         ]
+        if self.spec.satisfies("platform=darwin target=aarch64:"):
+            args.append("-DPNG_ARM_NEON=off")
+        return args

--- a/var/spack/repos/builtin/packages/librdkafka/package.py
+++ b/var/spack/repos/builtin/packages/librdkafka/package.py
@@ -14,6 +14,8 @@ class Librdkafka(AutotoolsPackage):
     url = "https://github.com/edenhill/librdkafka/archive/v1.5.0.tar.gz"
 
     version("2.1.0", sha256="d8e76c4b1cde99e283a19868feaaff5778aa5c6f35790036c5ef44bc5b5187aa")
+    version("2.0.2", sha256="f321bcb1e015a34114c83cf1aa7b99ee260236aab096b85c003170c90a47ca9d")
+    version("1.9.2", sha256="3fba157a9f80a0889c982acdd44608be8a46142270a389008b22d921be1198ad")
     version("1.5.0", sha256="f7fee59fdbf1286ec23ef0b35b2dfb41031c8727c90ced6435b8cf576f23a656")
     version("1.4.4", sha256="0984ffbe17b9e04599fb9eceb16cfa189f525a042bef02474cd1bbfe1ea68416")
     version("1.4.2", sha256="3b99a36c082a67ef6295eabd4fb3e32ab0bff7c6b0d397d6352697335f4e57eb")

--- a/var/spack/repos/builtin/packages/libvterm/package.py
+++ b/var/spack/repos/builtin/packages/libvterm/package.py
@@ -13,6 +13,7 @@ class Libvterm(MakefilePackage):
     homepage = "http://www.leonerd.org.uk/code/libvterm/"
     url = "http://www.leonerd.org.uk/code/libvterm/libvterm-0.1.3.tar.gz"
 
+    version("0.3.1", sha256="25a8ad9c15485368dfd0a8a9dca1aec8fea5c27da3fa74ec518d5d3787f0c397")
     version("0.3", sha256="61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358")
     version("0.2", sha256="4c5150655438cfb8c57e7bd133041140857eb04defd0e544521c0e469258e105")
     version("0.1.4", sha256="bc70349e95559c667672fc8c55b9527d9db9ada0fb80a3beda533418d782d3dd")

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -32,11 +32,8 @@ class Libxcb(AutotoolsPackage):
     depends_on("xcb-proto@1.12:", when="@1.12:1.12.999")
     depends_on("xcb-proto@1.11:", when="@1.11:1.11.999")
 
-    # TODO: uncomment once build deps can be resolved separately
-    # See #7646, #4145, #4063, and #2548 for details
     # libxcb 1.13 added Python 3 support
-    # depends_on('python', type='build')
-    # depends_on('python@2:2.8', when='@:1.12', type='build')
+    depends_on("python@3", when="@1.13:", type="build")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -17,9 +17,6 @@ class Libxcb(AutotoolsPackage):
 
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
     version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")
-    version("1.12", sha256="092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06")
-    version("1.11.1", sha256="660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd")
-    version("1.11", sha256="4b351e1dc95eb0a1c25fa63611a6f4cf033cb63e20997c4874c80bbd1876d0b4")
 
     depends_on("libpthread-stubs")
     depends_on("libxau@0.99.2:")
@@ -27,14 +24,10 @@ class Libxcb(AutotoolsPackage):
 
     # libxcb 1.X requires xcb-proto >= 1.X
     depends_on("xcb-proto")
-    depends_on("xcb-proto@1.14:", when="@1.14:1.14.999")
-    depends_on("xcb-proto@1.13:", when="@1.13:1.13.999")
-    depends_on("xcb-proto@1.12:", when="@1.12:1.12.999")
-    depends_on("xcb-proto@1.11:", when="@1.11:1.11.999")
+    depends_on("xcb-proto@1.14:", when="@1.14")
+    depends_on("xcb-proto@1.13:", when="@1.13")
 
-    # libxcb 1.13 added Python 3 support
-    depends_on("python@3", when="@1.13:", type="build")
-
+    depends_on("python", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
 

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -27,6 +27,6 @@ class Libxpm(AutotoolsPackage, XorgPackage):
     depends_on("util-macros", type="build")
 
     def flag_handler(self, name, flags):
-        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
+        if name == "ldflags" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")
         return env_flags(name, flags)

--- a/var/spack/repos/builtin/packages/lighttpd/package.py
+++ b/var/spack/repos/builtin/packages/lighttpd/package.py
@@ -13,6 +13,7 @@ class Lighttpd(CMakePackage):
     homepage = "https://www.lighttpd.net"
     url = "https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-1.4.50.tar.gz"
 
+    version("1.4.69", sha256="657010184c4c470ad98944abbf0a8e2281800fa2bb1836c7a2cd4a8874e97b28")
     version("1.4.55", sha256="065259fb618774df516add13df22a52cac76a8f59e4561f143fe3ec810f4a03a")
     version("1.4.54", sha256="5151d38cb7c4c40effa13710e77ebdbef899f945b062cf32befc02d128ac424c")
     version("1.4.53", sha256="423b3951f212e3a30511eb86f4662a1848c6e857074289ff23fc310eef520266")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -88,11 +88,6 @@ class Llvm(CMakePackage, CudaPackage):
         description="Build the LLVM Fortran compiler frontend "
         "(experimental - parser only, needs GCC)",
     )
-    variant(
-        "omp_debug",
-        default=False,
-        description="Include debugging code in OpenMP runtime libraries",
-    )
     variant("lldb", default=True, when="+clang", description="Build the LLVM debugger")
     variant("lld", default=True, description="Build the LLVM linker")
     variant("mlir", default=False, when="@10:", description="Build with MLIR support")
@@ -106,6 +101,18 @@ class Llvm(CMakePackage, CudaPackage):
     )
     variant(
         "libcxx", default=True, when="+clang", description="Build the LLVM C++ standard library"
+    )
+    variant(
+        "libomptarget",
+        default=True,
+        when="+clang",
+        description="Build the OpenMP offloading library",
+    )
+    variant(
+        "omp_debug",
+        default=False,
+        when="+libomptarget",
+        description="Include debugging code in OpenMP runtime libraries",
     )
     variant(
         "compiler-rt",
@@ -132,7 +139,7 @@ class Llvm(CMakePackage, CudaPackage):
     )
     variant(
         "targets",
-        default="none",
+        default="all",
         description=(
             "What targets to build. Spack's target family is always added "
             "(e.g. X86 is automatically enabled when targeting znver2)."
@@ -230,7 +237,7 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("hwloc")
     depends_on("hwloc@2.0.1:", when="@9:")
     depends_on("elf", when="+cuda")  # libomptarget
-    depends_on("libffi", when="+cuda")  # libomptarget
+    depends_on("libffi", when="+libomptarget")  # libomptarget
 
     # llvm-config --system-libs libraries.
     depends_on("zlib")
@@ -271,6 +278,15 @@ class Llvm(CMakePackage, CudaPackage):
     conflicts("%gcc@:10", when="@13:+libcxx")
     conflicts("%clang@:10", when="@13:+libcxx")
     conflicts("%apple-clang@:11", when="@13:+libcxx")
+
+    # libomptarget
+    conflicts("+cuda", when="@15:")  # +cuda variant is obselete since LLVM 15
+    conflicts(
+        "targets=none",
+        when="+libomptarget",
+        msg="Non-host backends needed for offloading, set targets=all",
+    )
+    conflicts("~lld", when="+libomptarget")
 
     # cuda_arch value must be specified
     conflicts("cuda_arch=none", when="+cuda", msg="A value for cuda_arch must be specified.")
@@ -643,6 +659,11 @@ class Llvm(CMakePackage, CudaPackage):
                 runtimes.append("openmp")
             else:
                 projects.append("openmp")
+
+            if "+libomptarget" in spec:
+                cmake_args.append(define("OPENMP_ENABLE_LIBOMPTARGET", True))
+            else:
+                cmake_args.append(define("OPENMP_ENABLE_LIBOMPTARGET", False))
 
             if "@8" in spec:
                 cmake_args.append(from_variant("CLANG_ANALYZER_ENABLE_Z3_SOLVER", "z3"))

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -21,6 +21,7 @@ class Lmod(AutotoolsPackage):
     homepage = "https://www.tacc.utexas.edu/research-development/tacc-projects/lmod"
     url = "https://github.com/TACC/Lmod/archive/8.5.6.tar.gz"
 
+    version("8.7.24", sha256="8451267652059b6507b652e1b563929ecf9b689ffb20830642085eb6a55bd539")
     version("8.7.20", sha256="c04deff7d2ca354610a362459a7aa9a1c642a095e45a4b0bb2471bb3254e85f4")
     version("8.7.2", sha256="5f44f3783496d2d597ced7531e1714c740dbb2883a7d16fde362135fb0b0fd96")
     version("8.6.18", sha256="3db1c665c35fb8beb78c02e40d56accd361d82b715df70b2a995bcb10fbc2c80")
@@ -54,6 +55,8 @@ class Lmod(AutotoolsPackage):
     depends_on("lua-luaposix", type=("build", "run"))
     depends_on("lua-luafilesystem", type=("build", "run"))
     depends_on("tcl", type=("build", "link", "run"))
+
+    depends_on("bc", type="build", when="@8.7.10:")
 
     variant("auto_swap", default=True, description="Auto swapping of compilers, etc.")
     variant(

--- a/var/spack/repos/builtin/packages/maker/package.py
+++ b/var/spack/repos/builtin/packages/maker/package.py
@@ -34,6 +34,7 @@ class Maker(Package):
     homepage = "https://www.yandell-lab.org/software/maker.html"
     manual_download = True
 
+    version("3.01.04", sha256="87be5b0fad92d7d7b359f233877830e8a353a80277c3c88aa89f359899fa8bfb")
     version("3.01.03", sha256="d3979af9710d61754a3b53f6682d0e2052c6c3f36be6f2df2286d2587406f07d")
     version("2.31.10", sha256="d3979af9710d61754a3b53f6682d0e2052c6c3f36be6f2df2286d2587406f07d")
 

--- a/var/spack/repos/builtin/packages/med/package.py
+++ b/var/spack/repos/builtin/packages/med/package.py
@@ -43,6 +43,16 @@ class Med(CMakePackage):
     # fix problem where CMake "could not find TARGET hdf5"
     patch("med-4.1.0-hdf5-target.patch", when="@4.0.0:4.1.99")
 
+    def patch(self):
+        # resembles FindSalomeHDF5.patch as in salome-configuration
+        # see https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_LINK_INTERFACE_LIBRARIES.html
+        filter_file(
+            "GET_PROPERTY(_lib_lst TARGET hdf5-shared PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)",  # noqa: E501
+            "#GET_PROPERTY(_lib_lst TARGET hdf5-shared PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)",  # noqa: E501
+            "config/cmake_files/FindMedfileHDF5.cmake",
+            string=True,
+        )
+
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/micromamba/package.py
+++ b/var/spack/repos/builtin/packages/micromamba/package.py
@@ -23,17 +23,14 @@ class Micromamba(CMakePackage):
 
     maintainers("charmoniumQ")
 
+    version("1.4.2", sha256="dce034908d02d991c5e9aadeb9d01f139d027ba199aaeb1d47d543e3f24895d1")
     version("1.1.0", sha256="e2392cd90221234ae8ea92b37f40829fbe36d80278056269aa1994a5efe7f530")
 
     variant(
         "linkage",
         default="dynamic",
         description=f"See MICROMAMBA_LINKAGE in {linkage_url}.",
-        values=(
-            "dynamic",
-            "static",
-            # "full_static",
-        ),
+        values=("dynamic", conditional("static", when="@1.1.0")),
         multi=False,
     )
 
@@ -60,6 +57,9 @@ class Micromamba(CMakePackage):
         # https://github.com/mamba-org/mamba/blob/micromamba-1.0.0/micromamba/src/common_options.hpp#L12
         depends_on("cli11@2.2:", type="link")
 
+        depends_on("zstd build_system=cmake", type="link", when="@1.4.0:")
+
+        # 1.4.2 made the static build the old "full_static" build and it needs some work.
     with when("linkage=static"):
         # When linkage is static, BUILD_STATIC=ON
         # and then

--- a/var/spack/repos/builtin/packages/mrchem/package.py
+++ b/var/spack/repos/builtin/packages/mrchem/package.py
@@ -16,6 +16,7 @@ class Mrchem(CMakePackage):
 
     maintainers("robertodr", "stigrj", "ilfreddy")
 
+    version("1.1.2", sha256="b4e74ad5ee89fc5e8a7329474cf0fa93155423f93a1f95c8c2888f7c53e353ea")
     version("1.0.0", sha256="9cdda4d30b2baabb26400742f78ef8f3fc50a54f5218c8b6071b0cbfbed746c3")
     version("0.2.2", sha256="7519cc104c7df51eea8902c225aac6ecce2ac4ff30765145e502342d5bf3d96b")
     version("0.2.1", sha256="c1d0da5fefae356d9746f8ee761a94f6f6cd8b735a8309a4048ad6b8943ad242")

--- a/var/spack/repos/builtin/packages/mutationpp/package.py
+++ b/var/spack/repos/builtin/packages/mutationpp/package.py
@@ -18,6 +18,7 @@ class Mutationpp(CMakePackage):
     homepage = "https://github.com/mutationpp/Mutationpp"
     url = "https://github.com/mutationpp/Mutationpp/archive/v0.3.1.tar.gz"
 
+    version("1.0.5", sha256="319eca4e82a2469946344195373eabf28caaf6a39ddf3142b2337f47aa0835a8")
     version("1.0.0", sha256="928df99accd1a02706a57246edeef8ebbf3bd91bb40492258ee18b810a7e0194")
     version("0.3.1", sha256="a6da2816e145ac9fcfbd8920595b7f65ce7bc8df0bec572b32647720758cbe69")
 

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -17,7 +17,7 @@ class Mvapich(AutotoolsPackage):
     platforms (x86 (Intel and AMD), ARM and OpenPOWER)"""
 
     homepage = "https://mvapich.cse.ohio-state.edu/userguide/userguide_spack/"
-    url = "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-3.0a.tar.gz"
+    url = "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich-3.0b.tar.gz"
     list_url = "https://mvapich.cse.ohio-state.edu/downloads/"
 
     maintainers("natshineman", "harisubramoni", "MatthewLieber")
@@ -25,7 +25,7 @@ class Mvapich(AutotoolsPackage):
     executables = ["^mpiname$", "^mpichversion$"]
 
     # Prefer the latest stable release
-    version("3.0a", sha256="71f6593bfbfe9a9f6f5c750904461f007bf74bec479544e4da375b7d4a56b2ac")
+    version("3.0b", sha256="52d8a742e16eef69e944754fea7ebf8ba4ac572dac67dbda528443d9f32547cc")
 
     provides("mpi")
     provides("mpi@:3.1")

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -24,6 +24,7 @@ class Mvapich2(AutotoolsPackage):
     executables = ["^mpiname$", "^mpichversion$"]
 
     # Prefer the latest stable release
+    version("2.3.7-1", sha256="fdd971cf36d6476d007b5d63d19414546ca8a2937b66886f24a1d9ca154634e4")
     version("2.3.7", sha256="c39a4492f4be50df6100785748ba2894e23ce450a94128181d516da5757751ae")
     version("2.3.6", sha256="b3a62f2a05407191b856485f99da05f5e769d6381cd63e2fcb83ee98fc46a249")
     version("2.3.5", sha256="f9f467fec5fc981a89a7beee0374347b10c683023c76880f92a1a0ad4b961a8c")

--- a/var/spack/repos/builtin/packages/netcdf95/package.py
+++ b/var/spack/repos/builtin/packages/netcdf95/package.py
@@ -13,7 +13,7 @@ class Netcdf95(CMakePackage):
     homepage = "https://lguez.github.io/NetCDF95/"
     git = "https://github.com/lguez/NetCDF95.git"
 
-    maintainers = ["RemiLacroix-IDRIS"]
+    maintainers("RemiLacroix-IDRIS")
 
     version("0.3", tag="v0.3", submodules=True)
 

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -31,7 +31,7 @@ class OpenspeedshopUtils(CMakePackage):
     homepage = "http://www.openspeedshop.org"
     git = "https://github.com/OpenSpeedShop/openspeedshop.git"
 
-    maintainers = ["jgalarowicz"]
+    maintainers("jgalarowicz")
 
     version("develop", branch="master")
     version("2.4.2.1", branch="2.4.2.1")

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -26,7 +26,7 @@ class Openspeedshop(CMakePackage):
     homepage = "http://www.openspeedshop.org"
     git = "https://github.com/OpenSpeedShop/openspeedshop.git"
 
-    maintainers = ["jgalarowicz"]
+    maintainers("jgalarowicz")
 
     version("develop", branch="master")
     version("2.4.2.1", branch="2.4.2.1")

--- a/var/spack/repos/builtin/packages/p11-kit/package.py
+++ b/var/spack/repos/builtin/packages/p11-kit/package.py
@@ -17,6 +17,7 @@ class P11Kit(AutotoolsPackage):
     homepage = "https://p11-glue.github.io/p11-glue/p11-kit.html"
     url = "https://github.com/p11-glue/p11-kit/archive/0.23.21.tar.gz"
 
+    version("0.24.1", sha256="27f3c23531b24a2672ab198a3118f4f399d3a1faa8697924cc8a1065a17ead25")
     version("0.23.21", sha256="0361bcc55858618625a8e99e7fe9069f81514849b7b51ade51f8117d3ad31d88")
     version("0.23.20", sha256="8f6116f34735f6902e9db461c5dbe3e7e25b5cb8c38f42ea2a5aede1cf693749")
     version("0.23.19", sha256="c27921404e82244d97b27f46bae654e5814b5963e0ce3c75ad37007ded46f700")

--- a/var/spack/repos/builtin/packages/packmol/package.py
+++ b/var/spack/repos/builtin/packages/packmol/package.py
@@ -13,4 +13,5 @@ class Packmol(CMakePackage):
     homepage = "https://m3g.iqm.unicamp.br/packmol/home.shtml"
     url = "https://github.com/mcubeg/packmol/archive/18.169.tar.gz"
 
+    version("20.0.0", sha256="4faa1c8d5e5db2e935fbc23e7167df7e0b85aa0993c57b74cb897d13e5cf2202")
     version("18.169", sha256="8acf2cbc742a609e763eb00cae55aecd09af2edb4cc4e931706e2f06ac380de9")

--- a/var/spack/repos/builtin/packages/palace/package.py
+++ b/var/spack/repos/builtin/packages/palace/package.py
@@ -19,6 +19,7 @@ class Palace(CMakePackage):
     maintainers("sebastiangrimberg")
 
     version("develop", branch="main")
+    version("0.11.1", tag="v0.11.1")
     version("0.11.0", tag="v0.11.0")
 
     variant("int64", default=False, description="Use 64 bit integers")
@@ -113,6 +114,12 @@ class Palace(CMakePackage):
             args += ["-DSTRUMPACK_REQUIRED_PACKAGES=MPI;MPI_Fortran"]
         if "+mumps" in self.spec:
             args += ["-DMUMPS_REQUIRED_PACKAGES=MPI;MPI_Fortran"]
+
+        # BLAS/LAPACK linkage
+        args += [
+            "-DBLAS_LIBRARIES={0}".format(self.spec["blas"].libs.joined(";")),
+            "-DLAPACK_LIBRARIES={0}".format(self.spec["lapack"].libs.joined(";")),
+        ]
 
         # HYPRE is always built with external BLAS/LAPACK
         args += ["-DHYPRE_REQUIRED_PACKAGES=LAPACK;BLAS"]

--- a/var/spack/repos/builtin/packages/perl-module-build-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-build-tiny/package.py
@@ -12,6 +12,7 @@ class PerlModuleBuildTiny(PerlPackage):
     homepage = "https://metacpan.org/pod/Module::Build::Tiny"
     url = "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz"
 
+    version("0.044", sha256="cb053a3049cb717dbf4fd7f3c7ab7c0cb1015b22e2d93f38b1ffc47c078322fd")
     version("0.039", sha256="7d580ff6ace0cbe555bf36b86dc8ea232581530cbeaaea09bccb57b55797f11c")
 
     depends_on("perl-module-build", type="build")

--- a/var/spack/repos/builtin/packages/pflotran/package.py
+++ b/var/spack/repos/builtin/packages/pflotran/package.py
@@ -37,6 +37,9 @@ class Pflotran(AutotoolsPackage):
     depends_on("petsc@3.10:+hdf5+metis", when="@xsdk-0.4.0")
     depends_on("petsc@3.8.0:+hdf5+metis", when="@xsdk-0.3.0")
 
+    # https://github.com/spack/spack/pull/37579#issuecomment-1545998141
+    conflicts("^hdf5@1.14.1", when="%oneapi")
+
     def build(self, spec, prefix):
         if spec.satisfies("+rxn"):
             with working_dir("src/pflotran"):

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -89,6 +89,9 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     # Other dependencies
     depends_on("boost@1.71:")
     depends_on("fmt@9:", when="@0.11:")
+    # https://github.com/pika-org/pika/issues/686
+    conflicts("fmt@10:", when="+cuda")
+    conflicts("fmt@10:", when="+rocm")
     depends_on("hwloc@1.11.5:")
 
     depends_on("gperftools", when="malloc=tcmalloc")

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -17,6 +17,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/pika-org/pika.git"
     maintainers("msimberg", "albestro", "teonnik", "aurianer")
 
+    version("0.15.1", sha256="b68b87cf956ad1448f5c2327a72ba4d9fb339ecabeabb0a87b8ea819457e293b")
     version("0.15.0", sha256="4ecd5b64bd8067283a161e1aeacfbab7658d89fe1504b788fd3236298fe66b00")
     version("0.14.0", sha256="c0fc10a3c2c24bccbdc292c22a3373a2ad579583ee9d8bd31aaf1755e49958a4")
     version("0.13.0", sha256="67e0843141fb711787e71171a7a669c9cdb9587e4afd851ee2b0339a62b9a254")

--- a/var/spack/repos/builtin/packages/preseq/package.py
+++ b/var/spack/repos/builtin/packages/preseq/package.py
@@ -16,6 +16,7 @@ class Preseq(MakefilePackage):
     homepage = "https://github.com/smithlabcode/preseq"
     url = "https://github.com/smithlabcode/preseq/releases/download/v2.0.2/preseq_v2.0.2.tar.bz2"
 
+    version("2.0.3", sha256="747ddd4227515a96a45fcff0709f26130386bff3458c829c7bc1f3306b4f3d91")
     version("2.0.2", sha256="1d7ea249bf4e5826e09697256643e6a2473bc302cd455f31d4eb34c23c10b97c")
 
     depends_on("samtools")

--- a/var/spack/repos/builtin/packages/py-amityping/package.py
+++ b/var/spack/repos/builtin/packages/py-amityping/package.py
@@ -12,7 +12,7 @@ class PyAmityping(PythonPackage):
     homepage = "https://github.com/slac-lcls/amityping"
     url = "https://github.com/slac-lcls/amityping/archive/refs/tags/1.1.12.tar.gz"
 
-    maintainers = ["valmar"]
+    maintainers("valmar")
 
     version("1.1.12", sha256="e00e7102a53fa6ee343f018669f6b811d703a2da4728b497f80579bf89efbd3c")
 

--- a/var/spack/repos/builtin/packages/py-asdf-standard/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf-standard/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAsdfStandard(PythonPackage):
+    """Standards document describing ASDF, Advanced Scientific Data Format"""
+
+    homepage = "https://asdf-standard.readthedocs.io/"
+    pypi = "asdf_standard/asdf_standard-1.0.3.tar.gz"
+
+    maintainers("lgarrison")
+
+    version("1.0.3", sha256="afd8ff9a70e7b17f6bcc64eb92a544867d5d4fe1f0076719142fdf62b96cfd44")
+
+    depends_on("python@3.8:", type=("build", "run"))
+
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools-scm@3.4: +toml", type="build")
+
+    depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")

--- a/var/spack/repos/builtin/packages/py-asdf-transform-schemas/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf-transform-schemas/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAsdfTransformSchemas(PythonPackage):
+    """ASDF schemas for transforms"""
+
+    homepage = "asdf-transform-schemas.readthedocs.io"
+    pypi = "asdf_transform_schemas/asdf_transform_schemas-0.3.0.tar.gz"
+
+    maintainers("lgarrison")
+
+    version("0.3.0", sha256="0cf2ff7b22ccb408fe58ddd9b2441a59ba73fe323e416d59b9e0a4728a7d2dd6")
+
+    depends_on("python@3.8:", type=("build", "run"))
+
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools-scm@3.4: +toml", type="build")
+
+    depends_on("py-asdf-standard@1.0.1:", type=("build", "run"))
+    depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")

--- a/var/spack/repos/builtin/packages/py-asdf-unit-schemas/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf-unit-schemas/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAsdfUnitSchemas(PythonPackage):
+    """ASDF schemas for units"""
+
+    homepage = "https://asdf-unit-schemas.readthedocs.io"
+    pypi = "asdf_unit_schemas/asdf_unit_schemas-0.1.0.tar.gz"
+
+    maintainers("lgarrison")
+
+    version("0.1.0", sha256="42b78d67213efe4ffd4529fb0e58d9c7a0dab5cbf8839b230f1bc0a446bff999")
+
+    depends_on("python@3.8:", type=("build", "run"))
+
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools-scm@3.4: +toml", type="build")
+
+    depends_on("py-asdf-standard@1.0.1:", type=("build", "run"))
+    depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")

--- a/var/spack/repos/builtin/packages/py-asdf/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf/package.py
@@ -11,16 +11,45 @@ class PyAsdf(PythonPackage):
     interchange format for scientific data. This package contains the Python
     implementation of the ASDF Standard."""
 
-    homepage = "https://github.com/spacetelescope/asdf"
-    pypi = "asdf/asdf-2.4.2.tar.gz"
+    homepage = "https://asdf.readthedocs.io/"
+    pypi = "asdf/asdf-2.15.0.tar.gz"
 
+    maintainers("lgarrison")
+
+    version("2.15.0", sha256="686f1c91ebf987d41f915cfb6aa70940d7ad17f87ede0be70463147ad2314587")
     version("2.4.2", sha256="6ff3557190c6a33781dae3fd635a8edf0fa0c24c6aca27d8679af36408ea8ff2")
 
-    depends_on("python@3.3:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm", type="build")
-    depends_on("py-semantic-version@2.3.1:2.6.0", type=("build", "run"))
-    depends_on("py-pyyaml@3.10:", type=("build", "run"))
-    depends_on("py-jsonschema@2.3:3", type=("build", "run"))
-    depends_on("py-six@1.9.0:", type=("build", "run"))
-    depends_on("py-numpy@1.8:", type=("build", "run"))
+    variant("lz4", default=True, description="Enable lz4 compression")
+
+    depends_on("py-lz4@0.10:", when="+lz4", type=("build", "run"))
+
+    with when("@2.15:"):
+        depends_on("python@3.8:", type=("build", "run"))
+
+        depends_on("py-setuptools@60:", type="build")
+        depends_on("py-setuptools-scm@3.4: +toml", type="build")
+
+        depends_on("py-asdf-standard@1.0.1:", type=("build", "run"))
+        depends_on("py-asdf-transform-schemas@0.3:", type=("build", "run"))
+        depends_on("py-asdf-unit-schemas@0.1:", type=("build", "run"))
+        depends_on("py-importlib-metadata@4.11.4:", type=("build", "run"))
+        depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")
+        depends_on("py-jmespath@0.6.2:", type=("build", "run"))
+        depends_on("py-jsonschema@4.0.1:4.17", type=("build", "run"))
+        depends_on("py-numpy@1.20:", type=("build", "run"))
+        depends_on("py-numpy@1.20:1.24", type=("build", "run"), when="^python@:3.8")
+        depends_on("py-packaging@19:", type=("build", "run"))
+        depends_on("py-pyyaml@5.4.1:", type=("build", "run"))
+        depends_on("py-semantic-version@2.8:", type=("build", "run"))
+
+    with when("@2.4.2"):
+        depends_on("python@3.3:", type=("build", "run"))
+
+        depends_on("py-setuptools@30.3.0:", type="build")
+        depends_on("py-setuptools-scm", type="build")
+
+        depends_on("py-semantic-version@2.3.1:2.6.0", type=("build", "run"))
+        depends_on("py-pyyaml@3.10:", type=("build", "run"))
+        depends_on("py-jsonschema@2.3:3", type=("build", "run"))
+        depends_on("py-six@1.9.0:", type=("build", "run"))
+        depends_on("py-numpy@1.8:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-dill/package.py
+++ b/var/spack/repos/builtin/packages/py-dill/package.py
@@ -15,6 +15,7 @@ class PyDill(PythonPackage):
     version("0.3.6", sha256="e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373")
     version("0.3.5.1", sha256="d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86")
     version("0.3.4", sha256="9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675")
+    version("0.3.1.1", sha256="42d8ef819367516592a825746a18073ced42ca169ab1f5f4044134703e7a049c")
     version("0.3.1", sha256="d3ddddf2806a7bc9858b20c02dc174396795545e9d62f243b34481fd26eb3e2c")
     version("0.2.9", sha256="f6d6046f9f9195206063dd0415dff185ad593d6ee8b0e67f12597c0f4df4986f")
     version("0.2.7", sha256="ddda0107e68e4eb1772a9f434f62a513c080c7171bd0dd6fb65d992788509812")
@@ -26,6 +27,9 @@ class PyDill(PythonPackage):
     version("0.2.1", sha256="a54401bdfae419cfe1c9e0b48e9b290afccaa413d2319d9bb0fdb85c130a7923")
     version("0.2", sha256="aba8d4c81c4136310e6ce333bd6f4f3ea2d53bd367e2f69c864428f260c0308c")
 
+    depends_on("py-setuptools@42:", when="@0.3.5.1:", type="build")
+    depends_on("py-setuptools@0.6:", type="build")
+
     # This patch addresses [this issue] with Dill and Spack.
     # The issue was introduced at or before 0.3.5 in [this commit] and is still present in 0.3.6.
     # We backport a [fixing PR] until it lands in upstream.
@@ -33,14 +37,6 @@ class PyDill(PythonPackage):
     # [fixing PR]: https://github.com/uqfoundation/dill/pull/567
     # [this commit]: https://github.com/uqfoundation/dill/commit/23c47455da62d4cb8582d8f98f1de9fc6e0971ad
     patch("fix-is-builtin-module.patch", when="@0.3.5:")
-
-    depends_on("python@2.5:2.8,3.1:", type=("build", "run"))
-    depends_on("python@2.6:2.8,3.1:", when="@0.3.0:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.6:", when="@0.3.4:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.7:", when="@0.3.5.1:", type=("build", "run"))
-
-    depends_on("py-setuptools@0.6:", type="build")
-    depends_on("py-setuptools@42:", when="@0.3.5.1:", type="build")
 
     def url_for_version(self, version):
         url = "https://pypi.io/packages/source/d/dill/"

--- a/var/spack/repos/builtin/packages/py-hdbscan/package.py
+++ b/var/spack/repos/builtin/packages/py-hdbscan/package.py
@@ -23,12 +23,17 @@ class PyHdbscan(PythonPackage):
     homepage = "https://github.com/scikit-learn-contrib/hdbscan"
     url = "https://github.com/scikit-learn-contrib/hdbscan/archive/0.8.26.tar.gz"
 
+    version("0.8.29", sha256="67ba1c00b5ad7c0dca2d662d6036b6df235bd61522a785d68a8458b732555d76")
     version("0.8.26", sha256="2fd10906603b6565ee138656b6d59df3494c03c5e8099aede400d50b13af912b")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.27:", type="build")
+    depends_on("py-cython@0.27:", type=("build", "run"))
     depends_on("py-numpy@1.16.0:", type=("build", "run"))
+    depends_on("py-numpy@1.20:", type=("build", "run"), when="@0.8.29:")
     depends_on("py-scipy@0.9:", type=("build", "run"))
+    depends_on("py-scipy@1.0:", type=("build", "run"), when="@0.8.29:")
     depends_on("py-scikit-learn@0.17:", type=("build", "run"))
+    depends_on("py-scikit-learn@0.20:", type=("build", "run"), when="@0.8.29:")
     depends_on("py-joblib", type=("build", "run"))
+    depends_on("py-joblib@1.0:", type=("build", "run"), when="@0.8.29:")
     depends_on("py-six", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-importlib-resources/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-resources/package.py
@@ -12,6 +12,7 @@ class PyImportlibResources(PythonPackage):
     homepage = "https://github.com/python/importlib_resources"
     pypi = "importlib_resources/importlib_resources-1.0.2.tar.gz"
 
+    version("5.12.0", sha256="4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6")
     version("5.9.0", sha256="5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681")
     version("5.3.0", sha256="f2e58e721b505a79abe67f5868d99f8886aec8594c962c7490d0c22925f518da")
     version("5.2.3", sha256="203d70dda34cfbfbb42324a8d4211196e7d3e858de21a5eb68c6d1cdd99e4e98")
@@ -19,12 +20,9 @@ class PyImportlibResources(PythonPackage):
     version("5.1.0", sha256="bfdad047bce441405a49cf8eb48ddce5e56c696e185f59147a8b79e75e9e6380")
     version("1.0.2", sha256="d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("python@3.6:", when="@5:", type=("build", "run"))
-    depends_on("python@3.7:", when="@5.9.0:", type=("build", "run"))
-
-    depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@56:", when="@5.9.0:", type="build")
+    depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-scm@3.4.1:+toml", when="@5:", type="build")
-    depends_on("py-zipp@0.4:", when="@5.0:5.1", type=("build", "run"))
+
     depends_on("py-zipp@3.1.0:", when="@5.2.2: ^python@:3.9", type=("build", "run"))
+    depends_on("py-zipp@0.4:", when="@5.0:5.1", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-kosh/package.py
+++ b/var/spack/repos/builtin/packages/py-kosh/package.py
@@ -20,6 +20,7 @@ class PyKosh(PythonPackage):
     # notify when the package is updated.
     maintainers("doutriaux1")
 
+    version("3.0.1", sha256="e0d97c93476930ccfe8ed892517439d555760d66d57f9a8e52459fb5910ba398")
     version("2.2", sha256="3c79c3b7e7b64018ec5987dd7148886a6c619a28cda6f84e61a57439c9f3d7a3")
     version("2.1", sha256="597ed5beb4c3c3675b4af15ee7bfb60a463d5bda2222cd927061737ed073d562")
     version("2.0", sha256="059e431e3d3219b53956cb464d9e10933ca141dc89662f55d9c633e35c8b3a1e")
@@ -28,3 +29,14 @@ class PyKosh(PythonPackage):
     depends_on("py-llnl-sina@1.11:", type=("build", "run"))
     depends_on("py-networkx", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
+
+    with when("@3:"):
+        depends_on("py-networkx@2.6:", type=("build", "run"))
+        depends_on("py-numpy@1.20:", type=("build", "run"))
+        depends_on("py-scipy", type=("build", "run"))
+        depends_on("py-h5py@3:", type=("build", "run"))
+        depends_on("py-scikit-learn@1.0.2:", type=("build", "run"))
+        depends_on("py-pandas", type=("build", "run"))
+        depends_on("py-hdbscan@0.8.29:", type=("build", "run"))
+        depends_on("py-matplotlib", type=("build", "run"))
+        depends_on("py-tqdm", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-lcls-krtc/package.py
+++ b/var/spack/repos/builtin/packages/py-lcls-krtc/package.py
@@ -11,7 +11,7 @@ class PyLclsKrtc(PythonPackage):
 
     pypi = "lcls-krtc/lcls-krtc-0.2.0.tar.gz"
 
-    maintainers = ["valmar"]
+    maintainers("valmar")
 
     version("0.2.0", sha256="20e6327d488d23e29135be44504bf7df72e4425a518f4222841efcd2cd2985f9")
 

--- a/var/spack/repos/builtin/packages/py-lightly/package.py
+++ b/var/spack/repos/builtin/packages/py-lightly/package.py
@@ -42,4 +42,4 @@ class PyLightly(PythonPackage):
     depends_on("py-pytorch-lightning@1.0.4:1", when="@:1.4.1", type=("build", "run"))
 
     # https://github.com/lightly-ai/lightly/issues/1153
-    depends_on("py-torch+distributed", type=("build", "run"))
+    depends_on("py-torch+distributed", when="@:1.4.4", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-lightly/package.py
+++ b/var/spack/repos/builtin/packages/py-lightly/package.py
@@ -15,12 +15,13 @@ class PyLightly(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("1.4.5", sha256="67b1de64950ff5bc35ef86fec3049f437ed1c9cb4a191c43b52384460207535f")
     version("1.4.4", sha256="e726120437ee61754da8e1c384d2ed27d9a7004e037c74d98e3debbc98cbd4a4")
     version("1.4.3", sha256="ff2cfded234bc5338519bdb2de774c59a55200159f4429b009b7a3923bc0be0e")
     version("1.4.2", sha256="bae451fcd04fbd3cc14b044a2583ae24591533d4a8a6ff51e5f1477f9a077648")
     version("1.4.1", sha256="4c64657639c66ee5c8b4b8d300fc9b5287dc7e14a260f3a2e04917dca7f57f5b")
 
-    # lightly/requirements/base.txt
+    # requirements/base.txt
     depends_on("py-certifi@14.05.14:", type=("build", "run"))
     depends_on("py-hydra-core@1:", type=("build", "run"))
     depends_on("py-lightly-utils@0.0", type=("build", "run"))
@@ -33,7 +34,7 @@ class PyLightly(PythonPackage):
     depends_on("py-tqdm@4.44:", type=("build", "run"))
     depends_on("py-urllib3@1.15.1:", type=("build", "run"))
 
-    # lightly/requirements/torch.txt
+    # requirements/torch.txt
     depends_on("py-torch", type=("build", "run"))
     depends_on("py-torch@:1", when="@:1.4.1", type=("build", "run"))
     depends_on("py-torchvision", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
+++ b/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
@@ -13,7 +13,7 @@ class PyMinkowskiengine(PythonPackage, CudaPackage):
     homepage = "https://nvidia.github.io/MinkowskiEngine/"
     pypi = "MinkowskiEngine/MinkowskiEngine-0.5.4.tar.gz"
 
-    maintainers = ["wdconinc"]
+    maintainers("wdconinc")
 
     version("0.5.4", sha256="b1879c00d0b0b1d30ba622cce239886a7e3c78ee9da1064cdfe2f64c2ab15f94")
 

--- a/var/spack/repos/builtin/packages/py-mne/package.py
+++ b/var/spack/repos/builtin/packages/py-mne/package.py
@@ -13,6 +13,7 @@ class PyMne(PythonPackage):
     pypi = "mne/mne-0.23.4.tar.gz"
     git = "https://github.com/mne-tools/mne-python.git"
 
+    version("1.4.0", sha256="7834f5b79c2c9885ca601bbddd8db3c2b2f37c34443fc0caf0447751f6c37a2a")
     version("1.3.1", sha256="0d0626d3187dd0ee6f8740d054660a1b5fce4c879f814b745b13c5a587baf32b")
     version("1.2.3", sha256="b300dcee69ffb878cdbc5c02490e877df385c1b9482622e3aa1da06a604a6e37")
     version("1.2.2", sha256="d40743d6ca7ae3919a557166fd5fc4c00a9719e40c07346baad57964e15f02bb")
@@ -20,25 +21,31 @@ class PyMne(PythonPackage):
     version("0.18.2", sha256="aa2e72ad3225efdad39b05e67cd5c88dbd5c3fabf5e1705e459347131f114bc6")
 
     # don't support full variant for newer versions (for now) because dependencies get out of hand
-    variant("full", default=False, when="@:23", description="Enable full functionality.")
+    variant("full", default=False, when="@:0.23", description="Enable full functionality.")
     variant("hdf5", default=False, when="@1:", description="Enable hdf5 functionality.")
 
-    depends_on("python@3.7:", when="@0.24:", type=("build", "run"))
+    depends_on("python@3.8:", when="@1.4:", type=("build", "run"))
+    depends_on("py-setuptools@45:", when="@1.4:", type="build")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm@6.2:", when="@1.4:", type="build")
 
     # requirements_base.txt with versions specified in README.rst (marked with *)
+    depends_on("py-numpy@1.20.2:", when="@1.4:", type=("build", "run"))  # *
     depends_on("py-numpy@1.18.1:", when="@1:", type=("build", "run"))  # *
     depends_on("py-numpy@1.15.4:", when="@0.23:", type=("build", "run"))
     depends_on("py-numpy@1.11.3:", type=("build", "run"))
+    depends_on("py-scipy@1.6.3:", when="@1.4:", type=("build", "run"))
     depends_on("py-scipy@1.4.1:", when="@1:", type=("build", "run"))  # *
     depends_on("py-scipy@1.1.0:", when="@0.23:", type=("build", "run"))
     depends_on("py-scipy@0.17.1:", type=("build", "run"))
+    depends_on("py-matplotlib@3.4:", when="@1:", type=("build", "run"))  # *
     depends_on("py-matplotlib@3.1:", when="@1:", type=("build", "run"))  # *
     depends_on("py-tqdm", when="@1:", type=("build", "run"))
     depends_on("py-pooch@1.5:", when="@1:", type=("build", "run"))
     depends_on("py-decorator", when="@1:", type=("build", "run"))
     depends_on("py-packaging", when="@1:", type=("build", "run"))
     depends_on("py-jinja2", when="@1:", type=("build", "run"))
+    depends_on("py-importlib-resources@5.10.2:", when="@1.4: ^python@:3.8", type=("build", "run"))
 
     with when("+hdf5"):
         depends_on("py-h5io", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pivy/package.py
+++ b/var/spack/repos/builtin/packages/py-pivy/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPivy(PythonPackage):
+    """Python bindings to coin3d"""
+
+    homepage = "https://github.com/coin3d/pivy"
+    url = "https://github.com/coin3d/pivy/archive/refs/tags/0.6.8.tar.gz"
+
+    version("0.6.8", sha256="c443dd7dd724b0bfa06427478b9d24d31e0c3b5138ac5741a2917a443b28f346")
+
+    depends_on("coin3d")
+    depends_on("py-setuptools", type="build")
+    depends_on("cmake@3.18:", type="build")
+    depends_on("swig", type="build")
+
+    def patch(self):
+        # https://github.com/coin3d/pivy/issues/93
+        filter_file(
+            "project(pivy_cmake_setup NONE)",
+            "project(pivy_cmake_setup)",
+            "distutils_cmake/CMakeLists.txt",
+            string=True,
+        )

--- a/var/spack/repos/builtin/packages/py-psalg/package.py
+++ b/var/spack/repos/builtin/packages/py-psalg/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPsalg(PythonPackage):
+    """LCLS II Developement: PSAlg Python."""
+
+    homepage = "https://github.com/slac-lcls/lcls2"
+    url = "https://github.com/slac-lcls/lcls2/archive/refs/tags/3.3.37.tar.gz"
+
+    maintainers("valmar")
+
+    version("3.3.37", sha256="127a5ae44c9272039708bd877849a3af354ce881fde093a2fc6fe0550b698b72")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("psalg")
+
+    build_directory = "psalg"

--- a/var/spack/repos/builtin/packages/py-psana/package.py
+++ b/var/spack/repos/builtin/packages/py-psana/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyPsana(PythonPackage):
+    """LCLS II Developement: PSAna Python."""
+
+    homepage = "https://github.com/slac-lcls/lcls2"
+    url = "https://github.com/slac-lcls/lcls2/archive/refs/tags/3.3.37.tar.gz"
+
+    maintainers("valmar")
+
+    version("3.3.37", sha256="127a5ae44c9272039708bd877849a3af354ce881fde093a2fc6fe0550b698b72")
+
+    patch("setup.patch")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-cython", type="build")
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-psalg", type=("build", "run"))
+    depends_on("py-requests", type=("build", "run"))
+    depends_on("py-mpi4py", type=("build", "run"))
+    depends_on("py-pymongo", type=("build", "run"))
+    depends_on("py-amityping", type=("build", "run"))
+    depends_on("py-mypy-extensions", type=("build", "run"))
+    depends_on("py-h5py", type=("build", "run"))
+    depends_on("py-pyzmq", type=("build", "run"))
+    depends_on("py-psmon", type=("build", "run"))
+    depends_on("py-lcls-krtc", type=("build", "run"))
+    depends_on("py-psmon", type=("build", "run"))
+    depends_on("py-ipykernel", type=("build", "run"))
+    depends_on("opencv", type=("build", "run"))
+    depends_on("py-scikit-learn", type=("build", "run"))
+    depends_on("py-pyabel", type=("build", "run"))
+    depends_on("xtcdata", type=("build", "run", "link"))
+    depends_on("psalg", type=("build", "run", "link"))
+
+    build_directory = "psana"
+
+    def setup_build_environment(self, env):
+        env.set("INSTDIR", "{0}".format(self.prefix))
+        env.set("XTCDATADIR", "{0}".format(self.spec["xtcdata"].prefix))
+        env.set("PSALGDIR", "{0}".format(self.spec["psalg"].prefix))

--- a/var/spack/repos/builtin/packages/py-psana/setup.patch
+++ b/var/spack/repos/builtin/packages/py-psana/setup.patch
@@ -1,0 +1,171 @@
+diff --git a/psana/setup.py b/psana/setup.py
+index 61412cf6..20ec023b 100644
+--- a/psana/setup.py
++++ b/psana/setup.py
+@@ -18,6 +18,18 @@ if not instdir_env:
+     raise Exception('Parameter --instdir is missing')
+ instdir = instdir_env
+ 
++xtcdatadir_env = os.environ.get('XTCDATADIR')
++if not xtcdatadir_env:
++    xtcdatadir = instdir_env
++else:
++    xtcdatadir = xtcdatadir_env
++
++psalgdir_env = os.environ.get('PSALGDIR')
++if not psalgdir_env:
++    psalgdir = instdir_env
++else:
++    psalgdir = psalgdir_env
++
+ # Shorter BUILD_LIST can be used to speedup development loop.
+ #Command example: ./build_all.sh -b PEAKFINDER:HEXANODE:CFD -md
+ BUILD_LIST = ('PSANA','SHMEM','PEAKFINDER','HEXANODE','DGRAM','HSD','CFD','NDARRAY')# ,'XTCAV')
+@@ -63,6 +75,10 @@ else:
+     openmp_link_args = ['-fopenmp']
+ 
+ extra_link_args_rpath = extra_link_args + ['-Wl,-rpath,'+ os.path.abspath(os.path.join(instdir, 'lib'))]
++if xtcdatadir_env:
++    extra_link_args_rpath = extra_link_args_rpath + ['-Wl,-rpath,'+ os.path.abspath(os.path.join(xtcdatadir, 'lib'))]
++if psalgdir_env:
++    extra_link_args_rpath = extra_link_args_rpath + ['-Wl,-rpath,'+ os.path.abspath(os.path.join(psalgdir, 'lib'))]
+ 
+ CYT_BLD_DIR = 'build'
+ 
+@@ -76,21 +92,38 @@ INSTALL_REQS = []
+ PACKAGE_DATA = {}
+ ENTRY_POINTS = {}
+ 
++if xtcdatadir_env:
++    xtc_headers =  os.path.join(xtcdatadir, 'include')
++    xtc_lib_path = os.path.join(xtcdatadir, 'lib')
++else:
++    xtc_headers =  os.path.join(instdir, 'include')
++    xtc_lib_path = os.path.join(instdir, 'lib')
++
++if psalgdir_env:
++    psalg_headers =  os.path.join(psalgdir, 'include')
++    psalg_lib_path =  os.path.join(psalgdir, 'lib')
++else:
++    psalg_headers =  os.path.join(instdir, 'include')
++    psalg_lib_path =  os.path.join(instdir, 'lib')
+ 
+ if 'PSANA' in BUILD_LIST :
+     dgram_module = Extension('psana.dgram',
+                             sources = ['src/dgram.cc'],
+                             libraries = ['xtc'],
+-                            include_dirs = ['src', np.get_include(), os.path.join(instdir, 'include')],
+-                            library_dirs = [os.path.join(instdir, 'lib')],
++                            #include_dirs = ['src', np.get_include(), os.path.join(instdir, 'include'), ],
++                            #library_dirs = [os.path.join(instdir, 'lib')],
++                            include_dirs = ['src', np.get_include(), os.path.join(instdir, 'include'), xtc_headers ],
++                            library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path],
+                             extra_link_args = extra_link_args_rpath,
+                             extra_compile_args = extra_cxx_compile_args)
+ 
+     container_module = Extension('psana.container',
+                             sources = ['src/container.cc'],
+                             libraries = ['xtc'],
+-                            include_dirs = [np.get_include(), os.path.join(instdir, 'include')],
+-                            library_dirs = [os.path.join(instdir, 'lib')],
++                            #include_dirs = [np.get_include(), os.path.join(instdir, 'include')],
++                            #library_dirs = [os.path.join(instdir, 'lib')],
++                            include_dirs = [np.get_include(), os.path.join(instdir, 'include'), xtc_headers ],
++                            library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path],
+                             extra_link_args = extra_link_args_rpath,
+                             extra_compile_args = extra_cxx_compile_args)
+ 
+@@ -122,6 +155,7 @@ if 'PSANA' in BUILD_LIST :
+             'xtcavDisplay        = psana.xtcav.app.xtcavDisplay:__main__',
+             'shmemClientSimple   = psana.app.shmemClientSimple:main',
+             'epix10ka_pedestals_calibration = psana.app.epix10ka_pedestals_calibration:do_main',
++            'epix10ka_charge_injection = psana.app.epix10ka_charge_injection:do_main',
+             'epix10ka_deploy_constants = psana.app.epix10ka_deploy_constants:do_main',
+             'epix10ka_raw_calib_image = psana.app.epix10ka_raw_calib_image:do_main',
+             'epix10ka_calib_components = psana.app.epix10ka_calib_components:__main__',
+@@ -137,8 +171,10 @@ if 'SHMEM' in BUILD_LIST and sys.platform != 'darwin':
+     ext = Extension('shmem',
+                     sources=["psana/shmem/shmem.pyx"],
+                     libraries = ['xtc','shmemcli'],
+-                    include_dirs = [np.get_include(), os.path.join(instdir, 'include')],
+-                    library_dirs = [os.path.join(instdir, 'lib')],
++                    #include_dirs = [np.get_include(), os.path.join(instdir, 'include')],
++                    #library_dirs = [os.path.join(instdir, 'lib')],
++                    include_dirs = [np.get_include(), os.path.join(instdir, 'include'), xtc_headers, psalg_headers ],
++                    library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path, psalg_lib_path],
+                     language="c++",
+                     extra_compile_args = extra_cxx_compile_args,
+                     extra_link_args = extra_link_args_rpath,
+@@ -239,8 +275,10 @@ if 'DGRAM' in BUILD_LIST :
+                     #packages=['psana.peakfinder',],
+                     sources=["psana/peakFinder/dgramCreate.pyx"],
+                     libraries = ['xtc'],
+-                    include_dirs = [np.get_include(), os.path.join(instdir, 'include')],
+-                    library_dirs = [os.path.join(instdir, 'lib')],
++                    #include_dirs = [np.get_include(), os.path.join(instdir, 'include')],
++                    #library_dirs = [os.path.join(instdir, 'lib')],
++                    include_dirs = [np.get_include(), os.path.join(instdir, 'include'), xtc_headers ],
++                    library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path],
+                     language="c++",
+                     extra_compile_args = extra_cxx_compile_args,
+                     extra_link_args = extra_link_args_rpath,
+@@ -257,7 +295,11 @@ if 'DGRAM' in BUILD_LIST :
+ 
+     ext = Extension("psana.smdreader",
+                     sources=["psana/smdreader.pyx"],
+-                    include_dirs=["psana"],
++                    libraries = ['xtc'],
++                    #include_dirs=["psana"],
++                    #include_dirs = [np.get_include(), os.path.join(instdir, 'include')],
++                    include_dirs = ["psana", np.get_include(), os.path.join(instdir, 'include'), xtc_headers ],
++                    library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path],
+                     #extra_compile_args=extra_c_compile_args,
+                     extra_compile_args=extra_c_compile_args + openmp_compile_args,
+                     #extra_link_args=extra_link_args,
+@@ -284,8 +326,10 @@ if 'DGRAM' in BUILD_LIST :
+     ext = Extension("psana.dgramedit",
+                     sources=["psana/dgramedit.pyx"],
+                     libraries = ['xtc'],
+-                    include_dirs=["psana",np.get_include(), os.path.join(instdir, 'include')],
+-                    library_dirs = [os.path.join(instdir, 'lib')],
++                    #include_dirs=["psana",np.get_include(), os.path.join(instdir, 'include')],
++                    #library_dirs = [os.path.join(instdir, 'lib')],
++                    include_dirs = ["psana", np.get_include(), os.path.join(instdir, 'include'), xtc_headers ],
++                    library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path],
+                     language="c++",
+                     extra_compile_args = extra_cxx_compile_args,
+                     extra_link_args = extra_link_args_rpath,
+@@ -305,8 +349,10 @@ if 'DGRAM' in BUILD_LIST :
+     ext = Extension("psana.dgramlite",
+                     sources=["psana/dgramlite.pyx"],
+                     libraries = ['xtc'],
+-                    include_dirs=["psana",np.get_include(), os.path.join(instdir, 'include')],
+-                    library_dirs = [os.path.join(instdir, 'lib')],
++                    #include_dirs=["psana",np.get_include(), os.path.join(instdir, 'include')],
++                    #iibrary_dirs = [os.path.join(instdir, 'lib')],
++                    include_dirs = ["psana", np.get_include(), os.path.join(instdir, 'include'), xtc_headers ],
++                    library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path],
+                     language="c++",
+                     extra_compile_args = extra_cxx_compile_args,
+                     extra_link_args = extra_link_args_rpath,
+@@ -316,15 +362,17 @@ if 'DGRAM' in BUILD_LIST :
+     ext = Extension("psana.mypybuffer",
+                     sources=["psana/mypybuffer.pyx"],
+                     libraries = ['xtc'],
+-                    include_dirs=["psana",np.get_include(), os.path.join(instdir, 'include')],
+-                    library_dirs = [os.path.join(instdir, 'lib')],
++                    #include_dirs=["psana",np.get_include(), os.path.join(instdir, 'include')],
++                    #library_dirs = [os.path.join(instdir, 'lib')],
++                    include_dirs = ["psana", np.get_include(), os.path.join(instdir, 'include'), xtc_headers ],
++                    library_dirs = [os.path.join(instdir, 'lib'), xtc_lib_path],
+                     language="c++",
+                     extra_compile_args = extra_cxx_compile_args,
+-                    extra_link_args = extra_link_args_rpath,
+     )
+     CYTHON_EXTS.append(ext)
+ 
+ 
++
+ if 'HSD' in BUILD_LIST :
+     ext = Extension("hsd",
+                     sources=["psana/hsd/hsd.pyx"],

--- a/var/spack/repos/builtin/packages/py-psmon/package.py
+++ b/var/spack/repos/builtin/packages/py-psmon/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyPsmon(PythonPackage):
+    """Monitors and limits process resource."""
+
+    homepage = "https://github.com/rkkautsar/psmon"
+    pypi = "psmon/psmon-1.1.1.tar.gz"
+
+    maintainers("valmar")
+
+    version("1.1.1", sha256="ecbd4e3a34b5f20ac5c62e4cd1e19f7384c6d72f2dd7d66c7b4bc36b529b8385")
+
+    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-poetry@0.12:", type="build")
+    depends_on("py-psutil@5.5:6.0", type=("build", "run"))
+    depends_on("py-loguru@0.2.5:0.3.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyabel/package.py
+++ b/var/spack/repos/builtin/packages/py-pyabel/package.py
@@ -12,7 +12,7 @@ class PyPyabel(PythonPackage):
     homepage = "https://github.com/PyAbel/PyAbel"
     pypi = "PyAbel/PyAbel-0.9.0.tar.gz"
 
-    maintainers = ["valmar"]
+    maintainers("valmar")
 
     version("0.9.0", sha256="4052143de9da19be13bb321fb0524090ffc8cdc56e0e990e5d6f557f18109f08")
 

--- a/var/spack/repos/builtin/packages/py-pyqt4/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt4/package.py
@@ -31,6 +31,7 @@ class PyPyqt4(SIPPackage):
 
     # Supposedly can also be built with Qt 5 compatibility layer
     depends_on("qt@:4")
+    depends_on("qt@4.1:", when="@4.12.3")
     depends_on("py-sip@:4.19.18 module=PyQt4.sip")
 
     # https://www.riverbankcomputing.com/static/Docs/PyQt4/installation.html

--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -13,6 +13,7 @@ class PyPysam(PythonPackage):
     homepage = "https://github.com/pysam-developers/pysam"
     pypi = "pysam/pysam-0.14.1.tar.gz"
 
+    version("0.21.0", sha256="5c9645ddd87668e36ff0a1966391e26f9c403bf85b1bc06c53fe2fcd592da2ce")
     version("0.19.1", sha256="dee403cbdf232170c1e11cc24c76e7dd748fc672ad38eb0414f3b9d569b1448f")
     version("0.18.0", sha256="1d6d49a0b3c626fae410a93d4c80583a8b5ddaacc9b46a080b250dbcebd30a59")
     version("0.15.3", sha256="a98dd0a164aa664b1ab30a36f653752f00e93c13deeb66868597f4b2a30f7265")
@@ -21,12 +22,15 @@ class PyPysam(PythonPackage):
     version("0.14.1", sha256="2e86f5228429d08975c8adb9030296699012a8deba8ba26cbfc09b374f792c97")
     version("0.7.7", sha256="c9f3018482eec99ee199dda3fdef2aa7424dde6574672a4c0d209a10985755cc")
 
+    depends_on("py-setuptools@59.0:", when="@0.21:", type="build")
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.29.12:", when="@0.18:", type="build")
-    depends_on("py-cython@0.21:", when="@0.14:", type="build")
-    depends_on("py-cython@0.17:", type="build")
+    depends_on("py-cython@0.29.30:2", when="@0.21:", type="build")
+    depends_on("py-cython@0.29.12:2", when="@0.18:", type="build")
+    depends_on("py-cython@0.21:2", when="@0.14:", type="build")
+    depends_on("py-cython@0.17:2", type="build")
     depends_on("curl")
     depends_on("xz")
+    depends_on("htslib@1.17", when="@0.21.0")
     depends_on("htslib@:1.6", when="@:0.13")
     depends_on("htslib")
 

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -34,7 +34,9 @@ class PyPyside2(PythonPackage):
     depends_on("python@2.7.0:2.7,3.5.0:3.5,3.6.1:3.8", when="@:5.14", type=("build", "run"))
 
     depends_on("cmake@3.1:", type="build")
-    depends_on("llvm@6:", type="build")
+    # libclang versioning from sources/shiboken2/doc/gettingstarted.rst
+    depends_on("llvm@6", type="build", when="@5.12:5.13")
+    depends_on("llvm@10", type="build", when="@5.15")
     depends_on("py-setuptools", type="build")
     depends_on("py-packaging", type="build")
     depends_on("py-wheel", type="build")
@@ -51,8 +53,13 @@ class PyPyside2(PythonPackage):
         args = [
             "--parallel={0}".format(make_jobs),
             "--ignore-git",
+            # if you want to debug build problems, uncomment this
+            # "--verbose-build",
             "--qmake={0}".format(spec["qt"].prefix.bin.qmake),
         ]
+        if spec.satisfies("^python@3.10:"):
+            args.append("--limited-api=yes")
+
         if self.run_tests:
             args.append("--build-tests")
         return args

--- a/var/spack/repos/builtin/packages/py-rsatoolbox/package.py
+++ b/var/spack/repos/builtin/packages/py-rsatoolbox/package.py
@@ -14,21 +14,35 @@ class PyRsatoolbox(PythonPackage):
     git = "https://github.com/rsagroup/rsatoolbox.git"
 
     version("main", branch="main")
+    version("0.1.2", sha256="2d091cbaa33373bf9da4df5ca8d127f0e427431a3db726076090ab2d54fe1213")
+    version("0.1.0", sha256="245f909d31909ba896b765fa51ea019510dd690c6bb8d04b178a9c76ec36dce9")
+    version("0.0.5", sha256="7ede9309755a6173c26f08fd36fa436a11993c7ae0fa9fce05f38be7af0dc6eb")
     version("0.0.4", sha256="84153fa4c686c95f3e83f2cb668b97b82b53dc2a565856db80aa5f8c96d09359")
     version("0.0.3", sha256="9bf6e16d9feadc081f9daaaaab7ef38fc1cd64dd8ef0ccd9f74adb5fe6166649")
 
+    depends_on("python@:3.10", when="@:0.1.2", type=("build", "run"))
+
+    # version restriction from pyproject.toml cannot be concretized at the
+    # moment but package also builds with older versions
     depends_on("py-setuptools", type="build")
-    depends_on("py-coverage", type=("build", "run"))
+    depends_on("py-setuptools-scm+toml@7.0", when="@0.0.5:", type="build")
+    # version restriction: same as for py-setuptools
+    depends_on("py-cython", when="@0.0.5:", type="build")
+    depends_on("py-twine@4.0.1:4.0", when="@0.0.5:", type="build")
+
     depends_on("py-numpy@1.21.2:", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-scikit-learn", type=("build", "run"))
     depends_on("py-scikit-image", type=("build", "run"))
-    depends_on("py-tqdm", type=("build", "run"))
-    depends_on("py-h5py", type=("build", "run"))
-    depends_on("py-matplotlib", type=("build", "run"))
-    depends_on("py-joblib", type=("build", "run"))
-    depends_on("py-petname@2.2", when="@0.0.4:", type=("build", "run"))
     depends_on("py-pandas", when="@0.0.4:", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-h5py", type=("build", "run"))
+    depends_on("py-tqdm", type=("build", "run"))
+    depends_on("py-joblib", type=("build", "run"))
+
+    # old dependcies
+    depends_on("py-coverage", when="@:0.1.1", type=("build", "run"))
+    depends_on("py-petname@2.2", when="@0.0.4", type=("build", "run"))
 
     @when("@:0.0.3")
     def patch(self):

--- a/var/spack/repos/builtin/packages/py-safetensors/package.py
+++ b/var/spack/repos/builtin/packages/py-safetensors/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySafetensors(PythonPackage):
+    """Fast and Safe Tensor serialization."""
+
+    homepage = "https://github.com/huggingface/safetensors"
+    pypi = "safetensors/safetensors-0.3.1.tar.gz"
+
+    version("0.3.1", sha256="571da56ff8d0bec8ae54923b621cda98d36dcef10feb36fd492c4d0c2cd0e869")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-rust", type="build")

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -35,6 +35,11 @@ class PySetuptools(Package, PythonExtension):
         expand=False,
     )
     version(
+        "63.4.3",
+        sha256="7f61f7e82647f77d4118eeaf43d64cbcd4d87e38af9611694d4866eb070cd10d",
+        expand=False,
+    )
+    version(
         "63.0.0",
         sha256="045aec56a3eee5c82373a70e02db8b6da9a10f7faf61ff89a14ab66c738ed370",
         expand=False,

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -14,6 +14,7 @@ class PySphinx(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("7.0.1", sha256="61e025f788c5977d9412587e733733a289e2b9fdc2fef8868ddfbfc4ccfe881d")
     version("7.0.0", sha256="283c44aa28922bb4223777b44ac0d59af50a279ac7690dfe945bb2b9575dc41b")
 
     version("6.2.1", sha256="6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b")
@@ -88,7 +89,8 @@ class PySphinx(PythonPackage):
     depends_on("py-pygments@2.13:", when="@6.0.1:", type=("build", "run"))
     depends_on("py-pygments@2.12:", when="@5.2:", type=("build", "run"))
     depends_on("py-pygments@2:", type=("build", "run"))
-    depends_on("py-docutils@0.18.1:0.19", when="@6.2:", type=("build", "run"))
+    depends_on("py-docutils@0.18.1:0.20", when="@7.0.1:", type=("build", "run"))
+    depends_on("py-docutils@0.18.1:0.19", when="@6.2:7.0.0", type=("build", "run"))
     depends_on("py-docutils@0.18:0.19", when="@6.0:6.1", type=("build", "run"))
     depends_on("py-docutils@0.14:0.19", when="@5.1:5", type=("build", "run"))
     depends_on("py-docutils@0.14:0.18", when="@5.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -129,13 +129,15 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     variant("aws", default=False, description="Build with Amazon AWS Platform support")
     variant("kafka", default=False, description="Build with Apache Kafka Platform support")
     variant("ignite", default=False, description="Build with Apache Ignite support")
-    variant("xla", default=False, description="Build with XLA JIT support")
+    variant("xla", default=sys.platform != "darwin", description="Build with XLA JIT support")
     variant("gdr", default=False, description="Build with GDR support")
     variant("verbs", default=False, description="Build with libverbs support")
     variant("ngraph", default=False, description="Build with Intel nGraph support")
     variant("opencl", default=False, description="Build with OpenCL SYCL support")
     variant("computecpp", default=False, description="Build with ComputeCPP support")
-    variant("tensorrt", default=False, description="Build with TensorRT support")
+    variant(
+        "tensorrt", default=False, description="Build with TensorRT support"
+    )  # TODO: enable when TensorRT in Spack
     variant("cuda", default=sys.platform != "darwin", description="Build with CUDA support")
     variant(
         "nccl", default=sys.platform.startswith("linux"), description="Enable NVIDIA NCCL support"
@@ -146,7 +148,9 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     variant("monolithic", default=False, description="Static monolithic build")
     variant("numa", default=False, description="Build with NUMA support")
     variant(
-        "dynamic_kernels", default=False, description="Build kernels into separate shared objects"
+        "dynamic_kernels",
+        default=sys.platform.startswith("linux"),
+        description="Build kernels into separate shared objects",
     )
 
     extends("python")

--- a/var/spack/repos/builtin/packages/py-timm/package.py
+++ b/var/spack/repos/builtin/packages/py-timm/package.py
@@ -12,11 +12,18 @@ class PyTimm(PythonPackage):
     homepage = "https://github.com/rwightman/pytorch-image-models"
     pypi = "timm/timm-0.4.12.tar.gz"
 
+    maintainers("adamjstewart")
+
+    version("0.9.2", sha256="d0977cc5e02c69bda979fca8b52aa315a5f2cb64ebf8ad2c4631b1e452762c14")
+    version("0.9.1", sha256="171420ac499e7999d38fb8b08fffa5ca3950b38db23bba84763cd92621ca80a2")
+    version("0.9.0", sha256="f0159bbeea5c8d11551ac3077752ee77008d2638578571303296054b5ffddad4")
     version("0.6.13", sha256="745c54f7b7985a18e08bd66c997b018c1c3fef99bbb8c018879a6f85571782f5")
     version("0.6.12", sha256="8f1747121598e06a1ea2d00df16d332cc284cdd4596bdc136b490a2122d3aa91")
     version("0.5.4", sha256="5d7b92e66a76c432009aba90d515ea7a882aae573415a7c5269e3617df901c1f")
     version("0.4.12", sha256="b14be70dbd4528b5ca8657cf5bc2672c7918c3d9ebfbffe80f4785b54e884b1e")
 
+    # https://github.com/huggingface/pytorch-image-models/commit/f744bda994ec305a823483bf52a20c1440205032
+    depends_on("python@3.8:", when="@0.9.0", type=("build", "run"))
     # https://github.com/huggingface/pytorch-image-models/issues/1530
     # https://github.com/huggingface/pytorch-image-models/pull/1649
     depends_on("python@:3.10", when="@:0.6.12", type=("build", "run"))
@@ -27,6 +34,7 @@ class PyTimm(PythonPackage):
     depends_on("py-torchvision", type=("build", "run"))
     depends_on("py-pyyaml", when="@0.6:", type=("build", "run"))
     depends_on("py-huggingface-hub", when="@0.6:", type=("build", "run"))
+    depends_on("py-safetensors", when="@0.9:", type=("build", "run"))
 
     # https://github.com/rwightman/pytorch-image-models/pull/1256
     depends_on("pil@:9", when="@:0.5", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -24,6 +24,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     import_modules = ["torch", "torch.autograd", "torch.nn", "torch.utils"]
 
     version("master", branch="master", submodules=True)
+    version("2.0.1", tag="v2.0.1", submodules=True)
     version("2.0.0", tag="v2.0.0", submodules=True)
     version("1.13.1", tag="v1.13.1", submodules=True)
     version("1.13.0", tag="v1.13.0", submodules=True)

--- a/var/spack/repos/builtin/packages/py-torchaudio/package.py
+++ b/var/spack/repos/builtin/packages/py-torchaudio/package.py
@@ -23,6 +23,7 @@ class PyTorchaudio(PythonPackage):
     git = "https://github.com/pytorch/audio.git"
 
     version("main", branch="main", submodules=True)
+    version("2.0.2", tag="v2.0.2", submodules=True)
     version("2.0.1", tag="v2.0.1", submodules=True)
     version("0.13.1", tag="v0.13.1", submodules=True)
     version("0.13.0", tag="v0.13.0", submodules=True)
@@ -66,6 +67,7 @@ class PyTorchaudio(PythonPackage):
 
     # https://github.com/pytorch/audio#dependencies
     depends_on("py-torch@master", when="@main", type=("build", "link", "run"))
+    depends_on("py-torch@2.0.1", when="@2.0.2", type=("build", "link", "run"))
     depends_on("py-torch@2.0.0", when="@2.0.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.1", when="@0.13.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.0", when="@0.13.0", type=("build", "link", "run"))

--- a/var/spack/repos/builtin/packages/py-torchdata/package.py
+++ b/var/spack/repos/builtin/packages/py-torchdata/package.py
@@ -16,6 +16,7 @@ class PyTorchdata(PythonPackage):
     maintainers("adamjstewart")
 
     version("main", branch="main")
+    version("0.6.1", sha256="c596db251c5e6550db3f00e4308ee7112585cca4d6a1c82a433478fd86693257")
     version("0.6.0", sha256="048dea12ee96c0ea1525097959fee811d7b38c2ed05f44a90f35f8961895fb5b")
     version("0.5.1", sha256="69d80bd33ce8f08e7cfeeb71cefddfc29cede25a85881e33dbae47576b96ed29")
     version("0.5.0", sha256="b4e1a7015b34e3576111d495a00a675db238bfd136629fc443078bab9383ec36")
@@ -36,6 +37,7 @@ class PyTorchdata(PythonPackage):
 
     # https://github.com/pytorch/data#version-compatibility
     depends_on("py-torch@master", when="@main", type=("build", "run"))
+    depends_on("py-torch@2.0.1", when="@0.6.1", type=("build", "run"))
     depends_on("py-torch@2.0.0", when="@0.6.0", type=("build", "run"))
     depends_on("py-torch@1.13.1", when="@0.5.1", type=("build", "run"))
     depends_on("py-torch@1.13.0", when="@0.5.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-torchtext/package.py
+++ b/var/spack/repos/builtin/packages/py-torchtext/package.py
@@ -16,6 +16,7 @@ class PyTorchtext(PythonPackage):
     maintainers("adamjstewart")
 
     version("main", branch="main", submodules=True)
+    version("0.15.2", tag="v0.15.2", submodules=True)
     version("0.15.1", tag="v0.15.1", submodules=True)
     version("0.14.1", tag="v0.14.1", submodules=True)
     version("0.14.0", tag="v0.14.0", submodules=True)
@@ -55,6 +56,7 @@ class PyTorchtext(PythonPackage):
 
     # https://github.com/pytorch/text#installation
     depends_on("py-torch@master", when="@main", type=("build", "link", "run"))
+    depends_on("py-torch@2.0.1", when="@0.15.2", type=("build", "link", "run"))
     depends_on("py-torch@2.0.0", when="@0.15.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.1", when="@0.14.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.0", when="@0.14.0", type=("build", "link", "run"))

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -18,6 +18,7 @@ class PyTorchvision(PythonPackage):
     maintainers("adamjstewart")
 
     version("main", branch="main")
+    version("0.15.2", sha256="1efcb80e0a6e42c54f07ee16167839b4d302aeeecc12839cc47c74b06a2c20d4")
     version("0.15.1", sha256="689d23d4ebb0c7e54e8651c89b17155b64341c14ae4444a04ca7dc6f2b6a0a43")
     version("0.14.1", sha256="ced67e1cf1f97e168cdf271851a4d0b6d382ab7936e7bcbb39aaa87239c324b6")
     version("0.14.0", sha256="be1621c85c56eb40537cb74e6ec5d8e58ed8b69f8374a58bcb6ec413cb540c8b")
@@ -77,6 +78,7 @@ class PyTorchvision(PythonPackage):
 
     # https://github.com/pytorch/vision#installation
     depends_on("py-torch@master", when="@main", type=("build", "link", "run"))
+    depends_on("py-torch@2.0.1", when="@0.15.2", type=("build", "link", "run"))
     depends_on("py-torch@2.0.0", when="@0.15.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.1", when="@0.14.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.0", when="@0.14.0", type=("build", "link", "run"))

--- a/var/spack/repos/builtin/packages/rocmlir/package.py
+++ b/var/spack/repos/builtin/packages/rocmlir/package.py
@@ -16,7 +16,7 @@ class Rocmlir(CMakePackage):
     git = "https://github.com/ROCmSoftwarePlatform/rocMLIR.git"
     url = "https://github.com/ROCmSoftwarePlatform/rocMLIR/archive/refs/tags/rocm-5.4.3.tar.gz"
 
-    maintainers = ["srekolam"]
+    maintainers("srekolam")
 
     version("5.4.3", sha256="c0ba0f565e1c6614c9e6091a24cbef67b734a29e4a4ed7a8a57dc43f58ed8d53")
     version("5.4.0", sha256="3823f455ee392118c3281e27d45fa0e5381f3c4070eb4e06ba13bc6b34a90a60")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -22,7 +22,9 @@ class Root(CMakePackage):
 
     tags = ["hep"]
 
-    maintainers("greenc-FNAL", "HadrienG2", "drbenmorgan", "vvolkl")
+    maintainers(
+        "drbenmorgan", "gartung", "greenc-FNAL", "HadrienG2", "marcmengel", "vitodb", "vvolkl"
+    )
 
     # ###################### Versions ##########################
 
@@ -32,6 +34,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version("6.28.04", sha256="70f7f86a0cd5e3f2a0befdc59942dd50140d990ab264e8e56c7f17f6bfe9c965")
     version("6.28.02", sha256="6643c07710e68972b00227c68b20b1016fec16f3fba5f44a571fa1ce5bb42faa")
     version("6.28.00", sha256="afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084")
     version("6.26.10", sha256="8e56bec397104017aa54f9eb554de7a1a134474fe0b3bb0f43a70fc4fabd625f")
@@ -313,8 +316,8 @@ class Root(CMakePackage):
     conflicts("+tmva", when="~gsl", msg="TVMA requires GSL")
     conflicts("+tmva", when="~mlp", msg="TVMA requires MLP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
-    conflicts("cxxstd=11", when="@6.25.02:", msg="This version of root " "requires at least C++14")
-    conflicts("cxxstd=20", when="@:6.25.01", msg="C++20 support was added " "in 6.25.02")
+    conflicts("cxxstd=11", when="@6.25.02:", msg="This version of root requires at least C++14")
+    conflicts("cxxstd=20", when="@:6.28.02", msg="C++20 support requires at least version 6.28.04")
 
     # See https://github.com/root-project/root/issues/11128
     conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in 6.26.08")

--- a/var/spack/repos/builtin/packages/routinator/package.py
+++ b/var/spack/repos/builtin/packages/routinator/package.py
@@ -14,9 +14,15 @@ class Routinator(Package):
 
     maintainers("aweits")
 
-    version("0.11.2", sha256="00f825c53168592da0285e8dbd228018e77248d458214a2c0f86cd0ca45438f5")
+    version("0.12.1", sha256="8150fe544f89205bb2d65bca46388f055cf13971d3163fe17508bf231f9ab8bc")
+    version(
+        "0.11.2",
+        sha256="00f825c53168592da0285e8dbd228018e77248d458214a2c0f86cd0ca45438f5",
+        deprecated=True,
+    )
 
-    depends_on("rust@1.56:")
+    depends_on("rust@1.56:", when="@0.11.2")
+    depends_on("rust@1.63:", when="@0.12.1")
 
     def install(self, spec, prefix):
         cargo = which("cargo")

--- a/var/spack/repos/builtin/packages/salome-med/package.py
+++ b/var/spack/repos/builtin/packages/salome-med/package.py
@@ -47,6 +47,16 @@ class SalomeMed(CMakePackage):
         with working_dir(self.build_directory):
             make("test", parallel=False)
 
+    def patch(self):
+        # resembles FindSalomeHDF5.patch as in salome-configuration
+        # see https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_LINK_INTERFACE_LIBRARIES.html
+        filter_file(
+            "GET_PROPERTY(_lib_lst TARGET hdf5 PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)",  # noqa: E501
+            "#GET_PROPERTY(_lib_lst TARGET hdf5 PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)",  # noqa: E501
+            "config/cmake_files/FindMedfileHDF5.cmake",
+            string=True,
+        )
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set("HDF5_ROOT_DIR", self.spec["hdf5"].prefix)
 

--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -13,20 +13,47 @@ class ScitokensCpp(CMakePackage):
     homepage = "https://github.com/scitokens/scitokens-cpp"
     url = "https://github.com/scitokens/scitokens-cpp/archive/refs/tags/v0.7.0.tar.gz"
 
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb")
+
     version("1.0.1", sha256="d4660521fa17189e7a7858747d066052dd8ea8f430ce7649911c157d4423c412")
     version("1.0.0", sha256="88376c5cd065aac8d92445184a02ccf5186dc4890ccd7518e88be436978675c0")
+    version("0.7.3", sha256="7d3c438596588cd74cf1af8255c55f44ca86a34293b81415ee24b33de64f886a")
+    version("0.7.2", sha256="594eee5f80463cd501e9b4c17b6ea6dcae47a42ef4947406ce8b157e15d50d5b")
     version("0.7.1", sha256="44a1bca188897b1e97645149d1f6bc187cd0e482ad36159ca376834f028ce5ef")
     version("0.7.0", sha256="72600cf32523b115ec7abf4ac33fa369e0a655b3d3b390e1f68363e6c4e961b6")
+
+    variant(
+        "cxxstd",
+        default="11",
+        values=("11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+    )
 
     depends_on("cmake@2.6:")
     depends_on("cmake@3.10:", when="@0.7.1:")
     depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")
+    depends_on("jwt-cpp", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("uuid", type="build")
+
+    conflicts("jwt-cpp@0.5:", when="@:0.7")
 
     # https://github.com/scitokens/scitokens-cpp/issues/72
     @when("@0.7.0 ^openssl@3:")
     def patch(self):
         filter_file(" -Werror", "", "CMakeLists.txt")
+
+    def cmake_args(self):
+        define = self.define
+        define_from_variant = self.define_from_variant
+        args = [
+            define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+            define("CMAKE_CXX_STANDARD_REQUIRED", True),
+        ]
+        return args
+
+    def setup_build_environment(self, env):
+        env.set("JWC_CPP_DIR", self.spec["jwt-cpp"].prefix)

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -14,7 +14,7 @@ class Scorep(AutotoolsPackage):
 
     homepage = "https://www.vi-hps.org/projects/score-p"
     url = "https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-7.1/scorep-7.1.tar.gz"
-    maintainers = ["wrwilliams"]
+    maintainers("wrwilliams")
 
     version("8.0", sha256="4c0f34f20999f92ebe6ca1ff706d0846b8ce6cd537ffbedb49dfaef0faa66311")
     version("7.1", sha256="98dea497982001fb82da3429ca55669b2917a0858c71abe2cfe7cd113381f1f7")

--- a/var/spack/repos/builtin/packages/shadow/package.py
+++ b/var/spack/repos/builtin/packages/shadow/package.py
@@ -14,6 +14,7 @@ class Shadow(AutotoolsPackage):
     url = "https://github.com/shadow-maint/shadow/releases/download/4.7/shadow-4.7.tar.gz"
     git = "https://github.com/shadow-maint/shadow.git"
 
+    version("4.13", sha256="813057047499c7fe81108adcf0cffa3ad4ec75e19a80151f9cbaa458ff2e86cd")
     version("4.8.1", sha256="3ee3081fbbcbcfea5c8916419e46bc724807bab271072104f23e7a29e9668f3a")
     version("4.7", sha256="5135b0ca2a361a218fab59e63d9c1720d2a8fc1faa520c819a654b638017286f")
     version("4.6", sha256="4668f99bd087399c4a586084dc3b046b75f560720d83e92fd23bf7a89dda4d31")

--- a/var/spack/repos/builtin/packages/shtools/package.py
+++ b/var/spack/repos/builtin/packages/shtools/package.py
@@ -14,6 +14,7 @@ class Shtools(MakefilePackage):
 
     maintainers("eschnett")
 
+    version("4.10.2", sha256="0caece67d65ddde19a79ec79bc6244f447f6fa878e5b2dc3f635cae2a3d1ee8c")
     version("4.10.1", sha256="f4fb5c86841fe80136b520d2040149eafd4bc2d49da6b914d8a843b812f20b61")
     version("4.9.1", sha256="5c22064f9daf6e9aa08cace182146993aa6b25a6ea593d92572c59f4013d53c2")
     version("4.8", sha256="c36fc86810017e544abbfb12f8ddf6f101a1ac8b89856a76d7d9801ffc8dac44")

--- a/var/spack/repos/builtin/packages/stdexec/package.py
+++ b/var/spack/repos/builtin/packages/stdexec/package.py
@@ -10,9 +10,11 @@ class Stdexec(CMakePackage):
     """The proposed C++ framework for asynchronous and parallel programming."""
 
     homepage = "https://github.com/NVIDIA/stdexec"
+    url = "https://github.com/NVIDIA/stdexec/archive/nvhpc-0.0.tar.gz"
     git = "https://github.com/NVIDIA/stdexec.git"
     maintainers("msimberg", "aurianer")
 
+    version("23.03", sha256="2c9dfb6e56a190543049d2300ccccd1b626f4bb82af5b607869c626886fadd15")
     version("main", branch="main")
 
     depends_on("cmake@3.23.1:", type="build")

--- a/var/spack/repos/builtin/packages/stream/package.py
+++ b/var/spack/repos/builtin/packages/stream/package.py
@@ -18,12 +18,26 @@ class Stream(MakefilePackage):
 
     variant("openmp", default=False, description="Build with OpenMP support")
 
+    variant("stream_array_size", default="none", description="Size of work arrays in elements")
+    variant(
+        "ntimes",
+        default="none",
+        description='STREAM runs each kernel "NTIMES" times and reports the *best* result',
+    )
+    variant("offset", default="none", description="Relative alignment between arrays")
+    variant(
+        "stream_type",
+        default="none",
+        values=("none", "float", "double", "int", "long"),
+        description="Datatype of arrays elements",
+    )
+
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
 
         # Use the Spack compiler wrappers
-        makefile.filter("CC = .*", "CC = cc")
-        makefile.filter("FC = .*", "FC = f77")
+        makefile.filter("CC = .*", "CC = {0}".format(spack_cc))
+        makefile.filter("FC = .*", "FC = {0}".format(spack_f77))
 
         cflags = "-O2"
         fflags = "-O2"
@@ -32,6 +46,17 @@ class Stream(MakefilePackage):
             fflags += " " + self.compiler.openmp_flag
         if "%aocc" in self.spec:
             cflags += " -mcmodel=large -ffp-contract=fast -fnt-store"
+
+        if self.spec.variants["stream_array_size"].value != "none":
+            cflags += " -DSTREAM_ARRAY_SIZE={0}".format(
+                self.spec.variants["stream_array_size"].value
+            )
+        if self.spec.variants["ntimes"].value != "none":
+            cflags += " -DNTIMES={0}".format(self.spec.variants["ntimes"].value)
+        if self.spec.variants["offset"].value != "none":
+            cflags += " -DOFFSET={0}".format(self.spec.variants["offset"].value)
+        if self.spec.variants["stream_type"].value != "none":
+            cflags += " -DSTREAM_TYPE={0}".format(self.spec.variants["stream_type"].value)
 
         # Set the appropriate flags for this compiler
         makefile.filter("CFLAGS = .*", "CFLAGS = {0}".format(cflags))

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -22,6 +22,7 @@ class Subversion(AutotoolsPackage):
 
     tags = ["build-tools"]
 
+    version("1.14.2", sha256="fd826afad03db7a580722839927dc664f3e93398fe88b66905732c8530971353")
     version("1.14.1", sha256="dee2796abaa1f5351e6cc2a60b1917beb8238af548b20d3e1ec22760ab2f0cad")
     version("1.14.0", sha256="ef3d1147535e41874c304fb5b9ea32745fbf5d7faecf2ce21d4115b567e937d0")
     version("1.13.0", sha256="daad440c03b8a86fcca804ea82217bb1902cfcae1b7d28c624143c58dcb96931")

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -27,6 +27,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     # Versions
     # ==========================================================================
     version("develop", branch="develop")
+    version("6.5.1", sha256="4252303805171e4dbdd19a01e52c1dcfe0dafc599c3cfedb0a5c2ffb045a8a75")
     version("6.5.0", sha256="4e0b998dff292a2617e179609b539b511eb80836f5faacf800e688a886288502")
     version("6.4.1", sha256="7bf10a8d2920591af3fba2db92548e91ad60eb7241ab23350a9b1bc51e05e8d0")
     version("6.4.0", sha256="0aff803a12c6d298d05b56839197dd09858631864017e255ed89e28b49b652f1")
@@ -773,6 +774,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         """(Hack) Set/get cmake dependency path."""
         filepath = join_path(self.install_test_root, "cmake_bin_path.txt")
         if set:
+            if not os.path.exists(self.install_test_root):
+                mkdirp(self.install_test_root)
             with open(filepath, "w") as out_file:
                 cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
                 out_file.write("{0}\n".format(cmake_bin))
@@ -782,7 +785,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
     @run_after("install")
     def setup_smoke_tests(self):
-        install_tree(self._smoke_tests_path, join_path(self.install_test_root, "testing"))
+        if "+examples-install" in self.spec:
+            install_tree(self._smoke_tests_path, join_path(self.install_test_root, "testing"))
         self.cmake_bin(set=True)
 
     def build_smoke_tests(self):
@@ -790,6 +794,10 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
         if not cmake_bin:
             tty.msg("Skipping sundials test: cmake_bin_path.txt not found")
+            return
+
+        if "~examples-install" in self.spec:
+            tty.msg("Skipping sundials test: examples were not installed")
             return
 
         for smoke_test in self._smoke_tests:
@@ -800,6 +808,9 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
                 self.run_test(exe="make")
 
     def run_smoke_tests(self):
+        if "~examples-install" in self.spec:
+            return
+
         for smoke_test in self._smoke_tests:
             self.run_test(
                 exe=join_path(self._smoke_tests_path, smoke_test[0]),
@@ -811,6 +822,9 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
             )
 
     def clean_smoke_tests(self):
+        if "~examples-install" in self.spec:
+            return
+
         for smoke_test in self._smoke_tests:
             work_dir = join_path(self._smoke_tests_path, os.path.dirname(smoke_test[0]))
             with working_dir(work_dir):

--- a/var/spack/repos/builtin/packages/swan/package.py
+++ b/var/spack/repos/builtin/packages/swan/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -14,22 +16,38 @@ class Swan(MakefilePackage):
     features. This list reflects on the scientific relevance of
     the development of SWAN."""
 
-    homepage = "http://swanmodel.sourceforge.net/"
-    url = "https://cfhcable.dl.sourceforge.net/project/swanmodel/swan/41.31/swan4131.tar.gz"
+    homepage = "https://swanmodel.sourceforge.net/"
+    url = "https://swanmodel.sourceforge.io/download/zip/swan4145.tar.gz"
 
-    maintainers("lhxone")
+    maintainers("lhxone", "stevenrbrandt")
 
-    version("4131", sha256="cd3ba1f0d79123f1b7d42a43169f07575b59b01e604c5e66fbc09769e227432e")
+    # This is very important
+    parallel = False
+
+    version(
+        "4145",
+        preferred=True,
+        sha256="4cced2250f11f5cff3417d1f541f5e3cdd09fa1bc4fd986e0d0917bfb88b1e2a",
+    )
+
+    version("4141", sha256="5d411e6602bd4ef764f6c7d23e5e25b588e955cb21a606d6d8a7bc4c9393aa0a")
 
     depends_on("mpi")
     depends_on("netcdf-fortran")
-    depends_on("libfabric")
+    depends_on("perl", type="build")
 
     def edit(self, spec, prefix):
-        env["FC"] = "gfortran"
+        fc = re.sub(r".*[\\/]", "", env["FC"])
+        mpifc = re.sub(r".*[\\/]", "", spec["mpi"].mpifc)
+
+        # Must not be the full path to the compiler or platform.pl gets confused
+        env["FC"] = fc
+        env["F90_MPI"] = mpifc
+
         m = FileFilter("platform.pl")
-        m.filter("F90_MPI = .*", 'F90_MPI = mpifort\\n";')
-        m.filter("NETCDFROOT =", "NETCDFROOT = {0}" + spec["netcdf-fortran"].prefix)
+        m.filter("F90_MPI = .*", "F90_MPI = " + mpifc + '\\n";')
+        m.filter("NETCDFROOT =", "NETCDFROOT = " + spec["netcdf-fortran"].prefix)
+        m.filter(r"-lnetcdf\b", "")
 
     def build(self, spec, prefix):
         make("config")

--- a/var/spack/repos/builtin/packages/tandem/package.py
+++ b/var/spack/repos/builtin/packages/tandem/package.py
@@ -21,7 +21,7 @@ class Tandem(CMakePackage):
     version("1.0", tag="v1.0", submodules=True)
     patch("fix_v1.0_compilation.diff", when="@1.0")
 
-    maintainers = ["dmay23", "Thomas-Ulrich"]
+    maintainers("dmay23", "Thomas-Ulrich")
     variant("polynomial_degree", default="2")
     variant("domain_dimension", default="2", values=("2", "3"), multi=False)
     variant("min_quadrature_order", default="0")

--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -22,7 +22,7 @@ class Thrift(Package):
     list_url = "http://archive.apache.org/dist/thrift/"
     list_depth = 1
 
-    maintainers = ["thomas-bouvier"]
+    maintainers("thomas-bouvier")
 
     version("0.18.1", sha256="04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726")
     version("0.17.0", sha256="b272c1788bb165d99521a2599b31b97fa69e5931d099015d91ae107a0b0cc58f")

--- a/var/spack/repos/builtin/packages/tig/package.py
+++ b/var/spack/repos/builtin/packages/tig/package.py
@@ -12,6 +12,7 @@ class Tig(AutotoolsPackage):
     homepage = "https://jonas.github.io/tig/"
     url = "https://github.com/jonas/tig/releases/download/tig-2.2.2/tig-2.2.2.tar.gz"
 
+    version("2.5.8", sha256="b70e0a42aed74a4a3990ccfe35262305917175e3164330c0889bd70580406391")
     version("2.2.2", sha256="316214d87f7693abc0cbe8ebbb85decdf5e1b49d7ad760ac801af3dd73385e35")
 
     depends_on("ncurses")

--- a/var/spack/repos/builtin/packages/tmalign/package.py
+++ b/var/spack/repos/builtin/packages/tmalign/package.py
@@ -10,12 +10,35 @@ class Tmalign(Package):
     """TM-align is an algorithm for sequence-order independent protein
     structure comparisons."""
 
-    homepage = "https://zhanglab.ccmb.med.umich.edu/TM-align"
-    url = "http://zhanglab.ccmb.med.umich.edu/TM-align/TM-align-C/TMalignc.tar.gz"
+    homepage = "https://zhanggroup.org/TM-align/"
+    url = "https://zhanggroup.org/TM-align/TMalign.cpp"
+
+    maintainers("snehring")
 
     version(
-        "2016-05-25", sha256="ce7f68289f3766d525afb0a58e3acfc28ae05f538d152bd33d57f8708c60e2af"
+        "20220412",
+        sha256="09227c46705ca8cf7c922a6e1672c34d7ed4daba32e5c7c484306808db54117a",
+        expand=False,
     )
+    version(
+        "2016-05-25",
+        sha256="ce7f68289f3766d525afb0a58e3acfc28ae05f538d152bd33d57f8708c60e2af",
+        url="http://zhanglab.ccmb.med.umich.edu/TM-align/TM-align-C/TMalignc.tar.gz",
+        deprecated=True,
+    )
+
+    variant("fast-math", default=False, when="@20220412:")
+
+    with when("@20220412:"):
+        phases = ["build", "install"]
+
+    def build(self, spec, prefix):
+        cxx = Executable(self.compiler.cxx)
+        args = ["-O3"]
+        if spec.satisfies("+fast-math"):
+            args.append("-ffast-math")
+        args.extend(["-lm", "-o", "TMalign", "TMalign.cpp"])
+        cxx(*args)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/tmscore/package.py
+++ b/var/spack/repos/builtin/packages/tmscore/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Tmscore(Package):
+    """TM-score is a metric for assessing the topological similarity of
+    protein structures."""
+
+    homepage = "https://zhanggroup.org/TM-score/"
+    url = "https://zhanggroup.org/TM-score/TMscore.cpp"
+
+    maintainers("snehring")
+
+    version(
+        "20220227",
+        sha256="30274251f4123601af102cf6d4f1a9cc496878c1ae776702f554e2fc25658d7f",
+        expand=False,
+    )
+
+    variant("fast-math", default=False)
+
+    phases = ["build", "install"]
+
+    def build(self, spec, prefix):
+        cxx = Executable(self.compiler.cxx)
+        args = ["-O3"]
+        if spec.satisfies("+fast-math"):
+            args.append("-ffast-math")
+        args.extend(["-lm", "-o", "TMscore", "TMscore.cpp"])
+        cxx(*args)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("TMscore", prefix.bin)

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -656,6 +656,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             ]
         )
 
+        if spec.satisfies("@develop +stokhos"):
+            options.append(self.define("Stokhos_ENABLE_PCE_Scalar_Type", False))
+
         if "+dtk" in spec:
             options.extend(
                 [
@@ -771,7 +774,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         ]
         if spec.satisfies("@12.12.1:"):
             tpl_dep_map.append(("Pnetcdf", "parallel-netcdf"))
-        if spec.satisfies("@13:"):
+        if spec.satisfies("@13:") and not spec.satisfies("@develop"):
             tpl_dep_map.append(("HWLOC", "hwloc"))
 
         for tpl_name, dep_name in tpl_dep_map:

--- a/var/spack/repos/builtin/packages/trimgalore/package.py
+++ b/var/spack/repos/builtin/packages/trimgalore/package.py
@@ -14,6 +14,7 @@ class Trimgalore(Package):
     homepage = "https://github.com/FelixKrueger/TrimGalore"
     url = "https://github.com/FelixKrueger/TrimGalore/archive/0.4.4.tar.gz"
 
+    version("0.6.9", sha256="d50ce6106f979c316c89c7e7bcb44e5f841935d88bc4f756ccf0bc4cbab4e6f5")
     version("0.6.6", sha256="b8db8ffd131d9d9e7c8532a5a1f1caee656c0c58d3eafd460fee3c39b9fcab5e")
     version("0.6.4", sha256="eb57e18203d8a1dce1397b930a348a9969eebaa758b8a7304d04c22f216cea2d")
     version("0.6.3", sha256="c85104452dbb5cfa8c9307920e804fb53baaad355ce656b111f5243e5eb92db4")

--- a/var/spack/repos/builtin/packages/ut/package.py
+++ b/var/spack/repos/builtin/packages/ut/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Ut(CMakePackage):
+    """UT: C++20 μ(micro)/Unit Testing Framework"""
+
+    homepage = "https://boost-ext.github.io/ut"
+    url = "https://github.com/boost-ext/ut/archive/v0.0.0.tar.gz"
+    git = "https://github.com/boost-ext/ut.git"
+
+    maintainers("msimberg")
+
+    version("master", branch="master")
+    version("1.1.9", sha256="1a666513157905aa0e53a13fac602b5673dcafb04a869100a85cd3f000c2ed0d")
+
+    generator("ninja")
+
+    depends_on("cmake@3.21:3.25", type="build", when="@master")
+    depends_on("cmake@3.12:3.20", type="build", when="@1.1.9")
+    depends_on("ninja", type="build")
+
+    conflicts("%gcc@:8")
+    conflicts("%clang@:8")
+    conflicts("%clang@:10", when="platform=darwin")
+
+    # 1.1.9 had the version set to 1.1.8. See: https://github.com/boost-ext/ut/pull/492.
+    patch(
+        "https://github.com/boost-ext/ut/pull/492.patch?full_index=1",
+        sha256="1858aefec7e6adbb6130bf32a0343f9ddd173182f9dba3eb3d30523e11d26987",
+        when="@1.1.9",
+    )
+
+    def cmake_args(self):
+        return [
+            self.define("BOOST_UT_BUILD_BENCHMARKS", False),
+            self.define("BOOST_UT_BUILD_EXAMPLES", False),
+            self.define("BOOST_UT_BUILD_TESTS", self.run_tests),
+        ]

--- a/var/spack/repos/builtin/packages/vdt/package.py
+++ b/var/spack/repos/builtin/packages/vdt/package.py
@@ -15,6 +15,7 @@ class Vdt(CMakePackage):
     homepage = "https://github.com/dpiparo/vdt"
     url = "https://github.com/dpiparo/vdt/archive/v0.3.9.tar.gz"
 
+    version("0.4.4", sha256="8b1664b45ec82042152f89d171dd962aea9bb35ac53c8eebb35df1cb9c34e498")
     version("0.4.3", sha256="705674612ebb5c182b65a8f61f4d173eb7fe7cdeee2235b402541a492e08ace1")
     version("0.3.9", sha256="1662d21037a29cae717ee50b73bd177bea79582f4138b7ad11404fc4be4e542e")
     version("0.3.8", sha256="e6d8485c3c8923993cb1b1a5bb85068a86746285058bf77faeb177363647be62")

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -43,17 +43,11 @@ class Whizard(AutotoolsPackage):
     )
 
     variant("pythia8", default=True, description="builds with pythia8")
-
     variant("fastjet", default=False, description="builds with fastjet")
-
     variant("lcio", default=False, description="builds with lcio")
-
     variant("lhapdf", default=False, description="builds with fastjet")
-
     variant("openmp", default=False, description="builds with openmp")
-
     variant("openloops", default=False, description="builds with openloops")
-
     variant("latex", default=False, description="data visualization with latex")
 
     depends_on("libtirpc")
@@ -86,9 +80,12 @@ class Whizard(AutotoolsPackage):
         msg="The fortran compiler needs to support Fortran 2008. For more detailed information see https://whizard.hepforge.org/compilers.html",
     )
 
-    # Trying to build in parallel leads to a race condition at the build step.
-    # See: https://github.com/key4hep/k4-spack/issues/71
-    parallel = False
+    @property
+    def parallel(self):
+        # Trying to build in parallel leads to a race condition at the build step.
+        # See: https://github.com/key4hep/key4hep-spack/issues/71
+        # On 3.1.0 it doesn't seem to happen
+        return self.spec.version > Version("3.0.3")
 
     def setup_build_environment(self, env):
         # whizard uses the compiler during runtime,

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -20,9 +20,7 @@ class XcbProto(AutotoolsPackage):
     version("1.12", sha256="cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59")
     version("1.11", sha256="d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906")
 
-    # TODO: uncomment once build deps can be resolved separately
-    # See #7646, #4145, #4063, and #2548 for details
-    # extends('python')
+    extends("python")
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
 

--- a/var/spack/repos/builtin/packages/xrootd/no-systemd-5.5.2.patch
+++ b/var/spack/repos/builtin/packages/xrootd/no-systemd-5.5.2.patch
@@ -1,0 +1,17 @@
+--- a/cmake/XRootDFindLibs.cmake	2021-07-29 12:22:48.000000000 +0000
++++ b/cmake/XRootDFindLibs.cmake	2021-10-25 18:26:07.308918231 +0000
+@@ -30,10 +30,10 @@
+   add_definitions( -DHAVE_XML2 )
+ endif()
+ 
+-find_package( systemd )
+-if( SYSTEMD_FOUND )
+-  add_definitions( -DHAVE_SYSTEMD )
+-endif()
++#find_package( systemd )
++#if( SYSTEMD_FOUND )
++#  add_definitions( -DHAVE_SYSTEMD )
++#endif()
+ 
+ find_package( CURL )
+ 

--- a/var/spack/repos/builtin/packages/xrootd/no-systemd-pre-5.5.2.patch
+++ b/var/spack/repos/builtin/packages/xrootd/no-systemd-pre-5.5.2.patch
@@ -1,0 +1,17 @@
+--- a/cmake/XRootDFindLibs.cmake	2021-07-29 12:22:48.000000000 +0000
++++ b/cmake/XRootDFindLibs.cmake	2021-10-25 18:26:07.308918231 +0000
+@@ -26,10 +26,10 @@
+   add_definitions( -DHAVE_XML2 )
+ endif()
+ 
+-find_package( Systemd )
+-if( SYSTEMD_FOUND )
+-  add_definitions( -DHAVE_SYSTEMD )
+-endif()
++#find_package( Systemd )
++#if( SYSTEMD_FOUND )
++#  add_definitions( -DHAVE_SYSTEMD )
++#endif()
+ 
+ find_package( CURL )
+ 

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -15,8 +15,9 @@ class Xrootd(CMakePackage):
     url = "https://xrootd.slac.stanford.edu/download/v5.5.1/xrootd-5.5.1.tar.gz"
     list_url = "https://xrootd.slac.stanford.edu/dload.html"
 
-    maintainers("wdconinc")
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb", "wdconinc")
 
+    version("5.5.5", sha256="0710caae527082e73d3bf8f9d1dffe95808afd3fcaaaa15ab0b937b8b226bc1f")
     version("5.5.4", sha256="41a8557ea2d118b1950282b17abea9230b252aa5ee1a5959173e2534b7d611d3")
     version("5.5.3", sha256="703829c2460204bd3c7ba8eaa23911c3c9a310f6d436211ba0af487ef7f6a980")
     version("5.5.2", sha256="ec4e0490b8ee6a3254a4ea4449342aa364bc95b78dc9a8669151be30353863c6")
@@ -49,35 +50,69 @@ class Xrootd(CMakePackage):
     version("4.4.0", sha256="f066e7488390c0bc50938d23f6582fb154466204209ca92681f0aa06340e77c8")
     version("4.3.0", sha256="d34865772d975b5d58ad80bb05312bf49aaf124d5431e54dc8618c05a0870e3c")
 
+    variant("davix", default=True, description="Build with Davix")
     variant("http", default=True, description="Build with HTTP support")
-
+    variant("krb5", default=False, description="Build with KRB5 support")
     variant("python", default=False, description="Build pyxroot Python extension")
-
     variant("readline", default=True, description="Use readline")
 
-    variant("krb5", default=False, description="Build with KRB5 support")
+    variant(
+        "cxxstd",
+        default="98",
+        values=("98", "11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+        when="@:4.5.99",
+    )
 
     variant(
         "cxxstd",
         default="11",
-        values=("98", "11", "14", "17"),
+        values=("98", "11", "14", "17", "20"),
         multi=False,
-        description="Use the specified C++ standard when building.",
+        description="Use the specified C++ standard when building",
+        when="@4.6.0:5.1.99",
+    )
+
+    variant(
+        "cxxstd",
+        default="14",
+        values=("98", "11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+        when="@5.2.0:",
     )
 
     variant(
         "scitokens-cpp", default=False, when="@5.1.0:", description="Enable support for SciTokens"
     )
 
+    variant(
+        "client_only", default=False, description="Build and install client only", when="@4.10.0:"
+    )
+
     conflicts("cxxstd=98", when="@4.7.0:")
+    # C++ standard is not honored without
+    # https://github.com/xrootd/xrootd/pull/1929
+    # Related: C++>14 causes compilation errors with ~client_only. See
+    # also https://github.com/xrootd/xrootd/pull/1933.
+    conflicts("cxxstd=17", when="@5.0:5.5.2")
+    conflicts("cxxstd=20", when="@5.0:5.5.2")
+    conflicts("cxxstd=17", when="@5 ~client_only")
+    conflicts("cxxstd=20", when="@5 ~client_only")
+    conflicts("scitokens-cpp", when="@:5.5.2 +client_only")
 
     depends_on("bzip2")
-    depends_on("cmake@2.6:", type="build")
+    depends_on("cmake@2.6:", type="build", when="@3.1.0:")
+    conflicts("cmake@:3.0", when="@5.0.0")
+    conflicts("cmake@:3.15.99", when="@5.5.4:")
+    depends_on("davix", when="+davix")
     depends_on("libxml2", when="+http")
     depends_on("uuid", when="@4.11.0:")
     depends_on("openssl@:1", when="@:5.4")
     depends_on("openssl")
     depends_on("python", when="+python")
+    depends_on("py-setuptools", type="build", when="+python")
     depends_on("readline", when="+readline")
     depends_on("xz")
     depends_on("zlib")
@@ -85,6 +120,7 @@ class Xrootd(CMakePackage):
     depends_on("krb5", when="+krb5")
     depends_on("json-c")
     depends_on("scitokens-cpp", when="+scitokens-cpp")
+    conflicts("openssl@3:", when="@:5.3.99")
 
     extends("python", when="+python")
     patch("python-support.patch", level=1, when="@:4.8+python")
@@ -94,35 +130,73 @@ class Xrootd(CMakePackage):
         sha256="2655e2d609d80bf9c9ab58557f4f6940408a1af9c686e7aa214ac0348c89c8fa",
         when="@5.5.1",
     )
+    # https://github.com/xrootd/xrootd/pull/1930
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/1930.patch?full_index=1",
+        sha256="969f8b07edff42449ad76b02f3e57d93b8d6c829be1ba14bccf831c27bc971e1",
+        when="@5.5.3",
+    )
 
+    # do not use systemd
+    patch("no-systemd-pre-5.5.2.patch", when="@:5.5.1")
+    patch("no-systemd-5.5.2.patch", when="@5.5.2:")
+
+    @when("@4.7.0:5.1.99")
     def patch(self):
-        # Do not use systemd
-        filter_file(
-            r"(add_definitions\(\s*-DHAVE_SYSTEMD\s*\))", r"#\1", "cmake/XRootDFindLibs.cmake"
-        )
+        """Remove hardcoded -std=c++0x flag"""
+        filter_file(r"\-std=c\+\+0x", r"", "cmake/XRootDOSDefs.cmake")
 
-        # Remove hardcoded -std=c++0x flag
-        if self.spec.satisfies("@4.7.0:"):
-            filter_file(r"\-std=c\+\+0x", r"", "cmake/XRootDOSDefs.cmake")
+    @when("@5.2.0:5 +client_only")
+    def patch(self):
+        """Allow CMAKE_CXX_STANDARD to be set in cache"""
+        # See https://github.com/xrootd/xrootd/pull/1929
+        filter_file(
+            r"^(\s+(?i:set)\s*\(\s*CMAKE_CXX_STANDARD\s+\d+)(\s*\).*)$",
+            r'\1 CACHE STRING "C++ Standard"\2',
+            "cmake/XRootDOSDefs.cmake",
+        )
 
     def cmake_args(self):
         spec = self.spec
-        options = [
-            "-DENABLE_HTTP:BOOL={0}".format("ON" if "+http" in spec else "OFF"),
-            "-DENABLE_PYTHON:BOOL={0}".format("ON" if "+python" in spec else "OFF"),
-            "-DENABLE_READLINE:BOOL={0}".format("ON" if "+readline" in spec else "OFF"),
-            "-DENABLE_KRB5:BOOL={0}".format("ON" if "+krb5" in spec else "OFF"),
-            "-DENABLE_CEPH:BOOL=OFF",
+        define = self.define
+        define_from_variant = self.define_from_variant
+        options = []
+        if spec.satisfies("@5.2.0: +client_only") or spec.satisfies("@6:"):
+            options += [
+                define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+                define("CMAKE_CXX_STANDARD_REQUIRED", True),
+            ]
+
+        options += [
+            define_from_variant("ENABLE_HTTP", "http"),
+            define_from_variant("ENABLE_XRDCLHTTP", "davix"),
+            define_from_variant("ENABLE_PYTHON", "python"),
+            define_from_variant("ENABLE_READLINE", "readline"),
+            define_from_variant("ENABLE_KRB5", "krb5"),
+            define_from_variant("ENABLE_SCITOKENS", "scitokens-cpp"),
+            define_from_variant("XRDCL_ONLY", "client_only"),
+            define("ENABLE_CEPH", False),
+            define("ENABLE_CRYPTO", True),
+            define("ENABLE_FUSE", False),
+            define("ENABLE_MACAROONS", False),
+            define("ENABLE_VOMS", False),
+            define("FORCE_ENABLED", True),
         ]
         # see https://github.com/spack/spack/pull/11581
         if "+python" in self.spec:
-            options.append("-DPYTHON_EXECUTABLE=%s" % spec["python"].command.path)
+            options.extend(
+                [
+                    define("PYTHON_EXECUTABLE", spec["python"].command.path),
+                    define("XRD_PYTHON_REQ_VERSION", spec["python"].version.up_to(2)),
+                ]
+            )
 
         if "+scitokens-cpp" in self.spec:
             options.append("-DSCITOKENS_CPP_DIR=%s" % spec["scitokens-cpp"].prefix)
 
         return options
 
+    @when("@:5.1.99")
     def setup_build_environment(self, env):
         cxxstdflag = ""
         if self.spec.variants["cxxstd"].value == "98":

--- a/var/spack/repos/builtin/packages/xtcdata/package.py
+++ b/var/spack/repos/builtin/packages/xtcdata/package.py
@@ -12,7 +12,7 @@ class Xtcdata(CMakePackage):
     homepage = "https://github.com/slac-lcls/lcls2"
     url = "https://github.com/slac-lcls/lcls2/archive/refs/tags/3.3.37.tar.gz"
 
-    maintainers = ["valmar"]
+    maintainers("valmar")
 
     version("3.3.37", sha256="127a5ae44c9272039708bd877849a3af354ce881fde093a2fc6fe0550b698b72")
 

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -15,6 +15,7 @@ class Yoda(AutotoolsPackage):
 
     tags = ["hep"]
 
+    version("1.9.8", sha256="7bc3062468abba50aff3ecb8b22ce677196036009890688ef4533aaa7f92e6e4")
     version("1.9.7", sha256="8d07bb04dcb79364858718a18203452d8d9fa00029fa94239eafa8529032b8ff")
     version("1.9.6", sha256="21523fa2f6b6c8f3348959f3a948734a930ca25951d3c9190b4424e13735f2a4")
     version("1.9.5", sha256="59191a0e9afa8db53ffaa2079f8532e5b13de1be622703d6f7060d3610528b6b")

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -20,7 +20,7 @@ class Zoltan(AutotoolsPackage):
 
     """
 
-    homepage = "http://www.cs.sandia.gov/zoltan"
+    homepage = "https://sandialabs.github.io/Zoltan/"
     url = "https://github.com/sandialabs/Zoltan/archive/v3.83.tar.gz"
 
     version("3.901", sha256="030c22d9f7532d3076e40cba1f03a63b2ee961d8cc9a35149af4a3684922a910")

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -23,6 +23,7 @@ class Zoltan(AutotoolsPackage):
     homepage = "http://www.cs.sandia.gov/zoltan"
     url = "https://github.com/sandialabs/Zoltan/archive/v3.83.tar.gz"
 
+    version("3.901", sha256="030c22d9f7532d3076e40cba1f03a63b2ee961d8cc9a35149af4a3684922a910")
     version("3.83", sha256="17320a9f08e47f30f6f3846a74d15bfea6f3c1b937ca93c0ab759ca02c40e56c")
 
     patch("notparallel.patch", when="@3.8")


### PR DESCRIPTION
- Update Intel Pin package up to 3.27 (#37470)
- libpng package: fix build error on macOS arm64 (#37613)
- Allow using -j to control the parallelism of concretization (#37608)
- e4s ci: trilinos +rocm: enable belos to fix build failure (#37617)
- gegl: add v0.4.44 (#37516)
- add 3.0b release (#37599)
- Environments: store spack version/commit in spack.lock (#32801)
- Install/update the qt dependency (#37600)
- py-pysam: adding version 0.21.0 (#37623)
- Coastal Codes (#37176)
- Improve error messages when Spack finds a too new DB / lockfile (#37614)
- Add pika 0.15.1 (#37628)
- Improve error message for buildcaches (#37626)
- AML: Convert to new stand-alone test process (#35701)
- cudnn: add versions 8.5.0, 8.6.0, 8.7.0 (#35998)
- [geant4,geant4-data] New version 10.7.4 (#37382)
- Fix logic in setting oneapi microarchitecture flags (#37634)
- Update tensorflow variant defaults to match upstream defaults (#37610)
- py-mne: add 1.4.0 and py-importlib-resources: add 5.12.0 (#37624)
- py-rsatoolbox: add 0.0.5, 0.1.0 and 0.1.2 (#37595)
- intel-oneapi-mkl: support gnu openmp (#37637)
- GDAL: add v3.7.0 (#37598)
- Add more variants for STREAM to customize build (#37283)
- [root] New version 6.28.04 with C++20 support (#37640)
- Update archspec to v0.2.1 (#37633)
- Allow buildcache specs to be referenced by hash (#35042)
- Osu/mvapich2.3.7 1 (#37636)
- py-dill: add v0.3.1.1 (#37415)
- py-lightly: add v1.4.5 (#37625)
- py-asdf: add 2.15.0 and dependencies (#37642)
- gitlab ci: release fixes and improvements (#37601)
- Add HDF5 version 1.14.1 (#37579)
- e4s ci stacks: add: hdf5-vol-{log,cache} (#37651)
- [gsoap] New package gSOAP (#37647)
- new pkg: py-psalg (#37653)
- new pkg: py-psmon (#37652)
- `spack spec`: remove noisy `@=` from output (#37663)
- py-lightly: py-torch~distributed supported in next release (#37558)
- Adding librdkafka versions 1.9.2, 2.0.2 (#37501)
- freecad: new package w/ dependencies/updates (#37557)
- gcc: add 12.3.0 (#37553)
- concretizer: don't change concrete environments without `--force` (#37438)
- Kokkos: add new release and new architectures (#37650)
- `spack find`: get rid of @= in arch/compiler headers (#37672)
- environment-modules: add version 5.3.0 (#37671)
- Bump tutorial command (#37674)
- palace: add v0.11.1 and explicit BLAS support (#37605)
- [jwt-cpp] New package (#37641)
- hdf5: fix showconfig (#34920)
- dlb: add v3.3 (#37677)
- routinator: update, deprecate old version (#37676)
- add new package flux-security (#37668)
- bugfix: don't look up patches from packages for concrete specs
- bugfix: don't look up virtual information for unknown packages
- bugfix: allow reuse of packages from foreign namespaces
- new pkg: py-psana (#37666)
- py-sphinx: add v7.0.1 (#37665)
- Update package.py for maker (#37662)
- iso-codes: add v4.15.0 (#37661)
- fplll: add v5.4.4 (#37659)
- code-server: add v4.12.0 (#37658)
- canal: add v1.1.6 (#37657)
- amrfinder: add v3.11.8 (#37656)
- oneapi: before script load modules (#37678)
- py-timm: add v0.9 (#37654)
- [scitokens-cpp] New variant cxxstd, depend on standalone jwt-cpp (#37643)
- tmalign: new version 20220412 (#37645)
- hwloc: explicitly disable building netloc for ~netloc (#35604)
- tmscore: adding new package (#37644)
- stdexec: Add 23.03 (#37638)
- Add double-batched FFT library v0.4.0 (#37616)
- Add ut (#37603)
- micromamba: adding version 1.4.2 (#37594)
- [davix] Enable third party copies with gSOAP (#37648)
- go: add v1.20.4 (#37660)
- subversion: add v1.14.2 (#37543)
- SUNDIALS: new version of sundials and guard against examples being install (#37576)
- Update PyTorch ecosystem (#37562)
- dos2unix: add v7.4.4 (#37512)
- crtm-fix: correct invalid checksum for v2.4.0 (#37500)
- gsl-lite: add v0.41.0 (#37483)
- Improve package source code context display on error  (#37655)
- vdt: add v0.4.4 (#37533)
- trimgalore: add v0.6.9 (#37532)
- tig: add v2.5.8 (#37531)
- shtools: add v4.10.2 (#37530)
- preseq: add v2.0.3 (#37528)
- mutationpp: add v1.0.5 (#37527)
- mrchem: add v1.1.2 (#37526)
- lighttpd: add v1.4.69 (#37525)
- libvterm: add v0.3.1 (#37524)
- libluv: add v1.44.2-1 (#37522)
- libfyaml: add v0.8 (#37520)
- krakenuniq: add v1.0.4 (#37519)
- graphviz: add v8.0.5 (#37517)
- fullock: add v1.0.50 (#37515)
- f3d: add v2.0.0 (#37514)
- dust: add v0.8.6 (#37513)
- diamond: add v2.1.6 (#37511)
- cups: add v2.3.3 (#37510)
- cronie: add v1.6.1 (#37509)
- beast-tracer: add v1.7.2 (#37508)
- bat: add v0.23.0 (#37507)
- actsvg: add v0.4.33 (#37503)
- babl: add v0.1.106 (#37506)
- audit-userspace: add v3.1.1 (#37505)
- bdii: add v6.0.1 (#37499)
- zoltan: add v3.901 (#37498)
- perl-module-build-tiny: add v0.044 (#37497)
- packmol: add v20.0.0 (#37496)
- p11-kit: add v0.24.1 (#37495)
- libnsl: add v2.0.0 (#37494)
- libconfuse: add v3.3 (#37493)
- harfbuzz: add v7.2.0 (#37492)
- entt: add v3.11.1 (#37491)
- cpp-httplib: add v0.12.3 (#37490)
- yoda: add v1.9.8 (#37487)
- shadow: add v4.13 (#37485)
- g2c: add v1.7.0 (#37482)
- coinutils: add v2.11.9 (#37481)
- codec2: add v1.1.0 (#37480)
- alluxio: add v2.9.3 (#37488)
- circos: add v0.69-9 (#37479)
- gitlab ci: reduce job name length of build_systems pipeline (#37686)
- trilinos: @develop fixes (#37615)
- Upgrading kosh to 3.0 (#37471)
- unify: when_possible and unify: true -- Bugfix for error in 37438 (#37681)
- Add conflict for pika with fmt@10 and +cuda/rocm (#37679)
- libxcb/xcb-proto: Enable internal Python dependency (#37575)
- Update llvm recipe regarding libomptarget. (#36675)
- check_modules_set_name: do not check for "enable" key (#37701)
- gha bootstrap-dev-rhel8: configure git safe.directory (#37702)
- Requirements and preferences should not define (non-git) versions (#37687)
- Revert "hdf5: fix showconfig (#34920)" (#37707)
- gha rhel8-platform-python: configure git safe.directory (#37708)
- CI: Expand E4S ROCm stack to include missing DaV packages (#36843)
- Windows: fix MSVC version handling (#37711)
- libxpm package: fix RHEL8 build with libintl (#37713)
- Fix `spack find` not able to display version ranges in compilers (#37715)
- emacs: convert to new stand-alone test process (#37725)
- Add recently added Spack Docker Images to documentation (#37732)
- Tk/Tcl packages: speed up file search (#35902)
- celeritas: new version 0.2.2 (#37731)
- spack test: fix stand-alone test suite status reporting (#37602)
- libxcb: depend on python, remove releases that need python 2 (#37698)
- whizard: build newer versions in parallel (#37422)
- gitlab ci: no copy-only pipelines w/ deprecated config (#37720)
- Limit deepcopy to just the initial "all" section (#37718)
- lmod: fix build, bump patch version (#37744)
- Added version 1.3.1 (#37735)
- Add aws-plcuster[-aarch64] stacks  (#37627)
- maintainers: switch from list to directive (#37752)
- Bugfix: allow preferred new versions from externals (#37747)
- Bump Spack version on develop to 0.21.0.dev0 (#37760)
- [xrootd] New variants, new version, improve build config (#37682)
