### PR TITLE
Remove unnecessary link-time dependence on `xproto`.

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -228,7 +228,6 @@ class Root(CMakePackage):
 
     # X-Graphics
     depends_on("libx11", when="+x")
-    depends_on("xproto", when="+x")
     depends_on("libxext", when="+x")
     depends_on("libxft", when="+x")
     depends_on("libxpm", when="+x")


### PR DESCRIPTION
This partially reverts commit 7a3f7d0e30346564e24b0523112ad38c48cf4f95.
