### PR TITLE
Ups table file updates for newer spack

### DIFF
--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -26,13 +26,15 @@ QUALIFIERS=""
 
 {%set spack_root = os.environ['SPACK_ROOT'] %}
 {%set install_root =  spack_root[0:spack_root.find('/spack/')] %}
-{%if spec.prefix[0:spec.prefix.find('/'+spec.name)] == install_root %}
+{%if spec.prefix.startswith(install_root) %}
 
 Action = setup
     prodDir()
     setupEnv()
 {% for package in spec._dependencies.keys() %}
-    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+   {% if spec[package].prefix != "/usr" %}
+    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@=')[0] == package%}{{c.split('@=')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+   {% endif %}
 {% endfor %}
 
 {% block environment %}

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -32,7 +32,7 @@ Action = setup
     prodDir()
     setupEnv()
 {% for package in spec._dependencies.keys() %}
-   {% if spec[package].prefix != "/usr" %}
+   {% if spec[package].prefix.startswith(install_root) %}
     setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@=')[0] == package%}{{c.split('@=')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
    {% endif %}
 {% endfor %}


### PR DESCRIPTION

Three things
* externals now show up in the dependencies, but don't get module files generated, so we had ups dependencies on nonexistent ups packages
* @= instead of @ in package strings
* check for package being in install area was failing with padding
This should fix all three.