### PR TITLE
LLVM/Clang 17.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -51,6 +51,8 @@ class Libuv(AutotoolsPackage):
         "See: https://github.com/libuv/libuv/issues/2805",
     )
 
+    conflicts("%gcc@:4.8.99", when="@1.44:", msg="libuv requires stdatomic.h")
+
     @when("@:1.43")
     def autoreconf(self, spec, prefix):
         # This is needed because autogen.sh generates on-the-fly

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -35,6 +35,7 @@ class Llvm(CMakePackage, CudaPackage):
     family = "compiler"  # Used by lmod
 
     version("main", branch="main")
+    version("17.0.1", sha256="d51b10be66c10a6a81f4c594b554ffbf1063ffbadcb810af37d1f88d6e0b49dd")
     version("16.0.6", sha256="56b2f75fdaa95ad5e477a246d3f0d164964ab066b4619a01836ef08e475ec9d5")
     version("16.0.5", sha256="e0fbca476693fcafa125bc71c8535587b6d9950293122b66b262bb4333a03942")
     version("16.0.4", sha256="10c3fe1757d2e4f1cd7745dc548ecf687680a71824ec81701c38524c2a0753e2")


### PR DESCRIPTION
- Add checksum for LLVM/Clang 17.0.1
- [libuv] >=1.44 requires `<stdatomic.h>` (missing from GCC <4.9)
