### PR TITLE
small tweaks for building mu2e stack

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1248,6 +1248,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # TODO: allow more than one active extendee.
         if deps:
+            if len(deps) == 2 and repr(deps[0]) == repr(deps[1]):
+                return deps[0]
             assert len(deps) == 1
             return deps[0]
 

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -209,7 +209,11 @@ class Glib(Package):
 
         # arguments for older versions
         if self.spec.satisfies("@:2.72"):
-            args.append("-Dgettext=external")
+            if self.spec["iconv"].name == "libc":
+                args.append("-Dgettext=libc")
+            else:
+                args.append("-Dgettext=external")
+
         if self.spec.satisfies("@:2.74"):
             if self.spec["iconv"].name == "libc":
                 args.append("-Diconv=libc")

--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -47,7 +47,7 @@ class Libgd(AutotoolsPackage):
             string=True,
         )
         filter_file(
-            "#include<string.h>", 
-            "#include<string.h>\n#include<limits.h>",
+            "#include *<string.h>",
+            "#include <string.h>\n#include <limits.h>",
             "src/gd_gd2.c"
         )

--- a/var/spack/repos/builtin/packages/range-v3/package.py
+++ b/var/spack/repos/builtin/packages/range-v3/package.py
@@ -23,6 +23,7 @@ class RangeV3(CMakePackage):
     maintainers("greenc-FNAL")
 
     version("master", branch="master")
+    version("0.12.0", sha256="015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb")
     version("0.11.0", sha256="376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c")
     version("0.10.0", sha256="5a1cd44e7315d0e8dcb1eee4df6802221456a9d1dbeac53da02ac7bd4ea150cd")
     version("0.5.0", sha256="32e30b3be042246030f31d40394115b751431d9d2b4e0f6d58834b2fd5594280")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -232,6 +232,9 @@ class Root(CMakePackage):
     depends_on("libxft", when="+x")
     depends_on("libxpm", when="+x")
     depends_on("libsm", when="+x")
+    depends_on("fontconfig", when="+x")
+    depends_on("xextproto", when="+x @:6.08")
+    depends_on("xextproto", when="+x @6.22:")
 
     # OpenGL
     depends_on("ftgl@2.4.0:", when="+opengl")


### PR DESCRIPTION
* libc iconv change for "glib"
* range-v3 version
* root dependencies referred to later not included in depends_on clauses