### PR TITLE
Sphinx-related dependencies for recent Cetmodules

### DIFF
--- a/var/spack/repos/builtin/packages/py-autodocsumm/package.py
+++ b/var/spack/repos/builtin/packages/py-autodocsumm/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAutodocsumm(PythonPackage):
+    """Extended sphinx autodoc including automatic autosummaries"""
+
+    homepage = "https://github.com/Chilipp/autodocsumm"
+    pypi = "autodocsumm/autodocsumm-0.2.11.tar.gz"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    license("Apache-2.0")
+
+    version("0.2.11", sha256="183212bd9e9f3b58a96bb21b7958ee4e06224107aa45b2fd894b61b83581b9a9")
+
+    depends_on("py-setuptools@61.0:", type="build")
+    depends_on("py-versioneer", type="build")
+
+    depends_on("py-sphinx@2.2:7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-cachecontrol/package.py
+++ b/var/spack/repos/builtin/packages/py-cachecontrol/package.py
@@ -13,13 +13,17 @@ class PyCachecontrol(PythonPackage):
     homepage = "https://github.com/ionrock/cachecontrol"
     pypi = "CacheControl/CacheControl-0.12.10.tar.gz"
 
+    version("0.13.0", sha256="fd3fd2cb0ca66b9a6c1d56cc9709e7e49c63dbd19b1b1bcbd8d3f94cedfe8ce5")
     version("0.12.11", sha256="a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144")
     version("0.12.10", sha256="d8aca75b82eec92d84b5d6eb8c8f66ea16f09d2adb09dbca27fe2d5fc8d3732d")
 
-    variant("filecache", default=False, description="Add lockfile dependency")
+    variant("filecache", default=False, description="Add filecache facility")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+
     depends_on("py-requests", type=("build", "run"))
+    depends_on("py-requests@2.16.0:", when="@0.13.0:", type=("build", "run"))
     depends_on("py-msgpack@0.5.2:", type=("build", "run"))
-    depends_on("py-lockfile@0.9:", when="+filecache", type="run")
+    depends_on("py-lockfile@0.9:", when="+filecache @:0.12", type="run")
+    depends_on("py-filelock@3.8.0:", when="+filecache @0.13.0:", type="run")

--- a/var/spack/repos/builtin/packages/py-coincidence/package.py
+++ b/var/spack/repos/builtin/packages/py-coincidence/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCoincidence(PythonPackage):
+    """Helper functions for pytest."""
+
+    homepage = "https://github.com/python-coincidence/coincidence"
+    pypi = "coincidence/coincidence-0.6.5.tar.gz"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    license("MIT")
+
+    version("0.6.5", sha256="0d6511665d23d237838adec59d51423712cd563fb1be32c1058a6de10c06fe44")
+
+    depends_on("py-whey", type="build")
+
+    depends_on("py-domdf-python-tools@2.8.0:", type=("build", "run"))
+    depends_on("py-pytest@6.2.0:", type=("build", "run"))
+    depends_on("py-pytest-regressions@2.0.2:", type=("build", "run"))
+    depends_on("py-typing-extensions@3.7.4.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-mdit-py-plugins/package.py
+++ b/var/spack/repos/builtin/packages/py-mdit-py-plugins/package.py
@@ -12,16 +12,34 @@ class PyMditPyPlugins(PythonPackage):
 
     homepage = "https://github.com/executablebooks/mdit-py-plugins/"
     git = "https://github.com/executablebooks/mdit-py-plugins/"
-    pypi = "mdit-py-plugins/mdit-py-plugins-0.3.1.tar.gz"
+    pypi = "mdit-py-plugins/mdit-py-plugins-0.3.5.tar.gz"
 
+    version("0.4.0", sha256="d8ab27e9aed6c38aa716819fedfde15ca275715955f8a185a8e1cf90fb1d2c1b")
+    version("0.3.5", sha256="eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a")
+    version("0.3.4", sha256="3278aab2e2b692539082f05e1243f24742194ffd92481f48844f057b51971283")
+    version("0.3.3", sha256="5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260")
+    version("0.3.2", sha256="c37ca25a4a5244b41cc3b34b9d7762a96ee0416dd43efaa837304d592a84995f")
     version("0.3.1", sha256="3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441")
     version("0.3.0", sha256="ecc24f51eeec6ab7eecc2f9724e8272c2fb191c2e93cf98109120c2cace69750")
     version("0.2.8", sha256="5991cef645502e80a5388ec4fc20885d2313d4871e8b8e320ca2de14ac0c015f")
 
-    depends_on("py-flit-core@3.4:3", when="@0.3.1", type=("build", "run"))
-    depends_on("python@3.7:", when="@0.3.1", type=("build", "run"))
-    depends_on("py-markdown-it-py@1.0:2", when="@0.3.1", type=("build", "run"))
+    depends_on("py-flit-core@3.4:3", when="@0.3.1:", type="build")
+    depends_on("py-setuptools", when="@:0.3.0", type="build")
 
-    depends_on("py-setuptools", when="@:0.2", type="build")
-    depends_on("py-markdown-it-py@1.0:1", when="@0.2.8", type=("build", "run"))
+    depends_on("python@3.8:3", when="@0.4.0:", type=("build", "run"))
+    depends_on("python@3.7:3", when="@0.3.1:0.3", type=("build", "run"))
     depends_on("python@3.6:3", when="@0.2.8", type=("build", "run"))
+
+    depends_on("py-markdown-it-py@1.0:3", when="@0.4.0:", type=("build", "run"))
+    depends_on("py-markdown-it-py@1.0:2", when="@0.3.1:0.3", type=("build", "run"))
+    depends_on("py-markdown-it-py@1.0:1", when="@0.2.8", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if version >= Version("0.4.0"):
+            separator = "_"
+        else:
+            separator = "-"
+        return (
+            "https://files.pythonhosted.org/packages/source/m/mdit-py-plugins/"
+            f"mdit{separator}py{separator}plugins-{version}.tar.gz"
+        )

--- a/var/spack/repos/builtin/packages/py-myst-parser/package.py
+++ b/var/spack/repos/builtin/packages/py-myst-parser/package.py
@@ -19,17 +19,25 @@ class PyMystParser(PythonPackage):
 
     maintainers("chissg", "gartung", "marcmengel", "vitodb")
 
+    version("1.0.0", sha256="502845659313099542bd38a2ae62f01360e7dd4b1310f025dd014dfc0439cdae")
     version("0.18.1", sha256="79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d")
     version("0.18.0", sha256="739a4d96773a8e55a2cacd3941ce46a446ee23dcd6b37e06f73f551ad7821d86")
 
-    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.7:", when="@:1", type=("build", "run"))
+    depends_on("python@3.8:", when="@2:", type=("build", "run"))
 
     depends_on("py-flit-core@3.4:3", type="build")
 
-    depends_on("py-docutils@0.15:0.19", type=("build", "run"))
+    depends_on("py-docutils@0.15:0.19", when="@:1", type=("build", "run"))
+    depends_on("py-docutils@0.15:0.20", when="@2:", type=("build", "run"))
     depends_on("py-jinja2", type=("build", "run"))
-    depends_on("py-markdown-it-py@1.0.0:2.9.9", type=("build", "run"))
-    depends_on("py-mdit-py-plugins@0.3:0.99", type=("build", "run"))
+    depends_on("py-markdown-it-py@1.0.0:2", when="@:1", type=("build", "run"))
+    depends_on("py-markdown-it-py@3", when="@2:", type=("build", "run"))
+    depends_on("py-mdit-py-plugins@0.3.1:0", when="@0", type=("build", "run"))
+    depends_on("py-mdit-py-plugins@0.3.4:0", when="@1", type=("build", "run"))
+    depends_on("py-mdit-py-plugins@0.4:0", when="@2:", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("py-sphinx@4.0.0:5", type=("build", "run"))
-    depends_on("py-typing-extensions", type=("build", "run"))
+    depends_on("py-sphinx@4.0.0:5", when="@0", type=("build", "run"))
+    depends_on("py-sphinx@5.0.0:6", when="@1", type=("build", "run"))
+    depends_on("py-sphinx@6.0.0:7", when="@2:", type=("build", "run"))
+    depends_on("py-typing-extensions", when="^python@:3.7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-design/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-design/package.py
@@ -12,17 +12,21 @@ class PySphinxDesign(PythonPackage):
     homepage = "https://sphinx-design.readthedocs.io"
     pypi = "sphinx-design/sphinx_design-0.3.0.tar.gz"
 
-    maintainers("ax3l", "adamjstewart")
+    maintainers("ax3l", "adamjstewart", "greenc-FNAL")
 
+    version("0.5.0", sha256="e8e513acea6f92d15c6de3b34e954458f245b8e761b45b63950f65373352ab00")
     version("0.4.1", sha256="5b6418ba4a2dc3d83592ea0ff61a52a891fe72195a4c3a18b2fa1c7668ce4708")
     version("0.4.0", sha256="b92948614900967499617d99aadd38ce5975ede924a18c7478cc6b8ec188f76b")
     version("0.3.0", sha256="7183fa1fae55b37ef01bda5125a21ee841f5bbcbf59a35382be598180c4cefba")
 
-    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.7:", when="@:0.4", type=("build", "run"))
+    depends_on("python@3.8:", when="@0.5:", type=("build", "run"))
     depends_on("py-flit-core@3.4:3", type=("build"))
     depends_on("py-sphinx@4:5", when="@0.3", type=("build", "run"))
-    depends_on("py-sphinx@4:6", when="@0.4:", type=("build", "run"))
+    depends_on("py-sphinx@4:6", when="@0.4", type=("build", "run"))
+    depends_on("py-sphinx@5:7", when="@0.5:", type=("build", "run"))
     depends_on("py-pytest@7.1:", type="test")
     depends_on("py-pytest-cov", type="test")
     depends_on("py-pytest-regressions", type="test")
-    depends_on("py-myst-parser@0.18.0:", type="test")
+    depends_on("py-myst-parser@0.18.0:1", when="@:0.4", type="test")
+    depends_on("py-myst-parser@1:2", when="@0.5:", type="test")

--- a/var/spack/repos/builtin/packages/py-sphinx-jinja2-compat/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-jinja2-compat/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxJinja2Compat(PythonPackage):
+    """Patches Jinja2 v3 to restore compatibility with earlier Sphinx versions."""
+
+    homepage = "https://github.com/sphinx-toolbox/sphinx-jinja2-compat"
+    pypi = "sphinx_jinja2_compat/sphinx_jinja2_compat-0.2.0.post1.tar.gz"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    license("MIT")
+
+    version(
+        "0.2.0.post1", sha256="974289a12a9f402108dead621e9c15f7004e945d5cfcaea8d6419e94d3fa95a3"
+    )
+
+    depends_on("py-whey", type="build")
+    depends_on("py-whey-pth", type="build")
+
+    depends_on("py-jinja2@2.10:", type=("build", "run"))
+    depends_on("py-markupsafe@1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-prompt/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-prompt/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxPrompt(PythonPackage):
+    """Sphinx directive to add unselectable prompt."""
+
+    homepage = "https://github.com/sbrunner/sphinx-prompt"
+    pypi = "sphinx_prompt/sphinx_prompt-1.8.0.tar.gz"
+
+    license("BSD-3-Clause")
+
+    version("1.8.0", sha256="47482f86fcec29662fdfd23e7c04ef03582714195d01f5d565403320084372ed")
+
+    depends_on("python@3.9:3", type=("build", "run"))
+
+    depends_on("py-poetry-core@1.0.0:", type="build")
+
+    depends_on("py-sphinx", type=("build", "run"))
+    depends_on("py-pygments", type=("build", "run"))
+    depends_on("py-docutils", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-tabs/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-tabs/package.py
@@ -15,10 +15,13 @@ class PySphinxTabs(PythonPackage):
 
     maintainers("schmitts")
 
+    version("3.4.4", sha256="f1b72c4f23d1ba9cdcaf880fd883524bc70689f561b9785719b8b3c3c5ed0aca")
     version("3.2.0", sha256="33137914ed9b276e6a686d7a337310ee77b1dae316fdcbce60476913a152e0a4")
 
     depends_on("python@3.6:3", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-sphinx@2:4", type=("build", "run"))
+    depends_on("py-sphinx@2:4", when="@:3.2", type=("build", "run"))
+    depends_on("py-sphinx", type=("build", "run"))
     depends_on("py-pygments", type=("build", "run"))
-    depends_on("py-docutils@0.16", type=("build", "run"))
+    depends_on("py-docutils@0.16:", when="@:3.2", type=("build", "run"))
+    depends_on("py-docutils@0.18:", when="@3.4.4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-toolbox/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-toolbox/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxToolbox(PythonPackage):
+    """Box of handy tools for Sphinx 🧰 📔"""
+
+    homepage = "https://github.com/sphinx-toolbox/sphinx-toolbox"
+    pypi = "sphinx_toolbox/sphinx_toolbox-3.5.0.tar.gz"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    license("MIT")
+
+    version("3.5.0", sha256="e5b5a7153f1997572d71a06aaf6cec225483492ec2c60097a84f15aad6df18b7")
+
+    depends_on("py-whey", type="build")
+
+    depends_on("py-apeye@0.4.0:", type=("build", "run"))
+    depends_on("py-autodocsumm@0.2.0:", type=("build", "run"))
+    depends_on("py-beautifulsoup4@4.9.1:", type=("build", "run"))
+    depends_on("py-cachecontrol@0.13.0: +filecache", type=("build", "run"))
+    depends_on("py-dict2css@0.2.3:", type=("build", "run"))
+    depends_on("py-docutils@0.16:", type=("build", "run"))
+    depends_on("py-domdf-python-tools@2.9.0:", type=("build", "run"))
+    depends_on("py-filelock@3.8.0:", type=("build", "run"))
+    depends_on("py-html5lib@1.1:", type=("build", "run"))
+    depends_on("py-ruamel-yaml@0.16.12:", type=("build", "run"))
+    depends_on("py-sphinx@3.2.0:", type=("build", "run"))
+    depends_on("py-sphinx-autodoc-typehints@1.11.1:", type=("build", "run"))
+    depends_on("py-sphinx-jinja2-compat@0.1.0:", type=("build", "run"))
+    depends_on("py-sphinx-prompt@1.1.0:", type=("build", "run"))
+    depends_on("py-sphinx-tabs@1.2.1:3.4", type=("build", "run"))
+    depends_on("py-tabulate@0.8.7:", type=("build", "run"))
+    depends_on("py-typing-extensions@3.7.4.3:", type=("build", "run"))
+    depends_on("py-typing-inspect@0.6.0:", when="^python@:3.7", type=("build", "run"))
+
+    depends_on("py-coincidence@0.4.3:", type="test")
+    depends_on("py-pygments@2.7.4:2.13.0", type="test")
+
+    conflicts("py-typing-extensions@=3.10.0.1")

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-moderncmakedomain/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-moderncmakedomain/package.py
@@ -14,6 +14,7 @@ class PySphinxcontribModerncmakedomain(PythonPackage):
 
     maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
 
+    version("3.27.0", sha256="51e259e91f58d17cc0fac9307fd40106aa59d5acaa741887903fc3660361d1a1")
     version("3.25.0", sha256="4138e4d3f60e5c4b3982caa10033693bfc1009cdd851766754d5990d9d1e992a")
 
     conflicts("python@:3.5")

--- a/var/spack/repos/builtin/packages/py-whey-pth/package.py
+++ b/var/spack/repos/builtin/packages/py-whey-pth/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyWheyPth(PythonPackage):
+    """Extension to whey to support .pth files."""
+
+    homepage = "https://github.com/repo-helper/whey-pth"
+    pypi = "whey-pth/whey-pth-0.0.5.tar.gz"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    license("MIT")
+
+    version("0.0.5", sha256="cbfcc723bc587ecde44c6b0c83270673d38d88c3fc8f8268a49b21db1fd60747")
+
+    depends_on("py-wheel@0.34.2:", type="build")
+
+    depends_on("py-setuptools@40.6.0:", type="build")
+
+    conflicts("py-setuptools@61")
+
+    depends_on("py-dom-toml@0.4.0:", type=("build", "run"))
+    depends_on("py-whey@0.0.15:", type=("build", "run"))


### PR DESCRIPTION
- [py-sphinxcontrib-moderncmakedomain] New version 3.27.0
- [py-mdit-py-plugins] New version, updated depedencies
- [py-myst-parser] New version, updated dependencies
- [py-sphinx-design] New version, updated dependencies
- [py-cachecontrol] New version, updated dependencies
- [py-sphinx-tabs] New version, updated dependencies
- [py-coincidence] New package
- [py-whey-pth] New package
- [py-sphinx-jinja2-compat] New package
- [py-sphinx-prompt] New package
- [py-autodocsumm] New package
- [py-sphinx-toolbox] New package
