### PR TITLE
feature/config list scopes

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -71,6 +71,21 @@ def setup_parser(subparser):
 
     sp.add_parser("list", help="list configuration sections")
 
+    list_scopes_parser = sp.add_parser("list-scopes", help="list defined scopes")
+    stype = list_scopes_parser.add_mutually_exclusive_group(required=False)
+    stype.add_argument(
+        "--file",
+        action="store_true",
+        default=False,
+        help="list only writable scopes with an associated file"
+    )
+    stype.add_argument(
+        "--non-platform",
+        action="store_true",
+        default=False,
+        help="list only non-platform scopes"
+    )
+
     add_parser = sp.add_parser("add", help="add configuration parameters")
     add_parser.add_argument(
         "path",
@@ -194,6 +209,11 @@ def config_list(args):
     Used primarily for shell tab completion scripts.
     """
     print(" ".join(list(spack.config.SECTION_SCHEMAS)))
+
+
+def config_list_scopes(args):
+    scopes = reversed(spack.config.CONFIG.file_scopes) if args.file else spack.config.CONFIG._non_platform_scopes if args.non_platform else reversed(spack.config.CONFIG.scopes.values())
+    print(" ".join([s.name for s in scopes]))
 
 
 def config_add(args):
@@ -467,6 +487,7 @@ def config(parser, args):
         "blame": config_blame,
         "edit": config_edit,
         "list": config_list,
+        "list-scopes": config_list_scopes,
         "add": config_add,
         "rm": config_remove,
         "remove": config_remove,

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -446,11 +446,8 @@ class Configuration:
         """Non-internal non-platform scope with highest precedence
 
         Platform-specific scopes are of the form scope/platform"""
-        generator = reversed(self.file_scopes)
-        highest = next(generator)
-        while highest and highest.is_platform_dependent:
-            highest = next(generator)
-        return highest
+        generator = self._non_platform_scopes
+        return next(generator)
 
     def matching_scopes(self, reg_expr) -> List[ConfigScope]:
         """
@@ -699,6 +696,15 @@ class Configuration:
             syaml.dump_config(data, stream=sys.stdout, default_flow_style=False, blame=blame)
         except (syaml.SpackYAMLError, IOError) as e:
             raise ConfigError(f"cannot read '{section}' configuration") from e
+
+    @property
+    def _non_platform_scopes(self):
+        """Returns non-platform scopes, highest priority first."""
+        for s in reversed(self.file_scopes):
+            if s.is_platform_dependent:
+                continue
+            else:
+                yield s
 
 
 @contextmanager

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -665,3 +665,20 @@ spack:
 
     with ev.Environment(str(tmpdir)) as e:
         assert not e.manifest.pristine_yaml_content["spack"]["config"]["ccache"]
+
+def test_config_list_scopes():
+    output = config("list-scopes")
+    assert "command_line" in output
+    assert "_builtin" in output
+    assert any("/" in s for s in output)
+
+def test_config_list_scopes_file():
+    output = config("list-scopes", "--file")
+    assert "site" in output
+    assert "_builtin" not in output
+    assert any("/" in s for s in output)
+
+def test_config_list_scopes_non_platform():
+    output = config("list-scopes", "--non-platform")
+    assert "site" in output
+    assert "default" in output


### PR DESCRIPTION
- py-kombu: pick older version of py-setuptools (#40642)
- py-kombu: fix setuptools bound (#40646)
- intel-tbb: patch patch for Apple's patch (#40640)
- Docs: Add version range example to conditional dependencies (#40630)
- py-kiwisolver: add a new version (#40653)
-  zlib-ng: add v2.1.4 (#40647)
- glib: add patch with a fix for PTRACE_0_EXITKILL (#40655)
- Add Score-P 8.3 and dependencies (#40478)
- libxml2: fix GitLab patch (#40658)
- vtk: fix GitLab patch (#40659)
- garfieldpp: fix GitLab patch (#40660)
- gobject-introspection: fix GitLab patch (#40661)
- knem: fix GitLab patch (#40662)
- libtheora: fix GitLab patch (#40657)
- Docs: Update spec variant checks plus python quotes and string formatting (#40643)
- py-cython: new version, python 3.11 upperbound (#40343)
- concretizer verbose: show progress in % too (#40654)
- 3proxy: respect compiler choice (#39240)
- nghttp2: add v1.57.0 (#40652)
- geant4: add patch for when using the system expat library (#40650)
- ngspice: new version 41 and option osdi (#40664)
- audit: add check for GitLab patches (#40656)
- py-scikit-learn: add v1.3.2 (#40672)
- Update survey package file for survey version 9 changes. (#40619)
- Add rccl and nccl variants to cp2k and cosma (#40451)
- Adios2: add kokkos variant (#40623)
- fix installation error of bear (#40637)
- armpl-gcc: add version 23.10 and macOS support (#40511)
- exago: fix v1.5.1 tag; only allow python up to 3.10 for for @:1.5 (#40676)
- hiop +cuda: fix issue 40678 (#40688)
- neovim: conflict for libluv problem on macOS + add newer versions of neovim and libluv (#40690)
- Added new benchmark version up to 1.8.3 (#40689)
- openmpi: fix pmi@4.2.3: compat (#40686)
- Updating rvs binary path. (#40604)
- Add ufs-utils@1.11.0 (#40695)
- Windows: search PATH for patch utility (#40513)
- [cp2k] Use fftw3 MKL by default when cp2k is compiled with mkl (#40671)
- Add dlaf variant to cp2k (#40702)
- py-lightning: py-torch~distributed is broken again (#40696)
- ci: darwin aarch64 use apple-clang-15 tag (#40706)
- ci: don't put compilers in config (#40700)
- build(deps): bump pytest from 7.4.2 to 7.4.3 in /lib/spack/docs (#40697)
- PyTorch: patch breakpad dependency (#40648)
- Added Highway versions up to 1.0.7 (#40691)
- cuda: add NVHPC_CUDA_HOME. (#40507)
- initial commit to fix mivisionx build for 5.6 (#40579)
- fdb: add releases v5.11.23 and v5.11.17 (#40571)
- Paraview 5.12 prep (#40527)
- git versions: fix commit shas [automated] (#40703)
- libluv: require CMake 3 and CMP0042 (#40716)
- modules: hide implicit modulefiles (#36619)
- spack checksum: show long flags in usage output (#40407)
- PythonPackage: nested config_settings (#40693)
- modules: no --delim option if separator is colon character (#39010)
- Add conflict between cxxstd > 17 and cuda < 12 in pika (#40717)
- spack checksum pkg@1.2, use as version filter (#39694)
- Update spack package for exago@1.6.0 release (#40614)
- unmaintained a* packages: update to use f-strings (#40467)
- curl: Fix librtmp variant (#40713)
- PythonPackage: allow archive_files to be overridden (#40694)
- dataTransferKit: add v3.1.1, v3.1.0 (#40556)
- ldak: add v5.2 & add maintainer (#40710)
- itk: misc fixes (#39832)
- plasma: add version 23.8.2 (#40728)
- akantu: use f-strings (#40466)
- gromacs: fix version branch in intel fftw (#40489)
- Fixes and options for package spglib (#40684)
- ci: spack compiler find should list extra config scopes (#40727)
- gromacs: default to external blas & lapack (#40490)
- strumpack: add version 7.2.0 (#40732)
- octopus: split netcdf-c and netcdf-fortran dependency (#40685)
- OCI buildcache (#38358)
- External finding: update default paths; treat .bat as executable on Windows (#39850)
- mgard@2020-10-01 %oneapi@2023: turn of c++11-narrowing via cxxflags (#40743)
- e4s ci stacks: add exago specs (#40712)
- hipsycl: restrict compatibility with llvm for v0.8.0 (#40736)
- MSVC: detection from registry (#38500)
- py-numpy: add v1.26 (#40057)
- py-comm: add 0.1.4 (#40669)
- py-bluepyemodel: opensourcing with dependencies (#40592)
- New version of py-langsmith (#40674)
- NCCL: Add version 2.19.3-1 (#40704)
- py-generateds: new package (#40555)
- py-moarchiving: new package (#40558)
- mercury: add v2.3.1 (#40749)
- Add liggght patched for newer compiler (#38685)
- py-numcodecs: fix broken sse / avx2 variables (#40754)
- acts: add v28.1.0:30.3.2 (#40723)
- ASP-based solver: avoid cycles in clingo using hidden directive (#40720)
- mfem: support petsc+rocm with spack-installed rocm (#40768)
- exago: fix exago missing on PYTHONPATH when `+python` (#40748)
- pcl: checksum new versions (#39039)
- PyTorch: build with external fp16 (#40760)
- py-pandas: add v2.1.2 (#40734)
- Fix an issue with using the environment variable `MACHTYPE` which is not always defined (#40733)
- RAJA: add "plugins" variant (#40750)
- acts: new variant +binaries when +examples (#40738)
- aluminum: make network variants "sticky" (#40715)
- justbuild: add version 1.2.2 (#40701)
- pegtl: add v3.2.7 (#35687)
- ISPC: Drop ncurses workaround in favor of patch (#39662)
- Fetch recola from gitlab and add a new version of collier (#40651)
- binary_distribution.py: fix type annotation singleton (#40572)
- linaro-forge: add v23.0.4 (#40772)
- Get utilities necessary for successful PIO build (#40502)
- spectre: add v2023.10.11 (#40463)
- must: remove release candidates (#40476)
- freesurfer: fix support for linux (#39864)
- tty: flush immediately (#40774)
- ci: print colored specs in concretization progress (#40711)
- squashfuse: add version 0.5.0 (#40775)
- adding sha for OMB 7.3 release (#40784)
- build(deps): bump black from 23.9.1 to 23.10.1 in /lib/spack/docs (#40680)
- Add hdf5 version 1.14.3. (#40786)
- dd4hep: Add tag for version 1.27 (#40776)
- selalib: add (sca)lapack dependency (#40667)
- docs: update `license()` docs with examples and links (#40598)
- Added NVML and cgroup support to the slurm package (#40638)
- tutorial: replace zlib -> gmake to avoid deprecated versions (#40769)
- ci: bump tutorial image and toolchain (#40795)
- spack checksum: fix error when initial filter yields empty list (#40799)
- Seacas: Update for latest seacas releaes version (#40698)
- spack checksum: improve signature (#40800)
- Fix interaction of spec literals that propagate variants with unify:false (#40789)
- add new recipe for rocm packages- amdsmi (#39270)
- TAU: Added dyninst variant (#40790)
- Fix cflags requirements (#40639)
- Update sperr (#40626)
- PyTorch: build with external gloo (#40759)
- force color in subshell if not SPACK_COLOR (#40782)
- beatnik: mall changes for  v1.0 (#40726)
- fix create/remove env with invalid spack.yaml (#39898)
- Enable address sanitizer in rocm's llvm-amdgpu package. (#40570)
- Fix env remove indentation (#40811)
- Revert python build isolation & setuptools source install (#40796)
- `SetupContext.get_env_modifications` fixes and documentation (#40683)
- Parser: fix ambiguity with whitespace in version ranges (#40344)
- Executable.add_default_arg: multiple (#40801)
- fix: sentence framing (#40809)
- podio: Add latest tags and variants and update dependencies accordingly (#40182)
- Add 2.33 to tau (#40810)
- LBANN: add explicit variant for shared builds (#40808)
- butterflypack: add version 2.4.0 (#40826)
- petsc, py-petsc4py: add v3.20.1 (#40794)
- amrex: add v23.11 (#40821)
- superlu-dist:  -std=c99 prevents usage of putenv() (#40729)
- hiop: fix cuda constraints and add tag to versions (#40721)
- changelog: add 0.20.2 and 0.20.3 changes (#40818)
- build(deps): bump black in /.github/workflows/style (#40681)
- pflotran: add version 5.0.0 (#40828)
- heffte: add v2.4.0 (#40741)
- pika: Add 0.20.0 (#40817)
- libCEED v0.12.0, Ratel v0.3.0 (#40822)
- py-matplotlib: add v3.8.1 (#40819)
- vcftools: add v0.1.16 (#40805)
- ceres-solver: adding version 2.2.0 (#40824)
- edm4hep: Add 0.10.1 tag and update maintainers (#40829)
- Cherry-picking virtual dependencies (#35322)
- openscenegraph: support more file formats (#39897)
- env remove: add a unit test removing two environments (#40814)
- spack external find: fix multi-arch troubles (#33973)
- go/rust bootstrap: no versions if unsupported arch (#40841)
- exago: update petsc dependency (#40831)
- depfile: deal with empty / non-concrete env (#40816)
- PyTorch: build with external sleef (#40763)
- clingo ^pyhton@3.12: revisit distutils fix (#40844)
- llvm: add 17.0.2-4 (#40820)
- Gaudi: Add a few versions and a dependency on tbb after 37.1 (#40802)
- add charliecloud 0.35 (#40842)
- Fixes to ffcx @0.6.0 (#40787)
- py-pyside2: fix to build with newer llvm and to use spack install headers (#40544)
- Update to latest version (#40778)
- py-pint: new versions 0.21, 0.22 (#40745)
- bugfix: computing NodeID2 in requirement node_flag_source (#40846)
- eccodes: rename variant 'definitions' to 'extra_definitions' (#36186)
- highfive: 2.8.0 (#40837)
- Automated deployment to update package flux-sched 2023-10-18 (#40596)
- Update Anaconda3 -- add version 2023.09-0 for x86_64, aarch64, and ppc64le (#40622)
- libtheora: fix build on macos (#40840)
- qt-*: add v6.5.3 & v6.6.0 (#40833)
- qt-svg: new package for Qt6 SVG module (#40834)
- MFEM: add logic to find CUDA math-libs when using HPC SDK installation (#40815)
- tau: update 2.33 hash, add syscall variant (#40851)
- fix typo in packaging guide (#40853)
- py-spython: updating to @0.3.1 (#40839)
- oci parsing: make image name case insensitive (#40858)
- ASP-based solver: fix for unsplittable providers (#40859)
- xdmf3: fix  compilation with hdf5@1.10 and above (#37551)
- squashfuse: remove url_for_version (#40862)
- clingo-bootstrap: force setuptools through variant (#40866)
- Bugfix: propagation of multivalued variants (#39833)
- GDAL: add v3.7.3 (#40865)
- environment: solve one spec per child process (#40876)
- linux-headers: support multiple versions (#40877)
- sundials +sycl: add cxxflags=-fsycl via flag_handler (#40845)
- hiop: fix cuda constraints (#40875)
- hdf5-vol-async: better specify dependency condition (#40882)
- spack.modules.commmon: pass spec to SetupContext (#40886)
- c-blosc: add v1.21.5 (#40888)
- mfem: allow cuda/rocm builds with superlu-dist built without cuda/rocm (#40847)
- Environments: Add support for including definitions files (#33960)
- Hidden modules: always append hash (#40868)
- bugfix: compress aliases for first command in completion (#40890)
- Add command and package suggestions (#40895)
- spack env activate: create & activate default environment without args (#40756)
- qt: new version 5.15.11 (#40884)
- mpich: remove unnecessary tuples and upperbounds (#40899)
- Add Python as build dependency of Julia (#40903)
- enable threading in amdlibflame (#40852)
- pythia8: fix configure args (#40644)
- Environments: remove environments created with SpackYAMLErrors (#40878)
- c-blosc2: add v2.11.1 (#40889)
- error messages: condition chaining (#40173)
- Introduce `default_args` context manager (#39964)
- defaults/modules.yaml: hide implicits (#40906)
- adios2: add v2.9.2 release (#40832)
- docs: mention public build cache for GHA (#40908)
- fix prefix_inspections keys in example (#40904)
- Don't let runtime env variables of compiler like deps leak into the build environment (#40916)
- Add support for aliases (#17229)
- docs: expand section about relocation, suggest padding (#40909)
- package/qgis: add latest ltr (#40752)
- spack compiler find --[no]-mixed-toolchain (#40902)
- database: optimize query() by skipping unnecessary virtual checks (#40898)
- archspec: update to v0.2.2 (#40917)
- ASP: targets, compilers and providers soft-preferences are only global (#31261)
- Change container labeling so that "latest" is the latest tag (#40593)
- Update package.py for new release 2.30.0 (#40907)
- fix configure args for darshan-runtime (#40873)
- catch exceptions in which_string (#40935)
- Update the branch for the tutorial command (#40934)
- ci: do not retry timed out build jobs (#40936)
- superlu-dist: add +parmetis variant. (#40746)
- Ensure global command line arguments end up in args like before (#40929)
- tutorial pipeline: force gcc@12.3.0 (#40937)
- Propagate variant across nodes that don't have that variant (#38512)
- sleef: build shared libs (#40893)
- julia: Add v1.9.3 (#40911)
- tutorial: use lmod@8.7.18 because @8.7.19: has bugs (#40939)
- intel-xed: fix git hash for mbuild, add version 2023.10.11 (#40922)
- adds  cubew 4.8.1, cubelib 4.8.1 and cubegui 4.8.1, 4.8.2 (#40612)
- discotec: add compression variant (#40925)
- mapl: add v2.41 and v2.42 (#40870)
- julia: constrain patchelf version (#40938)
- RAJA package: find libs (#40885)
- tutorial stack: update for changes to the basics section for SC23 (#40942)
- Add new tag on AMS (#40949)
- ScaFaCoS 1.0.4 (#40948)
- abinit:	add v9.10.3 (#40919)
- tcl: filter compiler wrappers to avoid pointing to Spack (#40946)
- lcov: add version2, embed perl path in binaries (#39342)
- py-lightning: add v2.1.1 (#40957)
- libevent: always autogen.sh (#40945)
- Revert "defaults/modules.yaml: hide implicits (#40906)" (#40955)
- podio: Add the latest tag (0.17.2) (#40956)
- modules: restore exclude_implicits (#40958)
- libgit2: add python as test dependency (#40863)
- modules: remove deprecated code and test data (#40966)
- intel-oneapi-mkl: do not set __INTEL_POST_CFLAGS env variable (#40947)
- Set version to 0.22.0.dev0 (#40975)
- buildcache: skip unrecognized metadata files (#40941)
- sundials: add v6.6.2 (#40920)
- py-macs3: adding zlib dependency (#40979)
- DiHydrogen, Hydrogen, and Aluminum CachedCMakePackage (#39714)
- hypre: add in hipblas dependency due to superlu-dist (#40980)
- mfem: add hipblas dependency for superlu-dist (#40981)
- [lcov] Add build and runtime deps necessary for lcov@2.0.0: (#40974)
- Add symlinks for hdf5 library names when built in debug mode (#40965)
- docs: tweak formatting of `+:` and `-:` operators (#40988)
- Revert "Deactivate Cray sles, due to unavailable runner (#40291)" (#40910)
- Release Gotcha v1.0.5 (#40973)
- new release cpp-logger v0.0.2 (#40972)
- PyTorch: specify CUDA root directory (#40855)
- py-black: add v23.10: (#40959)
- Add adiak v0.4.0 (#40993)
- info: rework spack info command to display variants better (#40998)
- env: compute env mods only for installed roots (#40997)
- gromacs et al: fix ^mkl pattern (#41002)
- pflotran: tweak for building with xsdk rocm/hip (#40990)
- alquimia: apply patch for iso_c_binding to latest version (#40989)
- fdb: add dependency on eckit later release (#40737)
- builtin.repo: fix ^mkl pattern in minor packages (#41003)
- libpspio 0.3.0 (#40953)
- new release (#41010)
- `spack deconcretize` command (#38803)
- Ginkgo: 1.7.0, change compatibility, update option oneapi->sycl (#40874)
- Add geomdl package (#40933)
- libEnsemble: add v1.1.0 (#40969)
- update to latest version (#40905)
- py-pynucleus: Add variant, modify dependencies (#41006)
- PyTorch: allow +openmp on macOS (#41025)
- sundials: add license directive (#41028)
- likwid: add 5.3.0 version (#41008)
- GEOS: add new versions (#41030)
- build(deps): bump mypy from 1.6.1 to 1.7.0 in /lib/spack/docs (#41020)
- py-pandas: add v2.1.3 (#41017)
- py-mypy: add v1.4:v1.7 (#41015)
- superlu-dist: add v8.2.0 (#41004)
- metkit: add v1.10.2 and v1.10.17 (#40668)
- build(deps): bump black in /.github/workflows/style (#40968)
- Compiler.debug_flags: drop -gz (#40900)
- Add license directives to various packages (#41039)
- conquest: add build system changes and library paths (#40718)
- riscv-gnu-toolchain: add v2023.09.13 -> v2023.10.18 (#40854)
- epics-base: patch to avoid failure on "perl xsubpp" when "xsubpp" otherwise works fine. (#40849)
- qwt: conflict with qt-base (Qt6) (#40883)
- build(deps): bump black from 23.10.1 to 23.11.0 in /lib/spack/docs (#40967)
- hdf5: add a new variant for enabling sub-filing VFD (#40804)
- dealii: add v9.5.0, v9.5.1 (#40747)
- spack diff: allow hashes from mirrors (#41043)
- gzip: deprecate <1.13 for vulnerability (#41044)
- info: improve coverage (#41001)
- Release Brahma v0.0.2 (#40994)
- CMake Package: support building  `~ownlibs` on Windows (#38758)
- py-numpy: add v1.26.2 (#41046)
- DLA-future: add v0.3.0 (#41042)
- dd4hep: avoid IndexError in setup_run_environment (#41051)
- build(deps): bump urllib3 from 2.0.7 to 2.1.0 in /lib/spack/docs (#41055)
- ispc: add v1.21 and v1.21.1 (#41053)
- GDAL: add v3.8.0 (#41047)
- modules: unit-tests without polluted user scope (#41041)
- fairmq: add v1.8.1 (#41007)
- R: cleanup recipe and fix linking to lapack libraries (#41040)
- Fix infinite recursion when computing concretization errors (#41061)
- Add papyrus to the list of broken tests (#40923)
- gmake: fix bootstrap (#41060)
- bison: conflict %oneapi due to possible miscompilation (#40860)
- xsdk: add version 1.0.0 (#40825)
- Fix typo in mumps recipe (#41062)
- esmf: add v8.6.0 (#41066)
- ParaView: Add release candidate 5.12.0-RC1 (#41009)
- libevent: call autoreconf directly instead of via autogen.sh (#41057)
- mrtrix3: fix some issues w/ 3.0.3 and add 3.0.4 (#41036)
- hpctoolkit: Add depends on autotools for @develop (#41067)
- cp2k: add hipfft and hipblas explicitly (#41074)
- docs: packages config on separate page, demote bootstrapping (#41085)
- taskflow: add v3.6.0 (#41098)
- justbuild: add version v1.2.3 (#41084)
- deal.II: Require at least taskflow 3.4 (#41095)
- Update package.py (#41092)
- Add patch for libffi@3.4.4 since failing to install using clang@15 (#41083)
- Add audit check to spot `when=` arguments using wrong named specs (#41107)
- Updates for Ospray@3.0.0 (#41054)
- enable rocAL and add MIVisionX tests (#39630)
- package/lemon: improve (#40971)
- py-lightning: add v2.1.2 (#41106)
- Update PyTorch ecosystem (#41105)
- Improve the error message for deprecated preferences (#41075)
- Use preferred capitalization of "Slurm" (#41109)
- podio: Add latest tag 0.17.3 (#41103)
- libgcrypt: add v1.10.3 (#41111)
- clhep: new version 2.4.7.1 (#41113)
- Update amrex maintainers (#41122)
- r-rlang: add v1.1.1, v1.1.2 (#41114)
- [doxygen] Add versions 1.9.7 and 1.9.8. (#41123)
- llvm: patch missing cstdint include (#41108)
- py-archspec: add v0.2.2 (#41110)
- lcio: Add latest tag 2.20.1 (#41102)
- root: new version 6.30.00 (#41118)
- Permit packages that depend on Intel oneAPI packages to access sdk (#41117)
- Add cxxstd variant to ecflow, update with latest ecflow version (#41120)
- Hydrogen package: avoid newer openblas on power (#41143)
- Update py-quantities (#39201)
- Fix invalid escape sequences (#41130)
- py-pyh5py: reorder dependencies from newest version to oldest (#41137)
- py-gitpython: version bump (#41079)
- py-jsonpath-ng: version bump (#41078)
- Release DLIO Profiler Py 0.0.2 (#41127)
- py-cleo: add versions 2.0.0 2.0.1; add maintainers (#40611)
- Update py-elephant (#39200)
- py-bokeh: new version 3.3.1, and supporting packages (#41089)
- py-pygithub: new versions, dependencies (#41072)
- Automated deployment to update package flux-security 2023-11-18 (#41152)
- Automated deployment to update package flux-core 2023-11-18 (#41154)
- Automated deployment to update package flux-sched 2023-11-18 (#41153)
- py-matplotlib: add v3.7.4, v3.8.2 (#41156)
- libksba: add v1.6.5 (#41129)
- heffte: add sycl variant (#41132)
- build(deps): bump docker/build-push-action from 5.0.0 to 5.1.0 (#41149)
- geant4: new version 11.1.3 (#41112)
- gromacs: Add new variants and clarify existing ones (#41115)
- votca: add v2023 (#41100)
- e4s oneapi stack: turn on +sycl: ginkgo, heffte, petsc, upcxx, warpx (#41157)
- elbencho:  add new version and git master branch (#41136)
- npm: only depend on libvips when @6, remove deprecated versions (#41159)
- docs: document how spack picks a version / variant (#41070)
- sherpa: only enable_or_disable in v3: (#41162)
- Remove a maintainer from CMS packages (#41170)
- glab: add v1.35.0 (#41167)
- rclone: add v1.64.2 (#41166)
- bfs: add v3.0.4 (#41165)
- restic: add v0.16.2 (#41168)
- mpich: support ch3:sock for a non busy-polling option (#40964)
- py-scipy: add v1.11.4 (#41158)
- openblas: optimize flags for A64FX (#41093)
- Catch2: add variant to choose cxx standard (#40996)
- llvm: Remove python bindings when >= v17 (#41160)
- rust: add v1.73.0 and add support for external openssl certs (#41161)
- MSVC preview version breaks clingo build (#41185)
- py-grpcio* do not assume lib / header dir (#41182)
- gromacs: fix newly added variant (#41178)
- qt-base: have QtBase provide qmake, ont QtPackage (#41186)
- elfutils: add version 0.190 (#41187)
- spack style: fix isort on sl:7 (#41133)
- build(deps): bump pygments from 2.16.1 to 2.17.1 in /lib/spack/docs (#41191)
- gettext: add v0.22.4 (#41189)
- Update py-scikit-build-core to version 0.6.1 (#40779)
- Add cxx17_flag to intel.py (#41207)
- python: add missing gmake dependency (#41211)
- perl: add missing gmake dependency (#41210)
- hub: add v2.14.2, update to go module (#41183)
- onnxruntime: fix the call to as_string() operator (#41087)
- ASP-based solver: don't emit spurious debug output (#41218)
- setup_platform_environment before package env mods (#41205)
- edm4hep: add latest tag for 0.10.2 (#41201)
- aocc: help compiler find include paths and libstdc++.so (#40450)
- pulseaudio: add missing m4 dependency (#41216)
- fzf: add v0.44.1 (#41204)
- dd4hep: add v1.27.1 (#41202)
- [nettle] depend on spack managed openssl (#40783)
- gloo: add a patch for building with gcc 12 (#41169)
- composable-kernel, migraphx: Fix build on CentOS8 (#41206)
- test_which: do not mutate os.environ
- Update CHANGELOG.md from v0.21.0
- Add dla-future 0.3.1 (#41219)
- rdma-core: add new variants for a library without Python dependencies (#41195)
- ASP-based solver: don't error for type mismatch on preferences (#41138)
- nlcglib: pass cuda_arch setting to kokkos dependency (#39725)
- starpu: add release 1.4.2 (#41238)
- pfunit: add version 4.7.4 (#41232)
- linaro-forge: update for 23.1 (#41236)
- spack graph: fix coloring with environments (#41240)
- Fix multi-word aliases (#41126)
- iwyu: new versions up 0.21 (depends_on llvm-17) (#41235)
- py-stashcp: new package (#41091)
- Update py-neo (#39213)
- py-dictdiffer: version bump (#41080)
- py-sqlalchemy-utils, py-sql-alchemy: version bump (#41081)
- py-heat: add new package (#39394)
- py-vermin: add latest version 1.6.0 (#41261)
- py-fenics-basix: update for main and future 0.8.0 (#40838)
- force cp2k cuda/rocm variant on elpa (#41241)
- Remove old conflict with gcc@10.3.0 (#41254)
- libxsmm: relax arch requirement (#41193)
- Improve semantic for packages:all:require (#41239)
- googletest: Add 1.13.0 and 1.14.0 tags (#41253)
- Add patch so that ccache can compile with the standard gcc@12 version (#41249)
- pastix: add v6.3.1 (#41265)
- sys-sage: update repo url, rework recipe (#41005)
- fpart: add license and variants (#41257)
- py-llvmlite: add new versions (#41247)
- vapor: add new recipe (#40707)
- libpsm3: add v11.5.1.1 (#41231)
- [sirius] update spack recipe; add v7.5.0 (#41233)
- tests: fix more cases of env variables (#41226)
- Balay/xsdk 1.0.0 updates (#41180)
- docs: refer to oci build cache from containers.rst (#41269)
- Simplify a few CMakePackages by removing redundant directives (#41163)
- verilator: add v5.018 (#41256)
- intel-oneapi 2024.0.0: added new version to packages (#41135)
- handle use of an unconfigured compiler (#41213)
- CargoPackage: add new build system for Cargo packages (#41192)
- Update SST packages to 13.1.0 (#41220)
- cprnc: add new package (#41237)
- CMake: add version 3.27.8 (#41094)
- iverilog-vpi: filter compiler wrappers from a few files (#41244)
- Move compiler renaming to filter_compiler_wrappers (#41275)
- libfabric: Add version 1.20.0 (#41277)
-  slepc: add v3.20.1 (#41274)
- smee-client: add new package (#41280)
- py-transformers: add v4.35.2 (#41266)
- qt-*: new versions 6.6.1 (#41281)
- GoPackage: add new build system for Go packages (#41164)
- build(deps): bump vermin from 1.5.2 to 1.6.0 in /.github/workflows/style (#41285)
- Fix elpa flags (missing optimization) (#41252)
- libvips requires pkg-config to find glib (#41184)
- root: add a webgui patch (#41289)
- celeritas: new version 0.4.0 (#41288)
- ASP-based solver: use a unique ID counter (#41290)
- vtk: Restrict application of patch xdmf2-hdf51.13.2.patch (#40266)
- e4s ci: disable gpu test stack (#41296)
- apple-libuuid: update installation directory (#40416)
- fix hip tests and bump hip-examples to 5.6.1 (#40928)
- update hipblas rocalution, rocsolver, rocsparse to new syntax (#40135)
- cuda: add 12.3.0 (#40827)
- Style fixes: black
- Style fixes: isort
- Style fixes: flake8
- New subcommand config list-scopes
