### PR TITLE
Merge from upstream as a base for upstream PRs

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # @v2
 
-      - uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
+      - uses: docker/metadata-action@e6428a5c4e294a61438ed7f43155db912025b6b3
         id: docker_meta
         with:
           images: |

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # @v2
 
-      - uses: docker/metadata-action@e6428a5c4e294a61438ed7f43155db912025b6b3
+      - uses: docker/metadata-action@31cebacef4805868f9ce9a0cb03ee36c32df2ac4
         id: docker_meta
         with:
           images: |

--- a/.github/workflows/style/requirements.txt
+++ b/.github/workflows/style/requirements.txt
@@ -2,6 +2,6 @@ black==23.11.0
 clingo==5.6.2
 flake8==6.1.0
 isort==5.12.0
-mypy==1.6.1
+mypy==1.7.1
 types-six==1.16.21.9
 vermin==1.6.0

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -215,7 +215,7 @@ jobs:
         $(which spack) bootstrap disable spack-install
         $(which spack) solve zlib
         common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
-        $(which spack) unit-test --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}"
+        $(which spack) unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}"
     - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
       with:
         flags: unittests,macos

--- a/lib/spack/docs/build_systems/cmakepackage.rst
+++ b/lib/spack/docs/build_systems/cmakepackage.rst
@@ -82,7 +82,7 @@ class already contains:
 
 .. code-block:: python
 
-   depends_on('cmake', type='build')
+   depends_on("cmake", type="build")
 
 
 If you need to specify a particular version requirement, you can
@@ -90,7 +90,7 @@ override this in your package:
 
 .. code-block:: python
 
-   depends_on('cmake@2.8.12:', type='build')
+   depends_on("cmake@2.8.12:", type="build")
 
 
 ^^^^^^^^^^^^^^^^^^^
@@ -137,10 +137,10 @@ and without the :meth:`~spack.build_systems.cmake.CMakeBuilder.define` and
 
    def cmake_args(self):
        args = [
-           '-DWHATEVER:STRING=somevalue',
-           self.define('ENABLE_BROKEN_FEATURE', False),
-           self.define_from_variant('DETECT_HDF5', 'hdf5'),
-           self.define_from_variant('THREADS'), # True if +threads
+           "-DWHATEVER:STRING=somevalue",
+           self.define("ENABLE_BROKEN_FEATURE", False),
+           self.define_from_variant("DETECT_HDF5", "hdf5"),
+           self.define_from_variant("THREADS"), # True if +threads
        ]
 
        return args
@@ -151,10 +151,10 @@ and CMake simply ignores the empty command line argument. For example the follow
 
 .. code-block:: python
 
-   variant('example', default=True, when='@2.0:')
+   variant("example", default=True, when="@2.0:")
 
    def cmake_args(self):
-      return [self.define_from_variant('EXAMPLE', 'example')]
+      return [self.define_from_variant("EXAMPLE", "example")]
 
 will generate ``'cmake' '-DEXAMPLE=ON' ...`` when `@2.0: +example` is met, but will
 result in ``'cmake' '' ...`` when the spec version is below ``2.0``.
@@ -193,9 +193,9 @@ a variant to control this:
 
 .. code-block:: python
 
-   variant('build_type', default='RelWithDebInfo',
-           description='CMake build type',
-           values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+   variant("build_type", default="RelWithDebInfo",
+           description="CMake build type",
+           values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"))
 
 However, not every CMake package accepts all four of these options.
 Grep the ``CMakeLists.txt`` file to see if the default values are
@@ -205,9 +205,9 @@ package overrides the default variant with:
 
 .. code-block:: python
 
-   variant('build_type', default='DebugRelease',
-           description='The build type to build',
-           values=('Debug', 'Release', 'DebugRelease'))
+   variant("build_type", default="DebugRelease",
+           description="The build type to build",
+           values=("Debug", "Release", "DebugRelease"))
 
 For more information on ``CMAKE_BUILD_TYPE``, see:
 https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
@@ -250,7 +250,7 @@ generator is Ninja. To switch to the Ninja generator, simply add:
 
 .. code-block:: python
 
-   generator = 'Ninja'
+   generator = "Ninja"
 
 
 ``CMakePackage`` defaults to "Unix Makefiles". If you switch to the
@@ -258,7 +258,7 @@ Ninja generator, make sure to add:
 
 .. code-block:: python
 
-   depends_on('ninja', type='build')
+   depends_on("ninja", type="build")
 
 to the package as well. Aside from that, you shouldn't need to do
 anything else. Spack will automatically detect that you are using
@@ -288,7 +288,7 @@ like so:
 
 .. code-block:: python
 
-   root_cmakelists_dir = 'src'
+   root_cmakelists_dir = "src"
 
 
 Note that this path is relative to the root of the extracted tarball,
@@ -304,7 +304,7 @@ different sub-directory, simply override ``build_directory`` like so:
 
 .. code-block:: python
 
-   build_directory = 'my-build'
+   build_directory = "my-build"
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Build and install targets
@@ -324,8 +324,8 @@ library or build the documentation, you can add these like so:
 
 .. code-block:: python
 
-   build_targets = ['all', 'docs']
-   install_targets = ['install', 'docs']
+   build_targets = ["all", "docs"]
+   install_targets = ["install", "docs"]
 
 ^^^^^^^
 Testing

--- a/lib/spack/docs/build_systems/intelpackage.rst
+++ b/lib/spack/docs/build_systems/intelpackage.rst
@@ -934,9 +934,9 @@ a *virtual* ``mkl`` package is declared in Spack.
   .. code-block:: python
 
      # Examples for absolute and conditional dependencies:
-     depends_on('mkl')
-     depends_on('mkl', when='+mkl')
-     depends_on('mkl', when='fftw=mkl')
+     depends_on("mkl")
+     depends_on("mkl", when="+mkl")
+     depends_on("mkl", when="fftw=mkl")
 
   The ``MKLROOT`` environment variable (part of the documented API) will be set
   during all stages of client package installation, and is available to both
@@ -972,8 +972,8 @@ a *virtual* ``mkl`` package is declared in Spack.
       def configure_args(self):
           args = []
           ...
-          args.append('--with-blas=%s' % self.spec['blas'].libs.ld_flags)
-          args.append('--with-lapack=%s' % self.spec['lapack'].libs.ld_flags)
+          args.append("--with-blas=%s" % self.spec["blas"].libs.ld_flags)
+          args.append("--with-lapack=%s" % self.spec["lapack"].libs.ld_flags)
           ...
 
   .. tip::
@@ -989,13 +989,13 @@ a *virtual* ``mkl`` package is declared in Spack.
 
   .. code-block:: python
 
-    self.spec['blas'].headers.include_flags
+    self.spec["blas"].headers.include_flags
 
   and to generate linker options (``-L<dir> -llibname ...``), use the same as above,
 
   .. code-block:: python
 
-    self.spec['blas'].libs.ld_flags
+    self.spec["blas"].libs.ld_flags
 
   See
   :ref:`MakefilePackage <makefilepackage>`

--- a/lib/spack/docs/build_systems/luapackage.rst
+++ b/lib/spack/docs/build_systems/luapackage.rst
@@ -88,7 +88,7 @@ override the ``luarocks_args`` method like so:
 .. code-block:: python
 
     def luarocks_args(self):
-        return ['flag1', 'flag2']
+        return ["flag1", "flag2"]
 
 One common use of this is to override warnings or flags for newer compilers, as in:
 

--- a/lib/spack/docs/build_systems/mavenpackage.rst
+++ b/lib/spack/docs/build_systems/mavenpackage.rst
@@ -48,8 +48,8 @@ class automatically adds the following dependencies:
 
 .. code-block:: python
 
-   depends_on('java', type=('build', 'run'))
-   depends_on('maven', type='build')
+   depends_on("java", type=("build", "run"))
+   depends_on("maven", type="build")
 
 
 In the ``pom.xml`` file, you may see sections like:
@@ -72,8 +72,8 @@ should add:
 
 .. code-block:: python
 
-   depends_on('java@7:', type='build')
-   depends_on('maven@3.5.4:', type='build')
+   depends_on("java@7:", type="build")
+   depends_on("maven@3.5.4:", type="build")
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,9 +88,9 @@ the build phase. For example:
 
    def build_args(self):
        return [
-           '-Pdist,native',
-           '-Dtar',
-           '-Dmaven.javadoc.skip=true'
+           "-Pdist,native",
+           "-Dtar",
+           "-Dmaven.javadoc.skip=true"
        ]
 
 

--- a/lib/spack/docs/build_systems/mesonpackage.rst
+++ b/lib/spack/docs/build_systems/mesonpackage.rst
@@ -86,8 +86,8 @@ the ``MesonPackage`` base class already contains:
 
 .. code-block:: python
 
-   depends_on('meson', type='build')
-   depends_on('ninja', type='build')
+   depends_on("meson", type="build")
+   depends_on("ninja", type="build")
 
 
 If you need to specify a particular version requirement, you can
@@ -95,8 +95,8 @@ override this in your package:
 
 .. code-block:: python
 
-   depends_on('meson@0.43.0:', type='build')
-   depends_on('ninja', type='build')
+   depends_on("meson@0.43.0:", type="build")
+   depends_on("ninja", type="build")
 
 
 ^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ override the ``meson_args`` method like so:
 .. code-block:: python
 
    def meson_args(self):
-       return ['--warnlevel=3']
+       return ["--warnlevel=3"]
 
 
 This method can be used to pass flags as well as variables.

--- a/lib/spack/docs/build_systems/perlpackage.rst
+++ b/lib/spack/docs/build_systems/perlpackage.rst
@@ -118,7 +118,7 @@ so ``PerlPackage`` contains:
 
 .. code-block:: python
 
-   extends('perl')
+   extends("perl")
 
 
 If your package requires a specific version of Perl, you should
@@ -132,14 +132,14 @@ properly. If your package uses ``Makefile.PL`` to build, add:
 
 .. code-block:: python
 
-   depends_on('perl-extutils-makemaker', type='build')
+   depends_on("perl-extutils-makemaker", type="build")
 
 
 If your package uses ``Build.PL`` to build, add:
 
 .. code-block:: python
 
-   depends_on('perl-module-build', type='build')
+   depends_on("perl-module-build", type="build")
 
 
 ^^^^^^^^^^^^^^^^^
@@ -165,11 +165,11 @@ arguments to ``Makefile.PL`` or ``Build.PL`` by overriding
 .. code-block:: python
 
    def configure_args(self):
-       expat = self.spec['expat'].prefix
+       expat = self.spec["expat"].prefix
 
        return [
-           'EXPATLIBPATH={0}'.format(expat.lib),
-           'EXPATINCPATH={0}'.format(expat.include),
+           "EXPATLIBPATH={0}".format(expat.lib),
+           "EXPATINCPATH={0}".format(expat.include),
        ]
 
 

--- a/lib/spack/docs/build_systems/qmakepackage.rst
+++ b/lib/spack/docs/build_systems/qmakepackage.rst
@@ -83,7 +83,7 @@ base class already contains:
 
 .. code-block:: python
 
-   depends_on('qt', type='build')
+   depends_on("qt", type="build")
 
 
 If you want to specify a particular version requirement, or need to
@@ -91,7 +91,7 @@ link to the ``qt`` libraries, you can override this in your package:
 
 .. code-block:: python
 
-   depends_on('qt@5.6.0:')
+   depends_on("qt@5.6.0:")
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Passing arguments to qmake
@@ -103,7 +103,7 @@ override the ``qmake_args`` method like so:
 .. code-block:: python
 
    def qmake_args(self):
-       return ['-recursive']
+       return ["-recursive"]
 
 
 This method can be used to pass flags as well as variables.
@@ -118,7 +118,7 @@ sub-directory by adding the following to the package:
 
 .. code-block:: python
 
-   build_directory = 'src'
+   build_directory = "src"
 
 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/build_systems/rpackage.rst
+++ b/lib/spack/docs/build_systems/rpackage.rst
@@ -163,28 +163,28 @@ attributes that can be used to set ``homepage``, ``url``, ``list_url``, and
 
 .. code-block:: python
 
-   cran = 'caret'
+   cran = "caret"
 
 is equivalent to:
 
 .. code-block:: python
 
-   homepage = 'https://cloud.r-project.org/package=caret'
-   url      = 'https://cloud.r-project.org/src/contrib/caret_6.0-86.tar.gz'
-   list_url = 'https://cloud.r-project.org/src/contrib/Archive/caret'
+   homepage = "https://cloud.r-project.org/package=caret"
+   url      = "https://cloud.r-project.org/src/contrib/caret_6.0-86.tar.gz"
+   list_url = "https://cloud.r-project.org/src/contrib/Archive/caret"
 
 Likewise, the following ``bioc`` attribute:
 
 .. code-block:: python
 
-   bioc = 'BiocVersion'
+   bioc = "BiocVersion"
 
 is equivalent to:
 
 .. code-block:: python
 
-   homepage = 'https://bioconductor.org/packages/BiocVersion/'
-   git      = 'https://git.bioconductor.org/packages/BiocVersion'
+   homepage = "https://bioconductor.org/packages/BiocVersion/"
+   git      = "https://git.bioconductor.org/packages/BiocVersion"
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -200,7 +200,7 @@ base class contains:
 
 .. code-block:: python
 
-   extends('r')
+   extends("r")
 
 
 Take a close look at the homepage for ``caret``. If you look at the
@@ -209,7 +209,7 @@ You should add this to your package like so:
 
 .. code-block:: python
 
-   depends_on('r@3.2.0:', type=('build', 'run'))
+   depends_on("r@3.2.0:", type=("build", "run"))
 
 
 ^^^^^^^^^^^^^^
@@ -227,7 +227,7 @@ and list all of their dependencies in the following sections:
 * LinkingTo
 
 As far as Spack is concerned, all 3 of these dependency types
-correspond to ``type=('build', 'run')``, so you don't have to worry
+correspond to ``type=("build", "run")``, so you don't have to worry
 about the details. If you are curious what they mean,
 https://github.com/spack/spack/issues/2951 has a pretty good summary:
 
@@ -330,7 +330,7 @@ the dependency:
 
 .. code-block:: python
 
-   depends_on('r-lattice@0.20:', type=('build', 'run'))
+   depends_on("r-lattice@0.20:", type=("build", "run"))
 
 
 ^^^^^^^^^^^^^^^^^^
@@ -361,20 +361,20 @@ like so:
 .. code-block:: python
 
    def configure_args(self):
-       mpi_name = self.spec['mpi'].name
+       mpi_name = self.spec["mpi"].name
 
        # The type of MPI. Supported values are:
        # OPENMPI, LAM, MPICH, MPICH2, or CRAY
-       if mpi_name == 'openmpi':
-           Rmpi_type = 'OPENMPI'
-       elif mpi_name == 'mpich':
-           Rmpi_type = 'MPICH2'
+       if mpi_name == "openmpi":
+           Rmpi_type = "OPENMPI"
+       elif mpi_name == "mpich":
+           Rmpi_type = "MPICH2"
        else:
-           raise InstallError('Unsupported MPI type')
+           raise InstallError("Unsupported MPI type")
 
        return [
-           '--with-Rmpi-type={0}'.format(Rmpi_type),
-           '--with-mpi={0}'.format(spec['mpi'].prefix),
+           "--with-Rmpi-type={0}".format(Rmpi_type),
+           "--with-mpi={0}".format(spec["mpi"].prefix),
        ]
 
 

--- a/lib/spack/docs/build_systems/rubypackage.rst
+++ b/lib/spack/docs/build_systems/rubypackage.rst
@@ -84,8 +84,8 @@ The ``*.gemspec`` file may contain something like:
 
 .. code-block:: ruby
 
-   summary = 'An implementation of the AsciiDoc text processor and publishing toolchain'
-   description = 'A fast, open source text processor and publishing toolchain for converting AsciiDoc content to HTML 5, DocBook 5, and other formats.'
+   summary = "An implementation of the AsciiDoc text processor and publishing toolchain"
+   description = "A fast, open source text processor and publishing toolchain for converting AsciiDoc content to HTML 5, DocBook 5, and other formats."
 
 
 Either of these can be used for the description of the Spack package.
@@ -98,7 +98,7 @@ The ``*.gemspec`` file may contain something like:
 
 .. code-block:: ruby
 
-   homepage = 'https://asciidoctor.org'
+   homepage = "https://asciidoctor.org"
 
 
 This should be used as the official homepage of the Spack package.
@@ -112,21 +112,21 @@ the base class contains:
 
 .. code-block:: python
 
-   extends('ruby')
+   extends("ruby")
 
 
 The ``*.gemspec`` file may contain something like:
 
 .. code-block:: ruby
 
-   required_ruby_version = '>= 2.3.0'
+   required_ruby_version = ">= 2.3.0"
 
 
 This can be added to the Spack package using:
 
 .. code-block:: python
 
-   depends_on('ruby@2.3.0:', type=('build', 'run'))
+   depends_on("ruby@2.3.0:", type=("build", "run"))
 
 
 ^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/build_systems/sippackage.rst
+++ b/lib/spack/docs/build_systems/sippackage.rst
@@ -124,7 +124,7 @@ are wrong, you can provide the names yourself by overriding
 
 .. code-block:: python
 
-   import_modules = ['PyQt5']
+   import_modules = ["PyQt5"]
 
 
 These tests often catch missing dependencies and non-RPATHed

--- a/lib/spack/docs/build_systems/wafpackage.rst
+++ b/lib/spack/docs/build_systems/wafpackage.rst
@@ -63,8 +63,8 @@ run package-specific unit tests.
 .. code-block:: python
 
    def installtest(self):
-       with working_dir('test'):
-           pytest = which('py.test')
+       with working_dir("test"):
+           pytest = which("py.test")
            pytest()
 
 
@@ -93,7 +93,7 @@ the following dependency automatically:
 
 .. code-block:: python
 
-   depends_on('python@2.5:', type='build')
+   depends_on("python@2.5:", type="build")
 
 
 Waf only supports Python 2.5 and up.
@@ -113,7 +113,7 @@ phase, you can use:
        args = []
 
        if self.run_tests:
-           args.append('--test')
+           args.append("--test")
 
        return args
 

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -9,46 +9,42 @@
 Custom Extensions
 =================
 
-*Spack extensions* permit you to extend Spack capabilities by deploying your
+*Spack extensions* allow you to extend Spack capabilities by deploying your
 own custom commands or logic in an arbitrary location on your filesystem.
 This might be extremely useful e.g. to develop and maintain a command whose purpose is
 too specific to be considered for reintegration into the mainline or to
 evolve a command through its early stages before starting a discussion to merge
 it upstream.
+
 From Spack's point of view an extension is any path in your filesystem which
-respects a prescribed naming and layout for files:
+respects the following naming and layout for files:
 
 .. code-block:: console
 
   spack-scripting/ # The top level directory must match the format 'spack-{extension_name}'
   ├── pytest.ini # Optional file if the extension ships its own tests
   ├── scripting # Folder that may contain modules that are needed for the extension commands
-  │   └── cmd # Folder containing extension commands
-  │       └── filter.py # A new command that will be available
-  ├── tests # Tests for this extension
+  │   ├── cmd # Folder containing extension commands
+  │   │   └── filter.py # A new command that will be available
+  │   └── functions.py # Module with internal details
+  └── tests # Tests for this extension
   │   ├── conftest.py
   │   └── test_filter.py
   └── templates # Templates that may be needed by the extension
 
-In the example above the extension named *scripting* adds an additional command (``filter``)
-and unit tests to verify its behavior. The code for this example can be
-obtained by cloning the corresponding git repository:
+In the example above, the extension is named *scripting*. It adds an additional command
+(``spack filter``) and unit tests to verify its behavior.
 
-.. TODO: write an ad-hoc "hello world" extension and make it part of the spack organization
+The extension can import any core Spack module in its implementation. When loaded by
+the ``spack`` command, the extension itself is imported as a Python package in the
+``spack.extensions`` namespace. In the example above, since the extension is named
+"scripting", the corresponding Python module is ``spack.extensions.scripting``.
+
+The code for this example extension can be obtained by cloning the corresponding git repository:
 
 .. code-block:: console
 
-   $ cd ~/
-   $ mkdir tmp && cd tmp
-   $ git clone https://github.com/alalazo/spack-scripting.git
-   Cloning into 'spack-scripting'...
-   remote: Counting objects: 11, done.
-   remote: Compressing objects: 100% (7/7), done.
-   remote: Total 11 (delta 0), reused 11 (delta 0), pack-reused 0
-   Receiving objects: 100% (11/11), done.
-
-As you can see by inspecting the sources, Python modules that are part of the extension
-can import any core Spack module.
+   $ git -C /tmp clone https://github.com/spack/spack-scripting.git
 
 ---------------------------------
 Configure Spack to Use Extensions
@@ -61,7 +57,7 @@ paths to ``config.yaml``. In the case of our example this means ensuring that:
 
    config:
      extensions:
-     - ~/tmp/spack-scripting
+     - /tmp/spack-scripting
 
 is part of your configuration file. Once this is setup any command that the extension provides
 will be available from the command line:
@@ -86,37 +82,32 @@ will be available from the command line:
      --implicit       select specs that are not installed or were installed implicitly
      --output OUTPUT  where to dump the result
 
-The corresponding unit tests can be run giving the appropriate options
-to ``spack unit-test``:
+The corresponding unit tests can be run giving the appropriate options to ``spack unit-test``:
 
 .. code-block:: console
 
    $ spack unit-test --extension=scripting
-
-   ============================================================== test session starts ===============================================================
-   platform linux2 -- Python 2.7.15rc1, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
-   rootdir: /home/mculpo/tmp/spack-scripting, inifile: pytest.ini
+   ========================================== test session starts ===========================================
+   platform linux -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
+   rootdir: /home/culpo/github/spack-scripting
+   configfile: pytest.ini
+   testpaths: tests
+   plugins: xdist-3.5.0
    collected 5 items
 
-   tests/test_filter.py ...XX
-   ============================================================ short test summary info =============================================================
-   XPASS tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
-   XPASS tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
+   tests/test_filter.py .....                                                                         [100%]
 
-   =========================================================== slowest 20 test durations ============================================================
-   3.74s setup    tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
-   0.17s call     tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
-   0.16s call     tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
-   0.15s call     tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
-   0.13s call     tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
-   0.08s call     tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
-   0.04s teardown tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
-   0.00s setup    tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
-   0.00s setup    tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
-   0.00s setup    tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
-   0.00s setup    tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
-   0.00s teardown tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
-   0.00s teardown tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
-   0.00s teardown tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
-   0.00s teardown tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
-   ====================================================== 3 passed, 2 xpassed in 4.51 seconds =======================================================
+   ========================================== slowest 30 durations ==========================================
+   2.31s setup    tests/test_filter.py::test_filtering_specs[kwargs0-specs0-expected0]
+   0.57s call     tests/test_filter.py::test_filtering_specs[kwargs2-specs2-expected2]
+   0.56s call     tests/test_filter.py::test_filtering_specs[kwargs4-specs4-expected4]
+   0.54s call     tests/test_filter.py::test_filtering_specs[kwargs3-specs3-expected3]
+   0.54s call     tests/test_filter.py::test_filtering_specs[kwargs1-specs1-expected1]
+   0.48s call     tests/test_filter.py::test_filtering_specs[kwargs0-specs0-expected0]
+   0.01s setup    tests/test_filter.py::test_filtering_specs[kwargs4-specs4-expected4]
+   0.01s setup    tests/test_filter.py::test_filtering_specs[kwargs2-specs2-expected2]
+   0.01s setup    tests/test_filter.py::test_filtering_specs[kwargs1-specs1-expected1]
+   0.01s setup    tests/test_filter.py::test_filtering_specs[kwargs3-specs3-expected3]
+
+   (5 durations < 0.005s hidden.  Use -vv to show these durations.)
+   =========================================== 5 passed in 5.06s ============================================

--- a/lib/spack/docs/gpu_configuration.rst
+++ b/lib/spack/docs/gpu_configuration.rst
@@ -111,3 +111,28 @@ CUDA is split into fewer components and is simpler to specify:
          prefix: /opt/cuda/cuda-11.0.2/
 
 where ``/opt/cuda/cuda-11.0.2/lib/`` contains ``libcudart.so``.
+
+
+
+-----------------------------------
+Using an External OpenGL API
+-----------------------------------
+Depending on whether we have a graphics card or not, we may choose to use OSMesa or GLX to implement the OpenGL API.
+
+If a graphics card is unavailable, OSMesa is recommended and can typically be built with Spack.
+However, if we prefer to utilize the system GLX tailored to our graphics card, we need to declare it as an external. Here's how to do it:
+
+
+.. code-block:: yaml
+
+  packages:
+    libglx:
+      require: [opengl]
+    opengl:
+      buildable: false
+      externals:
+      - prefix: /usr/
+        spec: opengl@4.6
+
+Note that prefix has to be the root of both the libraries and the headers, using is /usr not the path the the lib.
+To know which spec for opengl is available use ``cd /usr/include/GL && grep -Ri gl_version``.

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx==7.2.6
 sphinxcontrib-programoutput==0.17
 sphinx_design==0.5.0
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
 python-levenshtein==0.23.0
 docutils==0.18.1
 pygments==2.17.1

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -10,4 +10,4 @@ pytest==7.4.3
 isort==5.12.0
 black==23.11.0
 flake8==6.1.0
-mypy==1.7.0
+mypy==1.7.1

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -4,7 +4,7 @@ sphinx_design==0.5.0
 sphinx-rtd-theme==2.0.0
 python-levenshtein==0.23.0
 docutils==0.18.1
-pygments==2.17.1
+pygments==2.17.2
 urllib3==2.1.0
 pytest==7.4.3
 isort==5.12.0

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinxcontrib-programoutput==0.17
 sphinx_design==0.5.0
 sphinx-rtd-theme==2.0.0
 python-levenshtein==0.23.0
-docutils==0.18.1
+docutils==0.20.1
 pygments==2.17.2
 urllib3==2.1.0
 pytest==7.4.3

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -230,7 +230,11 @@ class BinaryCacheIndex:
                 )
                 return
 
-            spec_list = db.query_local(installed=False, in_buildcache=True)
+            spec_list = [
+                s
+                for s in db.query_local(installed=any, in_buildcache=any)
+                if s.external or db.query_local_by_spec_hash(s.dag_hash()).in_buildcache
+            ]
 
             for indexed_spec in spec_list:
                 dag_hash = indexed_spec.dag_hash()

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -136,12 +136,12 @@ class CudaPackage(PackageBase):
         conflicts("%gcc@11:", when="+cuda ^cuda@:11.4.0")
         conflicts("%gcc@11.2:", when="+cuda ^cuda@:11.5")
         conflicts("%gcc@12:", when="+cuda ^cuda@:11.8")
-        conflicts("%gcc@13:", when="+cuda ^cuda@:12.1")
+        conflicts("%gcc@13:", when="+cuda ^cuda@:12.3")
         conflicts("%clang@12:", when="+cuda ^cuda@:11.4.0")
         conflicts("%clang@13:", when="+cuda ^cuda@:11.5")
         conflicts("%clang@14:", when="+cuda ^cuda@:11.7")
         conflicts("%clang@15:", when="+cuda ^cuda@:12.0")
-        conflicts("%clang@16:", when="+cuda ^cuda@:12.1")
+        conflicts("%clang@16:", when="+cuda ^cuda@:12.3")
 
         # https://gist.github.com/ax3l/9489132#gistcomment-3860114
         conflicts("%gcc@10", when="+cuda ^cuda@:11.4.0")

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -6,13 +6,14 @@ import inspect
 import os
 import re
 import shutil
-from typing import Optional
+from typing import Iterable, List, Mapping, Optional
 
 import archspec
 
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
+from llnl.util.filesystem import HeaderList, LibraryList
 
 import spack.builder
 import spack.config
@@ -25,14 +26,18 @@ import spack.store
 from spack.directives import build_system, depends_on, extends, maintainers
 from spack.error import NoHeadersError, NoLibrariesError
 from spack.install_test import test_part
+from spack.spec import Spec
+from spack.util.prefix import Prefix
 
 from ._checks import BaseBuilder, execute_install_time_tests
 
 
-def _flatten_dict(dictionary):
+def _flatten_dict(dictionary: Mapping[str, object]) -> Iterable[str]:
     """Iterable that yields KEY=VALUE paths through a dictionary.
+
     Args:
         dictionary: Possibly nested dictionary of arbitrary keys and values.
+
     Yields:
         A single path through the dictionary.
     """
@@ -50,7 +55,7 @@ class PythonExtension(spack.package_base.PackageBase):
     maintainers("adamjstewart")
 
     @property
-    def import_modules(self):
+    def import_modules(self) -> Iterable[str]:
         """Names of modules that the Python package provides.
 
         These are used to test whether or not the installation succeeded.
@@ -65,7 +70,7 @@ class PythonExtension(spack.package_base.PackageBase):
         detected, this property can be overridden by the package.
 
         Returns:
-            list: list of strings of module names
+            List of strings of module names.
         """
         modules = []
         pkg = self.spec["python"].package
@@ -102,14 +107,14 @@ class PythonExtension(spack.package_base.PackageBase):
         return modules
 
     @property
-    def skip_modules(self):
+    def skip_modules(self) -> Iterable[str]:
         """Names of modules that should be skipped when running tests.
 
         These are a subset of import_modules. If a module has submodules,
         they are skipped as well (meaning a.b is skipped if a is contained).
 
         Returns:
-            list: list of strings of module names
+            List of strings of module names.
         """
         return []
 
@@ -185,12 +190,12 @@ class PythonExtension(spack.package_base.PackageBase):
 
         view.remove_files(to_remove)
 
-    def test_imports(self):
+    def test_imports(self) -> None:
         """Attempts to import modules of the installed package."""
 
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
-        python = inspect.getmodule(self).python
+        python = inspect.getmodule(self).python  # type: ignore[union-attr]
         for module in self.import_modules:
             with test_part(
                 self,
@@ -315,24 +320,27 @@ class PythonPackage(PythonExtension):
     py_namespace: Optional[str] = None
 
     @lang.classproperty
-    def homepage(cls):
+    def homepage(cls) -> Optional[str]:  # type: ignore[override]
         if cls.pypi:
             name = cls.pypi.split("/")[0]
-            return "https://pypi.org/project/" + name + "/"
+            return f"https://pypi.org/project/{name}/"
+        return None
 
     @lang.classproperty
-    def url(cls):
+    def url(cls) -> Optional[str]:
         if cls.pypi:
-            return "https://files.pythonhosted.org/packages/source/" + cls.pypi[0] + "/" + cls.pypi
+            return f"https://files.pythonhosted.org/packages/source/{cls.pypi[0]}/{cls.pypi}"
+        return None
 
     @lang.classproperty
-    def list_url(cls):
+    def list_url(cls) -> Optional[str]:  # type: ignore[override]
         if cls.pypi:
             name = cls.pypi.split("/")[0]
-            return "https://pypi.org/simple/" + name + "/"
+            return f"https://pypi.org/simple/{name}/"
+        return None
 
     @property
-    def headers(self):
+    def headers(self) -> HeaderList:
         """Discover header files in platlib."""
 
         # Remove py- prefix in package name
@@ -350,7 +358,7 @@ class PythonPackage(PythonExtension):
         raise NoHeadersError(msg.format(self.spec.name, include, platlib))
 
     @property
-    def libs(self):
+    def libs(self) -> LibraryList:
         """Discover libraries in platlib."""
 
         # Remove py- prefix in package name
@@ -384,7 +392,7 @@ class PythonPipBuilder(BaseBuilder):
     install_time_test_callbacks = ["test"]
 
     @staticmethod
-    def std_args(cls):
+    def std_args(cls) -> List[str]:
         return [
             # Verbose
             "-vvv",
@@ -409,7 +417,7 @@ class PythonPipBuilder(BaseBuilder):
         ]
 
     @property
-    def build_directory(self):
+    def build_directory(self) -> str:
         """The root directory of the Python package.
 
         This is usually the directory containing one of the following files:
@@ -420,51 +428,51 @@ class PythonPipBuilder(BaseBuilder):
         """
         return self.pkg.stage.source_path
 
-    def config_settings(self, spec, prefix):
+    def config_settings(self, spec: Spec, prefix: Prefix) -> Mapping[str, object]:
         """Configuration settings to be passed to the PEP 517 build backend.
 
         Requires pip 22.1 or newer for keys that appear only a single time,
         or pip 23.1 or newer if the same key appears multiple times.
 
         Args:
-            spec (spack.spec.Spec): build spec
-            prefix (spack.util.prefix.Prefix): installation prefix
+            spec: Build spec.
+            prefix: Installation prefix.
 
         Returns:
-            dict: Possibly nested dictionary of KEY, VALUE settings
+            Possibly nested dictionary of KEY, VALUE settings.
         """
         return {}
 
-    def install_options(self, spec, prefix):
+    def install_options(self, spec: Spec, prefix: Prefix) -> Iterable[str]:
         """Extra arguments to be supplied to the setup.py install command.
 
         Requires pip 23.0 or older.
 
         Args:
-            spec (spack.spec.Spec): build spec
-            prefix (spack.util.prefix.Prefix): installation prefix
+            spec: Build spec.
+            prefix: Installation prefix.
 
         Returns:
-            list: list of options
+            List of options.
         """
         return []
 
-    def global_options(self, spec, prefix):
+    def global_options(self, spec: Spec, prefix: Prefix) -> Iterable[str]:
         """Extra global options to be supplied to the setup.py call before the install
         or bdist_wheel command.
 
         Deprecated in pip 23.1.
 
         Args:
-            spec (spack.spec.Spec): build spec
-            prefix (spack.util.prefix.Prefix): installation prefix
+            spec: Build spec.
+            prefix: Installation prefix.
 
         Returns:
-            list: list of options
+            List of options.
         """
         return []
 
-    def install(self, pkg, spec, prefix):
+    def install(self, pkg: PythonPackage, spec: Spec, prefix: Prefix) -> None:
         """Install everything from build directory."""
 
         args = PythonPipBuilder.std_args(pkg) + [f"--prefix={prefix}"]

--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -6,7 +6,7 @@
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
+from spack.cmd.common import arguments
 
 description = "add a spec to an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -15,13 +15,13 @@ import spack
 import spack.bootstrap
 import spack.bootstrap.config
 import spack.bootstrap.core
-import spack.cmd.common.arguments
 import spack.config
 import spack.main
 import spack.mirror
 import spack.spec
 import spack.stage
 import spack.util.path
+from spack.cmd.common import arguments
 
 description = "manage bootstrap configuration"
 section = "system"
@@ -68,10 +68,9 @@ SOURCE_METADATA = {
 
 
 def _add_scope_option(parser):
-    scopes = spack.config.scopes()
     parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         help="configuration scope to read/modify",
     )
@@ -106,7 +105,7 @@ def setup_parser(subparser):
     disable.add_argument("name", help="name of the source to be disabled", nargs="?", default=None)
 
     reset = sp.add_parser("reset", help="reset bootstrapping configuration to Spack defaults")
-    spack.cmd.common.arguments.add_common_arguments(reset, ["yes_to_all"])
+    arguments.add_common_arguments(reset, ["yes_to_all"])
 
     root = sp.add_parser("root", help="get/set the root bootstrap directory")
     _add_scope_option(root)

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -69,10 +69,7 @@ SOURCE_METADATA = {
 
 def _add_scope_option(parser):
     parser.add_argument(
-        "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        help="configuration scope to read/modify",
+        "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
     )
 
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -184,9 +184,8 @@ def setup_parser(subparser: argparse.ArgumentParser):
     # used to construct scope arguments below
     check.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
         help="configuration scope containing mirrors to check",
     )
     check_spec_or_specfile = check.add_mutually_exclusive_group(required=True)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -21,7 +21,6 @@ from llnl.util.lang import elide_list
 
 import spack.binary_distribution as bindist
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.error
@@ -40,6 +39,7 @@ import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.build_environment import determine_number_of_jobs
 from spack.cmd import display_specs
+from spack.cmd.common import arguments
 from spack.oci.image import (
     Digest,
     ImageReference,
@@ -182,11 +182,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     # used to construct scope arguments below
-    scopes = spack.config.scopes()
-
     check.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope(),
         help="configuration scope containing mirrors to check",

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
+from spack.cmd.common import arguments
 
 description = "change an existing spec in an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -16,6 +16,7 @@ import spack.ci as spack_ci
 import spack.cmd.buildcache as buildcache
 import spack.config as cfg
 import spack.environment as ev
+import spack.environment.depfile
 import spack.hash_types as ht
 import spack.mirror
 import spack.util.gpg as gpg_util
@@ -606,7 +607,9 @@ def ci_rebuild(args):
             "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
             "-j$(nproc)",
             "install-deps/{}".format(
-                ev.depfile.MakefileSpec(job_spec).safe_format("{name}-{version}-{hash}")
+                spack.environment.depfile.MakefileSpec(job_spec).safe_format(
+                    "{name}-{version}-{hash}"
+                )
             ),
         ],
         spack_cmd + ["install"] + root_install_args,

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -12,13 +12,13 @@ import llnl.util.tty as tty
 
 import spack.bootstrap
 import spack.caches
-import spack.cmd.common.arguments as arguments
 import spack.cmd.test
 import spack.config
 import spack.repo
 import spack.stage
 import spack.store
 import spack.util.path
+from spack.cmd.common import arguments
 from spack.paths import lib_path, var_path
 
 description = "remove temporary build files and/or downloaded archives"

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -124,14 +124,31 @@ class DeptypeAction(argparse.Action):
         setattr(namespace, self.dest, deptype)
 
 
-class ConfigScopeChoices:
-    """A lazy list of config scope values (values may change at runtime in tests)."""
+class ConfigScope(argparse.Action):
+    """Pick the currently configured config scopes."""
 
-    def __contains__(self, item):
-        return item in spack.config.scopes()
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.setdefault("metavar", spack.config.SCOPES_METAVAR)
+        super().__init__(*args, **kwargs)
 
-    def __iter__(self):
-        return iter(spack.config.scopes().keys())
+    @property
+    def default(self):
+        return self._default() if callable(self._default) else self._default
+
+    @default.setter
+    def default(self, value):
+        self._default = value
+
+    @property
+    def choices(self):
+        return spack.config.scopes().keys()
+
+    @choices.setter
+    def choices(self, value):
+        pass
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
 
 
 def _cdash_reporter(namespace):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -124,6 +124,16 @@ class DeptypeAction(argparse.Action):
         setattr(namespace, self.dest, deptype)
 
 
+class ConfigScopeChoices:
+    """A lazy list of config scope values (values may change at runtime in tests)."""
+
+    def __contains__(self, item):
+        return item in spack.config.scopes()
+
+    def __iter__(self):
+        return iter(spack.config.scopes().keys())
+
+
 def _cdash_reporter(namespace):
     """Helper function to create a CDash reporter. This function gets an early reference to the
     argparse namespace under construction, so it can later use it to create the object.

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -8,13 +8,13 @@ import os
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.deptypes as dt
 import spack.error
 import spack.paths
 import spack.spec
 import spack.store
 from spack import build_environment, traverse
+from spack.cmd.common import arguments
 from spack.context import Context
 from spack.util.environment import dump_environment, pickle_environment
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -46,9 +46,8 @@ def setup_parser(subparser):
     find_parser.add_argument("add_paths", nargs=argparse.REMAINDER)
     find_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope("compilers"),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope("compilers"),
         help="configuration scope to modify",
     )
 
@@ -59,20 +58,15 @@ def setup_parser(subparser):
     )
     remove_parser.add_argument("compiler_spec")
     remove_parser.add_argument(
-        "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=None,
-        help="configuration scope to modify",
+        "--scope", action=arguments.ConfigScope, default=None, help="configuration scope to modify"
     )
 
     # List
     list_parser = sp.add_parser("list", help="list available compilers")
     list_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_list_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_list_scope(),
         help="configuration scope to read from",
     )
 
@@ -81,9 +75,8 @@ def setup_parser(subparser):
     info_parser.add_argument("compiler_spec")
     info_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_list_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_list_scope(),
         help="configuration scope to read from",
     )
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -14,6 +14,7 @@ from llnl.util.tty.color import colorize
 import spack.compilers
 import spack.config
 import spack.spec
+from spack.cmd.common import arguments
 
 description = "manage compilers"
 section = "system"
@@ -22,8 +23,6 @@ level = "long"
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="compiler_command")
-
-    scopes = spack.config.scopes()
 
     # Find
     find_parser = sp.add_parser(
@@ -47,7 +46,7 @@ def setup_parser(subparser):
     find_parser.add_argument("add_paths", nargs=argparse.REMAINDER)
     find_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope("compilers"),
         help="configuration scope to modify",
@@ -61,7 +60,7 @@ def setup_parser(subparser):
     remove_parser.add_argument("compiler_spec")
     remove_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=None,
         help="configuration scope to modify",
@@ -71,7 +70,7 @@ def setup_parser(subparser):
     list_parser = sp.add_parser("list", help="list available compilers")
     list_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_list_scope(),
         help="configuration scope to read from",
@@ -82,7 +81,7 @@ def setup_parser(subparser):
     info_parser.add_argument("compiler_spec")
     info_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_list_scope(),
         help="configuration scope to read from",

--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.config
+from spack.cmd.common import arguments
 from spack.cmd.compiler import compiler_list
 
 description = "list available compilers"
@@ -12,11 +13,9 @@ level = "short"
 
 
 def setup_parser(subparser):
-    scopes = spack.config.scopes()
-
     subparser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         help="configuration scope to read/modify",
     )

--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.config
 from spack.cmd.common import arguments
 from spack.cmd.compiler import compiler_list
 
@@ -14,10 +13,7 @@ level = "short"
 
 def setup_parser(subparser):
     subparser.add_argument(
-        "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        help="configuration scope to read/modify",
+        "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
     )
 
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -10,7 +10,6 @@ from typing import List
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
-import spack.cmd.common.arguments
 import spack.config
 import spack.environment as ev
 import spack.repo
@@ -18,6 +17,7 @@ import spack.schema.env
 import spack.schema.packages
 import spack.store
 import spack.util.spack_yaml as syaml
+from spack.cmd.common import arguments
 from spack.util.editor import editor
 
 description = "get and set configuration options"
@@ -26,12 +26,10 @@ level = "long"
 
 
 def setup_parser(subparser):
-    scopes = spack.config.scopes()
-
     # User can only choose one
     subparser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         help="configuration scope to read/modify",
     )
@@ -101,13 +99,13 @@ def setup_parser(subparser):
     setup_parser.add_parser = add_parser
 
     update = sp.add_parser("update", help="update configuration files to the latest format")
-    spack.cmd.common.arguments.add_common_arguments(update, ["yes_to_all"])
+    arguments.add_common_arguments(update, ["yes_to_all"])
     update.add_argument("section", help="section to update")
 
     revert = sp.add_parser(
         "revert", help="revert configuration files to their state before update"
     )
-    spack.cmd.common.arguments.add_common_arguments(revert, ["yes_to_all"])
+    arguments.add_common_arguments(revert, ["yes_to_all"])
     revert.add_argument("section", help="section to update")
 
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -28,10 +28,7 @@ level = "long"
 def setup_parser(subparser):
     # User can only choose one
     subparser.add_argument(
-        "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        help="configuration scope to read/modify",
+        "--scope", action=arguments.ConfigScope, help="configuration scope to read/modify"
     )
 
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="config_command")

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -359,20 +359,7 @@ class PythonPackageTemplate(PackageTemplate):
         # FIXME: Add configuration settings to be passed to the build backend
         # FIXME: If not needed, delete this function
         settings = {}
-        return settings
-
-    def install_options(self, spec, prefix):
-        # FIXME: Add options to pass to setup.py install
-        # FIXME: If not needed, delete this function
-        options = []
-        return options
-
-    def optional_extras(self, spec, prefix):
-        # FIXME: Add extras to pass to pip install:
-        # FIXME:   pip install ... <path/wheel>[extra,...]
-        # FIXME: If not needed, delete this function.
-        extras = []
-        return extras"""
+        return settings"""
 
     def __init__(self, name, url, *args, **kwargs):
         # If the user provided `--name py-numpy`, don't rename it py-py-numpy

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -10,10 +10,10 @@ from typing import List
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.cmd.common.confirmation as confirmation
 import spack.environment as ev
 import spack.spec
+from spack.cmd.common import arguments
 
 description = "remove specs from the concretized lockfile of an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -9,11 +9,11 @@ import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.package_base
 import spack.repo
 import spack.store
+from spack.cmd.common import arguments
 
 description = "show dependencies of a package"
 section = "basic"

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -9,10 +9,10 @@ import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.repo
 import spack.store
+from spack.cmd.common import arguments
 
 description = "show packages that depend on another"
 section = "basic"

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -20,9 +20,9 @@ import llnl.util.tty as tty
 from llnl.util.symlink import symlink
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.store
+from spack.cmd.common import arguments
 from spack.database import InstallStatuses
 from spack.error import SpackError
 

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -9,9 +9,9 @@ import sys
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.repo
+from spack.cmd.common import arguments
 
 description = "developer build: build from code in current working directory"
 section = "build"

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -8,10 +8,10 @@ import shutil
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.spec
 import spack.util.path
 import spack.version
+from spack.cmd.common import arguments
 from spack.error import SpackError
 
 description = "add a spec to an environment's dev-build information"

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -10,11 +10,11 @@ import llnl.util.tty as tty
 from llnl.util.tty.color import cprint, get_color_when
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.solver.asp as asp
 import spack.util.environment
 import spack.util.spack_json as sjson
+from spack.cmd.common import arguments
 
 description = "compare two specs"
 section = "basic"

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -20,7 +20,6 @@ from llnl.util.tty.color import colorize
 import spack.cmd
 import spack.cmd.common
 import spack.cmd.common.arguments
-import spack.cmd.common.arguments as arguments
 import spack.cmd.install
 import spack.cmd.modules
 import spack.cmd.uninstall
@@ -31,6 +30,7 @@ import spack.environment.shell
 import spack.schema.env
 import spack.spec
 import spack.tengine
+from spack.cmd.common import arguments
 from spack.util.environment import EnvironmentModifications
 
 description = "manage virtual environments"

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -10,10 +10,10 @@ import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import spack.cmd as cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.repo
 import spack.store
+from spack.cmd.common import arguments
 
 description = "list extensions for package"
 section = "extensions"

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -14,12 +14,12 @@ import llnl.util.tty.colify as colify
 
 import spack
 import spack.cmd
-import spack.cmd.common.arguments
 import spack.config
 import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
 import spack.util.environment
+from spack.cmd.common import arguments
 
 description = "manage external packages in Spack configuration"
 section = "config"
@@ -28,8 +28,6 @@ level = "short"
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="external_command")
-
-    scopes = spack.config.scopes()
 
     find_parser = sp.add_parser("find", help="add external packages to packages.yaml")
     find_parser.add_argument(
@@ -48,7 +46,7 @@ def setup_parser(subparser):
     )
     find_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope("packages"),
         help="configuration scope to modify",
@@ -56,7 +54,7 @@ def setup_parser(subparser):
     find_parser.add_argument(
         "--all", action="store_true", help="search for all packages that Spack knows about"
     )
-    spack.cmd.common.arguments.add_common_arguments(find_parser, ["tags", "jobs"])
+    arguments.add_common_arguments(find_parser, ["tags", "jobs"])
     find_parser.add_argument("packages", nargs=argparse.REMAINDER)
     find_parser.epilog = (
         'The search is by default on packages tagged with the "build-tools" or '

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -46,9 +46,8 @@ def setup_parser(subparser):
     )
     find_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope("packages"),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope("packages"),
         help="configuration scope to modify",
     )
     find_parser.add_argument(

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -6,11 +6,11 @@
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.repo
 import spack.traverse
+from spack.cmd.common import arguments
 
 description = "fetch archives for packages"
 section = "build"

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -12,9 +12,9 @@ import llnl.util.tty.color as color
 
 import spack.bootstrap
 import spack.cmd as cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.repo
+from spack.cmd.common import arguments
 from spack.database import InstallStatuses
 
 description = "list and search installed packages"

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -7,11 +7,11 @@ import argparse
 import os
 
 import spack.binary_distribution
-import spack.cmd.common.arguments as arguments
 import spack.mirror
 import spack.paths
 import spack.util.gpg
 import spack.util.url
+from spack.cmd.common import arguments
 
 description = "handle GPG actions for spack"
 section = "packaging"

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -5,10 +5,10 @@
 from llnl.util import tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.store
+from spack.cmd.common import arguments
 from spack.graph import DAGWithDependencyTypes, SimpleDAG, graph_ascii, graph_dot, static_graph_dot
 
 description = "generate graphs of package dependency relationships"

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -11,13 +11,13 @@ import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
-import spack.cmd.common.arguments as arguments
 import spack.deptypes as dt
 import spack.fetch_strategy as fs
 import spack.install_test
 import spack.repo
 import spack.spec
 import spack.version
+from spack.cmd.common import arguments
 from spack.package_base import preferred_version
 
 description = "get detailed information on a particular package"

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -327,7 +327,7 @@ def _variants_by_name_when(pkg):
     """Adaptor to get variants keyed by { name: { when: { [Variant...] } }."""
     # TODO: replace with pkg.variants_by_name(when=True) when unified directive dicts are merged.
     variants = {}
-    for name, (variant, whens) in pkg.variants.items():
+    for name, (variant, whens) in sorted(pkg.variants.items()):
         for when in whens:
             variants.setdefault(name, {}).setdefault(when, []).append(variant)
     return variants

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -14,7 +14,6 @@ from llnl.util import lang, tty
 
 import spack.build_environment
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.fetch_strategy
@@ -23,6 +22,7 @@ import spack.paths
 import spack.report
 import spack.spec
 import spack.store
+from spack.cmd.common import arguments
 from spack.error import SpackError
 from spack.installer import PackageInstaller
 

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -15,9 +15,9 @@ from html import escape
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
-import spack.cmd.common.arguments as arguments
 import spack.deptypes as dt
 import spack.repo
+from spack.cmd.common import arguments
 from spack.version import VersionList
 
 description = "list and search available packages"

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -8,12 +8,12 @@ import sys
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.cmd.find
 import spack.environment as ev
 import spack.store
 import spack.user_environment as uenv
 import spack.util.environment
+from spack.cmd.common import arguments
 
 description = "add package to the user environment"
 section = "user environment"

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -9,11 +9,11 @@ import llnl.util.tty as tty
 
 import spack.builder
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.paths
 import spack.repo
 import spack.stage
+from spack.cmd.common import arguments
 
 description = "print out locations of packages and spack directories"
 section = "basic"

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -8,11 +8,11 @@ import sys
 from llnl.util import tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.error
 import spack.package_base
 import spack.repo
 import spack.store
+from spack.cmd.common import arguments
 from spack.database import InstallStatuses
 
 description = "mark packages as explicitly or implicitly installed"

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -94,9 +94,8 @@ def setup_parser(subparser):
     add_parser.add_argument("url", help="url of mirror directory from 'spack mirror create'")
     add_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
     add_parser.add_argument(
@@ -114,9 +113,8 @@ def setup_parser(subparser):
     remove_parser.add_argument("name", help="mnemonic name for mirror", metavar="mirror")
     remove_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
 
@@ -133,9 +131,8 @@ def setup_parser(subparser):
     )
     set_url_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
     arguments.add_connection_args(set_url_parser, False)
@@ -162,9 +159,8 @@ def setup_parser(subparser):
     set_parser.add_argument("--url", help="url of mirror directory from 'spack mirror create'")
     set_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
     arguments.add_connection_args(set_parser, False)
@@ -173,9 +169,8 @@ def setup_parser(subparser):
     list_parser = sp.add_parser("list", help=mirror_list.__doc__)
     list_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_list_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_list_scope(),
         help="configuration scope to read from",
     )
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -11,7 +11,6 @@ import llnl.util.tty.colify as colify
 
 import spack.caches
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.concretize
 import spack.config
 import spack.environment as ev
@@ -20,6 +19,7 @@ import spack.repo
 import spack.spec
 import spack.util.path
 import spack.util.web as web_util
+from spack.cmd.common import arguments
 from spack.error import SpackError
 
 description = "manage mirrors (source and binary)"
@@ -88,16 +88,13 @@ def setup_parser(subparser):
         "--mirror-url", metavar="mirror_url", type=str, help="find mirror to destroy by url"
     )
 
-    # used to construct scope arguments below
-    scopes = spack.config.scopes()
-
     # Add
     add_parser = sp.add_parser("add", help=mirror_add.__doc__)
     add_parser.add_argument("name", help="mnemonic name for mirror", metavar="mirror")
     add_parser.add_argument("url", help="url of mirror directory from 'spack mirror create'")
     add_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify",
@@ -117,7 +114,7 @@ def setup_parser(subparser):
     remove_parser.add_argument("name", help="mnemonic name for mirror", metavar="mirror")
     remove_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify",
@@ -136,7 +133,7 @@ def setup_parser(subparser):
     )
     set_url_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify",
@@ -165,7 +162,7 @@ def setup_parser(subparser):
     set_parser.add_argument("--url", help="url of mirror directory from 'spack mirror create'")
     set_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify",
@@ -176,7 +173,7 @@ def setup_parser(subparser):
     list_parser = sp.add_parser("list", help=mirror_list.__doc__)
     list_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_list_scope(),
         help="configuration scope to read from",

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -14,11 +14,11 @@ from llnl.util import filesystem, tty
 from llnl.util.tty import color
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.modules
 import spack.modules.common
 import spack.repo
+from spack.cmd.common import arguments
 
 description = "manipulate module files"
 section = "environment"

--- a/lib/spack/spack/cmd/patch.py
+++ b/lib/spack/spack/cmd/patch.py
@@ -6,12 +6,12 @@
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.package_base
 import spack.repo
 import spack.traverse
+from spack.cmd.common import arguments
 
 description = "patch expanded archive sources in preparation for install"
 section = "build"

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -12,11 +12,11 @@ import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.paths
 import spack.repo
 import spack.util.executable as exe
 import spack.util.package_hash as ph
+from spack.cmd.common import arguments
 
 description = "query packages associated with particular git revisions"
 section = "developer"

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -6,7 +6,7 @@
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
+from spack.cmd.common import arguments
 
 description = "remove specs from an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -11,6 +11,7 @@ import llnl.util.tty as tty
 import spack.config
 import spack.repo
 import spack.util.path
+from spack.cmd.common import arguments
 
 description = "manage package source repositories"
 section = "config"
@@ -19,7 +20,6 @@ level = "long"
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="repo_command")
-    scopes = spack.config.scopes()
 
     # Create
     create_parser = sp.add_parser("create", help=repo_create.__doc__)
@@ -43,7 +43,7 @@ def setup_parser(subparser):
     list_parser = sp.add_parser("list", help=repo_list.__doc__)
     list_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_list_scope(),
         help="configuration scope to read from",
@@ -54,7 +54,7 @@ def setup_parser(subparser):
     add_parser.add_argument("path", help="path to a Spack package repository directory")
     add_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify",
@@ -67,7 +67,7 @@ def setup_parser(subparser):
     )
     remove_parser.add_argument(
         "--scope",
-        choices=scopes,
+        choices=arguments.ConfigScopeChoices(),
         metavar=spack.config.SCOPES_METAVAR,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify",

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -43,9 +43,8 @@ def setup_parser(subparser):
     list_parser = sp.add_parser("list", help=repo_list.__doc__)
     list_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_list_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_list_scope(),
         help="configuration scope to read from",
     )
 
@@ -54,9 +53,8 @@ def setup_parser(subparser):
     add_parser.add_argument("path", help="path to a Spack package repository directory")
     add_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
 
@@ -67,9 +65,8 @@ def setup_parser(subparser):
     )
     remove_parser.add_argument(
         "--scope",
-        choices=arguments.ConfigScopeChoices(),
-        metavar=spack.config.SCOPES_METAVAR,
-        default=spack.config.default_modify_scope(),
+        action=arguments.ConfigScope,
+        default=lambda: spack.config.default_modify_scope(),
         help="configuration scope to modify",
     )
 

--- a/lib/spack/spack/cmd/restage.py
+++ b/lib/spack/spack/cmd/restage.py
@@ -6,8 +6,8 @@
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.repo
+from spack.cmd.common import arguments
 
 description = "revert checked out package source code"
 section = "build"

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -12,12 +12,12 @@ import llnl.util.tty.color as color
 
 import spack
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment
 import spack.hash_types as ht
 import spack.package_base
 import spack.solver.asp as asp
+from spack.cmd.common import arguments
 
 description = "concretize a specs using an ASP solver"
 section = "developer"

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -10,11 +10,11 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.spec
 import spack.store
+from spack.cmd.common import arguments
 
 description = "show what would be installed, given a spec"
 section = "build"

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -8,13 +8,13 @@ import os
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.package_base
 import spack.repo
 import spack.stage
 import spack.traverse
+from spack.cmd.common import arguments
 
 description = "expand downloaded archive in preparation for install"
 section = "build"

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -15,12 +15,12 @@ from llnl.util import lang, tty
 from llnl.util.tty import colify
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.install_test
 import spack.package_base
 import spack.repo
 import spack.report
+from spack.cmd.common import arguments
 
 description = "run spack's tests for an install"
 section = "admin"

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -10,11 +10,11 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
 import spack
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.paths
 import spack.util.git
 import spack.util.gpg
+from spack.cmd.common import arguments
 from spack.util.spack_yaml import syaml_dict
 
 description = "set up spack for our tutorial (WARNING: modifies config!)"

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -6,7 +6,7 @@
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
+from spack.cmd.common import arguments
 
 description = "remove specs from an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -10,13 +10,13 @@ from llnl.util import tty
 from llnl.util.tty.colify import colify
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.cmd.common.confirmation as confirmation
 import spack.environment as ev
 import spack.package_base
 import spack.spec
 import spack.store
 import spack.traverse as traverse
+from spack.cmd.common import arguments
 from spack.database import InstallStatuses
 
 description = "remove installed packages"

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -227,9 +227,7 @@ def unit_test(parser, args, unknown_args):
     # has been used, then test that extension.
     pytest_root = spack.paths.spack_root
     if args.extension:
-        target = args.extension
-        extensions = spack.extensions.get_extension_paths()
-        pytest_root = spack.extensions.path_for_extension(target, *extensions)
+        pytest_root = spack.extensions.load_extension(args.extension)
 
     # pytest.ini lives in the root of the spack repository.
     with llnl.util.filesystem.working_dir(pytest_root):

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -7,10 +7,10 @@ import os
 import sys
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.error
 import spack.user_environment as uenv
 import spack.util.environment
+from spack.cmd.common import arguments
 
 description = "remove package from the user environment"
 section = "user environment"

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -8,9 +8,9 @@ import sys
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
-import spack.cmd.common.arguments as arguments
 import spack.repo
 import spack.spec
+from spack.cmd.common import arguments
 from spack.version import infinity_versions, ver
 
 description = "list available versions of a package"

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -309,10 +309,14 @@ class WindowsKitExternalPaths:
         return glob.glob(kit_base)
 
     @staticmethod
-    def find_windows_kit_bin_paths(kit_base: Optional[str] = None) -> List[str]:
+    def find_windows_kit_bin_paths(
+        kit_base: Union[Optional[str], Optional[list]] = None
+    ) -> List[str]:
         """Returns Windows kit bin directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
         assert kit_base, "Unexpectedly empty value for Windows kit base path"
+        if isinstance(kit_base, str):
+            kit_base = kit_base.split(";")
         kit_paths = []
         for kit in kit_base:
             kit_bin = os.path.join(kit, "bin")
@@ -320,10 +324,14 @@ class WindowsKitExternalPaths:
         return kit_paths
 
     @staticmethod
-    def find_windows_kit_lib_paths(kit_base: Optional[str] = None) -> List[str]:
+    def find_windows_kit_lib_paths(
+        kit_base: Union[Optional[str], Optional[list]] = None
+    ) -> List[str]:
         """Returns Windows kit lib directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
         assert kit_base, "Unexpectedly empty value for Windows kit base path"
+        if isinstance(kit_base, str):
+            kit_base = kit_base.split(";")
         kit_paths = []
         for kit in kit_base:
             kit_lib = os.path.join(kit, "Lib")

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -6,11 +6,13 @@
 for Spack's command extensions.
 """
 import difflib
+import glob
 import importlib
 import os
 import re
 import sys
 import types
+from typing import List
 
 import llnl.util.lang
 
@@ -75,6 +77,15 @@ def load_command_extension(command, path):
     if not os.path.exists(cmd_path):
         return None
 
+    ensure_extension_loaded(extension, path=path)
+
+    module = importlib.import_module(module_name)
+    sys.modules[module_name] = module
+
+    return module
+
+
+def ensure_extension_loaded(extension, *, path):
     def ensure_package_creation(name):
         package_name = "{0}.{1}".format(__name__, name)
         if package_name in sys.modules:
@@ -100,10 +111,22 @@ def load_command_extension(command, path):
     ensure_package_creation(extension)
     ensure_package_creation(extension + ".cmd")
 
-    module = importlib.import_module(module_name)
-    sys.modules[module_name] = module
 
-    return module
+def load_extension(name: str) -> str:
+    """Loads a single extension into the 'spack.extensions' package.
+
+    Args:
+        name: name of the extension
+    """
+    extension_root = path_for_extension(name, paths=get_extension_paths())
+    ensure_extension_loaded(name, path=extension_root)
+    commands = glob.glob(
+        os.path.join(extension_root, extension_name(extension_root), "cmd", "*.py")
+    )
+    commands = [os.path.basename(x).rstrip(".py") for x in commands]
+    for command in commands:
+        load_command_extension(command, extension_root)
+    return extension_root
 
 
 def get_extension_paths():
@@ -125,7 +148,7 @@ def get_command_paths():
     return command_paths
 
 
-def path_for_extension(target_name, *paths):
+def path_for_extension(target_name: str, *, paths: List[str]) -> str:
     """Return the test root dir for a given extension.
 
     Args:

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -206,11 +206,15 @@ def tokenize(text: str) -> Iterator[Token]:
     scanner = ALL_TOKENS.scanner(text)  # type: ignore[attr-defined]
     match: Optional[Match] = None
     for match in iter(scanner.match, None):
+        # The following two assertions are to help mypy
+        msg = (
+            "unexpected value encountered during parsing. Please submit a bug report "
+            "at https://github.com/spack/spack/issues/new/choose"
+        )
+        assert match is not None, msg
+        assert match.lastgroup is not None, msg
         yield Token(
-            TokenType.__members__[match.lastgroup],  # type: ignore[attr-defined]
-            match.group(),  # type: ignore[attr-defined]
-            match.start(),  # type: ignore[attr-defined]
-            match.end(),  # type: ignore[attr-defined]
+            TokenType.__members__[match.lastgroup], match.group(), match.start(), match.end()
         )
 
     if match is None and not text:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -153,6 +153,25 @@ class CDash(Reporter):
             elif cdash_phase:
                 report_data[cdash_phase]["loglines"].append(xml.sax.saxutils.escape(line))
 
+        # something went wrong pre-cdash "configure" phase b/c we have an exception and only
+        # "update" was encounterd.
+        # dump the report in the configure line so teams can see what the issue is
+        if len(phases_encountered) == 1 and package["exception"]:
+            # TODO this mapping is not ideal since these are pre-configure errors
+            # we need to determine if a more appropriate cdash phase can be utilized
+            # for now we will add a message to the log explaining this
+            cdash_phase = "configure"
+            phases_encountered.append(cdash_phase)
+
+            log_message = (
+                "Pre-configure errors occured in Spack's process that terminated the "
+                "build process prematurely.\nSpack output::\n{0}".format(
+                    xml.sax.saxutils.escape(package["exception"])
+                )
+            )
+
+            report_data[cdash_phase]["loglines"].append(log_message)
+
         # Move the build phase to the front of the list if it occurred.
         # This supports older versions of CDash that expect this phase
         # to be reported before all others.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2699,15 +2699,13 @@ class SpackSolverSetup:
             self.gen.fact(fn.pkg_fact(spec.name, fn.condition_trigger(condition_id, trigger_id)))
             self.gen.fact(fn.condition_reason(condition_id, f"{spec} requested from CLI"))
 
-            # Effect imposes the spec
             imposed_spec_key = str(spec), None
             cache = self._effect_cache[spec.name]
-            msg = (
-                "literal specs have different requirements. clear cache before computing literals"
-            )
-            assert imposed_spec_key not in cache, msg
-            effect_id = next(self._id_counter)
-            requirements = self.spec_clauses(spec)
+            if imposed_spec_key in cache:
+                effect_id, requirements = cache[imposed_spec_key]
+            else:
+                effect_id = next(self._id_counter)
+                requirements = self.spec_clauses(spec)
             root_name = spec.name
             for clause in requirements:
                 clause_name = clause.args[0]

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -20,7 +20,7 @@
 % Integrity constraints on DAG nodes
 :- attr("root", PackageNode), not attr("node", PackageNode).
 :- attr("version", PackageNode, _), not attr("node", PackageNode), not attr("virtual_node", PackageNode).
-:- attr("node_version_satisfies", PackageNode), not attr("node", PackageNode).
+:- attr("node_version_satisfies", PackageNode, _), not attr("node", PackageNode), not attr("virtual_node", PackageNode).
 :- attr("hash", PackageNode, _), not attr("node", PackageNode).
 :- attr("node_platform", PackageNode, _), not attr("node", PackageNode).
 :- attr("node_os", PackageNode, _), not attr("node", PackageNode).

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3540,7 +3540,7 @@ def test_environment_created_in_users_location(mutable_mock_env_path, tmp_path):
     assert os.path.isdir(os.path.join(env_dir, dir_name))
 
 
-def test_environment_created_from_lockfile_has_view(mock_packages, tmpdir):
+def test_environment_created_from_lockfile_has_view(mock_packages, temporary_store, tmpdir):
     """When an env is created from a lockfile, a view should be generated for it"""
     env_a = str(tmpdir.join("a"))
     env_b = str(tmpdir.join("b"))

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -203,7 +203,9 @@ class Changing(Package):
                 # TODO: in case tests using this fixture start failing.
                 if sys.modules.get("spack.pkg.changing.changing"):
                     del sys.modules["spack.pkg.changing.changing"]
+                if sys.modules.get("spack.pkg.changing.root"):
                     del sys.modules["spack.pkg.changing.root"]
+                if sys.modules.get("spack.pkg.changing"):
                     del sys.modules["spack.pkg.changing"]
 
                 # Change the recipe
@@ -1604,7 +1606,9 @@ class TestConcretize:
         assert not new_root["changing"].satisfies("@1.0")
 
     @pytest.mark.regression("28259")
-    def test_reuse_with_unknown_namespace_dont_raise(self, mock_custom_repository):
+    def test_reuse_with_unknown_namespace_dont_raise(
+        self, temporary_store, mock_custom_repository
+    ):
         with spack.repo.use_repositories(mock_custom_repository, override=False):
             s = Spec("c").concretized()
             assert s.namespace != "builtin.mock"
@@ -1615,8 +1619,8 @@ class TestConcretize:
         assert s.namespace == "builtin.mock"
 
     @pytest.mark.regression("28259")
-    def test_reuse_with_unknown_package_dont_raise(self, tmpdir, monkeypatch):
-        builder = spack.repo.MockRepositoryBuilder(tmpdir, namespace="myrepo")
+    def test_reuse_with_unknown_package_dont_raise(self, tmpdir, temporary_store, monkeypatch):
+        builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"), namespace="myrepo")
         builder.add_package("c")
         with spack.repo.use_repositories(builder.root, override=False):
             s = Spec("c").concretized()

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1239,11 +1239,11 @@ def test_user_config_path_is_default_when_env_var_is_empty(working_env):
     assert os.path.expanduser("~%s.spack" % os.sep) == spack.paths._get_user_config_path()
 
 
-def test_default_install_tree(monkeypatch):
+def test_default_install_tree(monkeypatch, default_config):
     s = spack.spec.Spec("nonexistent@x.y.z %none@a.b.c arch=foo-bar-baz")
     monkeypatch.setattr(s, "dag_hash", lambda: "abc123")
-    projection = spack.config.get("config:install_tree:projections:all", scope="defaults")
-    assert s.format(projection) == "foo-bar-baz/none-a.b.c/nonexistent-x.y.z-abc123"
+    _, _, projections = spack.store.parse_install_tree(spack.config.get("config"))
+    assert s.format(projections["all"]) == "foo-bar-baz/none-a.b.c/nonexistent-x.y.z-abc123"
 
 
 def test_local_config_can_be_disabled(working_env):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -714,9 +714,6 @@ def configuration_dir(tmpdir_factory, linux_os):
     t.write(content)
     yield tmpdir
 
-    # Once done, cleanup the directory
-    shutil.rmtree(str(tmpdir))
-
 
 def _create_mock_configuration_scopes(configuration_dir):
     """Create the configuration scopes used in `config` and `mutable_config`."""

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -720,13 +720,13 @@ def configuration_dir(tmpdir_factory, linux_os):
 
 def _create_mock_configuration_scopes(configuration_dir):
     """Create the configuration scopes used in `config` and `mutable_config`."""
-    scopes = [spack.config.InternalConfigScope("_builtin", spack.config.CONFIG_DEFAULTS)]
-    scopes += [
-        spack.config.ConfigScope(name, str(configuration_dir.join(name)))
-        for name in ["site", "system", "user"]
+    return [
+        spack.config.InternalConfigScope("_builtin", spack.config.CONFIG_DEFAULTS),
+        spack.config.ConfigScope("site", str(configuration_dir.join("site"))),
+        spack.config.ConfigScope("system", str(configuration_dir.join("system"))),
+        spack.config.ConfigScope("user", str(configuration_dir.join("user"))),
+        spack.config.InternalConfigScope("command_line"),
     ]
-    scopes += [spack.config.InternalConfigScope("command_line")]
-    return scopes
 
 
 @pytest.fixture(scope="session")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -630,7 +630,7 @@ def platform_config():
     spack.config.add_default_platform_scope(spack.platforms.real_host().name)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def default_config():
     """Isolates the default configuration from the user configs.
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -695,7 +695,7 @@ def test_removing_spec_from_manifest_with_exact_duplicates(
 
 @pytest.mark.regression("35298")
 @pytest.mark.only_clingo("Propagation not supported in the original concretizer")
-def test_variant_propagation_with_unify_false(tmp_path, mock_packages):
+def test_variant_propagation_with_unify_false(tmp_path, mock_packages, config):
     """Spack distributes concretizations to different processes, when unify:false is selected and
     the number of roots is 2 or more. When that happens, the specs to be concretized need to be
     properly reconstructed on the worker process, if variant propagation was requested.

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -778,3 +778,32 @@ def test_env_with_include_def_missing(mutable_mock_env_path, mock_packages):
     with e:
         with pytest.raises(UndefinedReferenceError, match=r"which does not appear"):
             e.concretize()
+
+
+@pytest.mark.regression("41292")
+def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, mock_packages):
+    """Tests that, after having deconcretized a spec, we can reconcretize an environment which
+    has 2 or more user specs mapping to the same concrete spec.
+    """
+    mutable_mock_env_path.mkdir()
+    spack_yaml = mutable_mock_env_path / ev.manifest_name
+    spack_yaml.write_text(
+        """spack:
+      specs:
+      # These two specs concretize to the same hash
+      - c
+      - c@1.0
+      # Spec used to trigger the bug
+      - a
+      concretizer:
+        unify: true
+    """
+    )
+    e = ev.Environment(mutable_mock_env_path)
+    with e:
+        e.concretize()
+        e.deconcretize(spack.spec.Spec("a"), concrete=False)
+        e.concretize()
+    assert len(e.concrete_roots()) == 3
+    all_root_hashes = set(x.dag_hash() for x in e.concrete_roots())
+    assert len(all_root_hashes) == 2

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -27,16 +27,13 @@ test_module_lines = [
 ]
 
 
-def test_module_function_change_env(tmpdir, working_env):
-    src_file = str(tmpdir.join("src_me"))
-    with open(src_file, "w") as f:
-        f.write("export TEST_MODULE_ENV_VAR=TEST_SUCCESS\n")
-
-    os.environ["NOT_AFFECTED"] = "NOT_AFFECTED"
-    module("load", src_file, module_template=". {0} 2>&1".format(src_file))
-
-    assert os.environ["TEST_MODULE_ENV_VAR"] == "TEST_SUCCESS"
-    assert os.environ["NOT_AFFECTED"] == "NOT_AFFECTED"
+def test_module_function_change_env(tmp_path):
+    environb = {b"TEST_MODULE_ENV_VAR": b"TEST_FAIL", b"NOT_AFFECTED": b"NOT_AFFECTED"}
+    src_file = tmp_path / "src_me"
+    src_file.write_text("export TEST_MODULE_ENV_VAR=TEST_SUCCESS\n")
+    module("load", str(src_file), module_template=f". {src_file} 2>&1", environb=environb)
+    assert environb[b"TEST_MODULE_ENV_VAR"] == b"TEST_SUCCESS"
+    assert environb[b"NOT_AFFECTED"] == b"NOT_AFFECTED"
 
 
 def test_module_function_no_change(tmpdir):

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -147,7 +147,8 @@ def test_reverse_environment_modifications(working_env):
 
     reversal = to_reverse.reversed()
 
-    os.environ = start_env.copy()
+    os.environ.clear()
+    os.environ.update(start_env)
 
     print(os.environ)
     to_reverse.apply_modifications()

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -10,6 +10,7 @@ parsing environment modules.
 import os
 import re
 import subprocess
+from typing import MutableMapping, Optional
 
 import llnl.util.tty as tty
 
@@ -21,8 +22,13 @@ module_change_commands = ["load", "swap", "unload", "purge", "use", "unuse"]
 awk_cmd = r"""awk 'BEGIN{for(name in ENVIRON)""" r"""printf("%s=%s%c", name, ENVIRON[name], 0)}'"""
 
 
-def module(*args, **kwargs):
-    module_cmd = kwargs.get("module_template", "module " + " ".join(args))
+def module(
+    *args,
+    module_template: Optional[str] = None,
+    environb: Optional[MutableMapping[bytes, bytes]] = None,
+):
+    module_cmd = module_template or ("module " + " ".join(args))
+    environb = environb or os.environb
 
     if args[0] in module_change_commands:
         # Suppress module output
@@ -33,10 +39,10 @@ def module(*args, **kwargs):
             stderr=subprocess.STDOUT,
             shell=True,
             executable="/bin/bash",
+            env=environb,
         )
 
-        # In Python 3, keys and values of `environ` are byte strings.
-        environ = {}
+        new_environb = {}
         output = module_p.communicate()[0]
 
         # Loop over each environment variable key=value byte string
@@ -45,11 +51,11 @@ def module(*args, **kwargs):
             parts = entry.split(b"=", 1)
             if len(parts) != 2:
                 continue
-            environ[parts[0]] = parts[1]
+            new_environb[parts[0]] = parts[1]
 
         # Update os.environ with new dict
-        os.environ.clear()
-        os.environb.update(environ)  # novermin
+        environb.clear()
+        environb.update(new_environb)  # novermin
 
     else:
         # Simply execute commands that don't change state and return output

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -461,6 +461,28 @@ build_systems-build:
     - artifacts: True
       job: build_systems-generate
 
+###########################################
+# Build tests for different developer tools
+###########################################
+.developer-tools:
+  extends: [ ".linux_x86_64_v3" ]
+  variables:
+    SPACK_CI_STACK_NAME: developer-tools
+
+developer-tools-generate:
+  extends: [ ".developer-tools", ".generate-x86_64"]
+
+developer-tools-build:
+  extends: [ ".developer-tools", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: developer-tools-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: developer-tools-generate
+
 #########################################
 # RADIUSS
 #########################################

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -193,7 +193,6 @@ ci:
       - blt
       - bzip2
       - camp
-      - cmake
       - curl
       - czmq
       - darshan-util

--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools/spack.yaml
@@ -1,0 +1,69 @@
+spack:
+  view: false
+  packages:
+    all:
+      require: target=x86_64_v3
+  concretizer:
+    unify: true
+  definitions:
+    - default_specs:
+      # editors
+      - neovim~no_luajit
+      - py-pynvim
+      - emacs@29.1+json+native+treesitter # note, pulls in gcc
+      # - tree-sitter is a dep, should also have cli but no package
+      - nano # just in case
+      # tags and scope search helpers
+      - universal-ctags # only maintained ctags, works better with c++
+      - direnv
+      # runtimes and compilers
+      - python
+      - llvm+link_llvm_dylib~lld~lldb~polly+python build_type=MinSizeRel # for clangd, clang-format
+      - node-js # for editor plugins etc., pyright language server
+      - npm
+      - go # to build fzf, gh, hub
+      - rust+analysis # fd, ripgrep, hyperfine, exa, rust-analyzer
+      - binutils+ld+gold+plugins # support linking with built gcc
+      # styling and lints
+      - astyle
+      - cppcheck
+      - uncrustify
+      - py-fprettify
+      - py-fortran-language-server
+      - py-python-lsp-server
+      # cli dev tools
+      - ripgrep
+      - gh
+      - fd
+      - bfs
+      - fzf
+      - tree
+      - jq
+      - py-yq
+      - hub
+      - ncdu
+      - eza
+      - lsd
+      - hyperfine
+      - htop
+      - tmux
+      - ccache
+      # ensure we can use a jobserver build and do this fast
+      - gmake
+      - ninja # should be @kitware, can't be because of meson requirement
+      - "openssl certs=system" # must be this, system external does not work
+    - arch:
+      - '%gcc target=x86_64_v3'
+
+  specs:
+    - matrix:
+        - - $default_specs
+        - - $arch
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01"
+
+  cdash:
+    build-group: Developer Tools

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -198,12 +198,12 @@ spack:
   # GPU
   - aml +ze
   - amrex +sycl
-  - arborx +sycl ^kokkos +sycl +openmp cxxstd=17 +tests +examples
-  - cabana +sycl ^kokkos +sycl +openmp cxxstd=17 +tests +examples
+  - arborx +sycl ^kokkos +sycl +openmp cxxstd=17 +examples
+  - cabana +sycl ^kokkos +sycl +openmp cxxstd=17 +examples
   - ginkgo +sycl
   - heffte +sycl
-  - kokkos +sycl +openmp cxxstd=17 +tests +examples
-  - kokkos-kernels build_type=Release %oneapi ^kokkos +sycl +openmp cxxstd=17 +tests +examples
+  - kokkos +sycl +openmp cxxstd=17 +examples
+  - kokkos-kernels build_type=Release %oneapi ^kokkos +sycl +openmp cxxstd=17 +examples
   - petsc +sycl
   - slate +sycl
   - sundials +sycl cxxstd=17 +examples-install

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -24,7 +24,9 @@ spack:
 
   # Keras
   # Bazel codesign issues
-  # - py-keras
+  # - py-keras backend=tensorflow
+  # - py-keras backend=jax
+  - py-keras backend=torch
   - py-keras-applications
   - py-keras-preprocessing
   - py-keras2onnx

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -19,7 +19,9 @@ spack:
     - py-jaxlib
 
     # Keras
-    - py-keras
+    # - py-keras backend=tensorflow
+    - py-keras backend=jax
+    - py-keras backend=torch
     - py-keras-applications
     - py-keras-preprocessing
     - py-keras2onnx

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -22,7 +22,9 @@ spack:
     - py-jaxlib
 
     # Keras
-    - py-keras
+    # - py-keras backend=tensorflow
+    - py-keras backend=jax
+    - py-keras backend=torch
     - py-keras-applications
     - py-keras-preprocessing
     - py-keras2onnx

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -24,7 +24,9 @@ spack:
     - py-jaxlib
 
     # Keras
-    - py-keras
+    # - py-keras backend=tensorflow
+    - py-keras backend=jax
+    # - py-keras backend=torch
     - py-keras-applications
     - py-keras-preprocessing
     - py-keras2onnx

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -618,7 +618,12 @@ _spack_buildcache_preview() {
 }
 
 _spack_buildcache_check() {
-    SPACK_COMPREPLY="-h --help -m --mirror-url -o --output-file --scope -s --spec --spec-file"
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -m --mirror-url -o --output-file --scope -s --spec --spec-file"
+    else
+        _all_packages
+    fi
 }
 
 _spack_buildcache_download() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -797,6 +797,7 @@ complete -c spack -n '__fish_spack_using_command buildcache preview' -s h -l hel
 
 # spack buildcache check
 set -g __fish_spack_optspecs_spack_buildcache_check h/help m/mirror-url= o/output-file= scope= s/spec= spec-file=
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 buildcache check' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache check' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -f -a mirror_url

--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -184,12 +184,13 @@ def get_os(ver):
 
 def get_armpl_version_to_3(spec):
     """Return version string with 3 numbers"""
-    version_len = len(spec.version)
+    version = spec.version.up_to(3)
+    version_len = len(version)
     assert version_len == 2 or version_len == 3
     if version_len == 2:
-        return spec.version.string + ".0"
+        return version.string + ".0"
     elif version_len == 3:
-        return spec.version.string
+        return version.string
 
 
 def get_armpl_prefix(spec):

--- a/var/spack/repos/builtin/packages/amg2023/package.py
+++ b/var/spack/repos/builtin/packages/amg2023/package.py
@@ -18,7 +18,6 @@ class Amg2023(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/LLNL/AMG2023.git"
 
     version("develop", branch="main")
-    version("cmake-build", git="https://github.com/dyokelson/AMG2023.git", branch="cmake")
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=False, description="Enable OpenMP support")

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -24,6 +24,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     maintainers("WeiqunZhang", "asalmgren", "atmyers")
 
     version("develop", branch="development")
+    version("23.12", sha256="90e00410833d7a82bf6d9e71a70ce85d2bfb89770da7e34d0dda940f2bf5384a")
     version("23.11", sha256="49b9fea10cd2a2b6cb0fedf7eac8f7889eacc68a05ae5ac7c5702bc0eb1b3848")
     version("23.10", sha256="3c85aa0ad5f96303e797960a6e0aa37c427f6483f39cdd61dbc2f7ca16357714")
     version("23.09", sha256="1a539c2628041b17ad910afd9270332060251c8e346b1482764fdb87a4f25053")

--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -15,6 +15,12 @@ class Arrow(CMakePackage, CudaPackage):
     homepage = "https://arrow.apache.org"
     url = "https://github.com/apache/arrow/archive/apache-arrow-0.9.0.tar.gz"
 
+    version("14.0.1", sha256="a48e54a09d58168bc04d86b13e7dab04f0aaba18a6f7e4dadf3e9c7bb835c8f1")
+    version("14.0.0", sha256="39e3388bbaba23faa7a5e8a82ebba7fe4c38ace2c394d6a3f26559715b30f401")
+    version("13.0.0", sha256="99c27e6a517c750f29c3e6b264836e31251bb8e978dbbf11316680ca3eb8ebda")
+    version("12.0.1", sha256="f01b76a42ceb30409e7b1953ef64379297dd0c08502547cae6aaafd2c4a4d92e")
+    version("12.0.0", sha256="f25901c486e1e79cde8b78b3e7b1d889919f942549996003a7341a8ee86addaa")
+    version("11.0.0", sha256="4a8c0c3d5b39ca81f4a636a41863f1cf5e0ed199f994bf5ead0854ca037eb741")
     version("10.0.1", sha256="28c3e0402bc1c3c1e047b6e26cedb8d1d89b2b9497d576af24b0b700eef11701")
     version("9.0.0", sha256="bb187b4b0af8dcc027fffed3700a7b891c9f76c9b63ad8925b4afb8257a2bb1b")
     version("8.0.0", sha256="19ece12de48e51ce4287d2dee00dc358fbc5ff02f41629d16076f77b8579e272")

--- a/var/spack/repos/builtin/packages/binder/package.py
+++ b/var/spack/repos/builtin/packages/binder/package.py
@@ -49,6 +49,6 @@ class Binder(CMakePackage):
     def setup_dependent_package(self, module, dependent_spec):
         llvm_dir = self.spec["llvm"].prefix
         self.spec.clang_include_dirs = llvm_dir.include
-        self.spec.LibClang_include_dir = llvm_dir.lib.clang.join(
+        self.spec.libclang_include_dir = llvm_dir.lib.clang.join(
             format(self.spec["llvm"].version)
         ).include

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -27,6 +27,7 @@ class Cmake(Package):
     executables = ["^cmake[0-9]*$"]
 
     version("master", branch="master")
+    version("3.27.9", sha256="609a9b98572a6a5ea477f912cffb973109ed4d0a6a6b3f9e2353d2cdc048708e")
     version("3.27.8", sha256="fece24563f697870fbb982ea8bf17482c9d5f855d8c9bf0b82463d76c9e8d0cc")
     version("3.27.7", sha256="08f71a106036bf051f692760ef9558c0577c42ac39e96ba097e7662bd4158d8e")
     version("3.27.6", sha256="ef3056df528569e0e8956f6cf38806879347ac6de6a4ff7e4105dc4578732cfb")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -271,7 +271,8 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         depends_on("sirius@7.0.0:7.0", when="@8:8.2")
         depends_on("sirius@7.2", when="@8.3:8.9")
         depends_on("sirius@7.3:", when="@9.1")
-        depends_on("sirius@7.4:", when="@2023.2")
+        depends_on("sirius@7.4:7.5", when="@2023.2")
+        depends_on("sirius@7.5:", when="@master")
         conflicts("~mpi", msg="SIRIUS requires MPI")
         # sirius support was introduced in 7, but effectively usable starting from CP2K 9
         conflicts("@:8")

--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -15,7 +15,10 @@ class Cprnc(CMakePackage):
 
     maintainers("jedwards4b", "billsacks")
 
-    version("1.0.1", sha256="19517b52688f5ce40c385d7a718e06bf88a8731335943bc32e2b8410c489d6eb")
+    version("1.0.3", sha256="3e7400f9a13d5de01964d7dd95151d08e6e30818d2a1efa9a9c7896cf6646d69")
+    version("1.0.2", sha256="02edfa8050135ac0dc4a74aea05d19b0823d769b22cafa88b9352e29723d4179")
+    version("1.0.1", sha256="b8a8fd4ad7e2716968dfa60f677217c55636580807b1309276f4c062ee432ccd")
+    version("1.0.0", sha256="70ff75bbf01a0cef885db3074c78f39a8890949ca505530c0407398b8803552c")
 
     depends_on("netcdf-fortran")
     depends_on("cmake@3:", type="build")

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -345,6 +345,12 @@ class Curl(NMakePackage, AutotoolsPackage):
     def command(self):
         return Executable(self.prefix.bin.join("curl-config"))
 
+    def flag_handler(self, name, flags):
+        build_system_flags = []
+        if name == "cflags" and self.spec.compiler.name in ["intel", "oneapi"]:
+            build_system_flags = ["-we147"]
+        return flags, None, build_system_flags
+
 
 class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -3,85 +3,161 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 
-class Dftbplus(MakefilePackage):
+class Dftbplus(CMakePackage, MakefilePackage):
     """DFTB+ is an implementation of the
     Density Functional based Tight Binding (DFTB) method,
     containing many extensions to the original method."""
 
     homepage = "https://www.dftbplus.org"
-    url = "https://github.com/dftbplus/dftbplus/archive/19.1.tar.gz"
+    url = "https://github.com/dftbplus/dftbplus/releases/download/22.1/dftbplus-22.1.tar.xz"
+    git = "https://github.com/dftbplus/dftbplus.git"
 
-    version("19.1", sha256="4d07f5c6102f06999d8cfdb1d17f5b59f9f2b804697f14b3bc562e3ea094b8a8")
+    maintainers = ["HaoZeke", "aradi", "iamashwin99"]
+    generator = "Ninja"
 
-    resource(
-        name="slakos",
-        url="https://github.com/dftbplus/testparams/archive/dftbplus-18.2.tar.gz",
-        sha256="bd191b3d240c1a81a8754a365e53a78b581fc92eb074dd5beb8b56a669a8d3d1",
-        destination="external/slakos",
-        when="@18.2:",
+    build_system(
+        conditional("cmake", when="@20.1:"),
+        conditional("makefile", when="@:19.1"),
+        default="cmake",
     )
 
-    variant("mpi", default=True, description="Build an MPI-paralelised version of the code.")
+    version("main", branch="main")
+    version("22.1", sha256="02daca6f4c6372656598f3ba0311110c8e473c87c8d934d7bb276feaa4cc1c82")
+    version("21.2", sha256="fbeb0e0ea93ab4dc4450f298ec712d2cf991f19f621badf57dae05f0e43b5906")
+    version("21.1", sha256="8c1eb8a38f72c421e2ae20118a6db3a656fa84e8b180ef387e549a73ae77f970")
+    version("20.2.1", sha256="95cc85fdb08bd57ca013bd09f4f902303720e17d015a5fab2d4db63fcb6d9cb3")
+    version("20.2", sha256="eafd219159d600624041658046c89db539ceb0c1d2988b72321c80d9b992c9bf")
+    version("20.1", sha256="04c2b906b8670937c8ddd9c5fb68e7e9921b464840cf54aa3d698db98167d0b7")
+    version(
+        "19.1",
+        deprecated=True,
+        sha256="78f45ef0571c78cf732a5493d32830455a832fa05ebcad43098895e46ad8d220",
+    )
 
     variant(
-        "gpu",
-        default=False,
-        description="Use the MAGMA library " "for GPU accelerated computation",
+        "api",
+        default=True,
+        description="Whether public API should be included and the DFTB+ library installed.",
     )
-
+    variant(
+        "arpack",
+        default=False,
+        description="Whether the ARPACK library should be included (needed for TD-DFTB).",
+        when="~mpi",
+    )
+    variant(
+        "chimes",
+        default=False,
+        when="@21.2:",
+        description="Whether repulsive corrections" "via the ChIMES library should be enabled.",
+    )
     variant(
         "elsi",
         default=False,
         description="Use the ELSI library for large scale systems. "
         "Only has any effect if you build with '+mpi'",
+        when="+mpi",
     )
-
+    variant(
+        "gpu",
+        default=False,
+        description="Use the MAGMA library " "for GPU accelerated computation",
+    )
+    variant(
+        "mbd",
+        default=False,
+        when="@21.1:",
+        description="Whether DFTB+ should be built with many-body-dispersion support.",
+    )
+    variant("mpi", default=False, description="Whether DFTB+ should support MPI-parallelism.")
+    variant(
+        "openmp",
+        default=True,
+        description="Whether OpenMP thread parallisation should be enabled.",
+    )
+    variant(
+        "plumed",
+        default=False,
+        when="@20.1:",
+        description="Whether metadynamics via the PLUMED2 library should be allowed.",
+    )
+    variant("poisson", default=False, description="Whether the Poisson-solver should be included.")
+    variant(
+        "python",
+        default=False,
+        description="Whether the Python components of DFTB+ should be tested and installed.",
+    )
+    variant(
+        "sdftd3",
+        default=False,
+        when="@21.2:",
+        description="Whether the s-dftd3 library should be included",
+    )
     variant(
         "sockets",
         default=False,
         description="Whether the socket library " "(external control) should be linked",
     )
-
-    variant("arpack", default=False, description="Use ARPACK for excited state DFTB functionality")
-
     variant(
         "transport",
         default=False,
+        when="+shared",
         description="Whether transport via libNEGF should be included. "
         "Only affects parallel build. "
         "(serial version is built without libNEGF/transport)",
     )
+    variant(
+        "tblite",
+        default=False,
+        when="@21.2:",
+        description="Whether xTB support should be included via tblite.",
+    )
+
+    variant("shared", default=False, description="Most often for the Python wrappers.")
 
     variant(
         "dftd3",
         default=False,
+        when="@:19.1",
         description="Use DftD3 dispersion library " "(if you need this dispersion model)",
     )
 
-    depends_on("lapack")
-    depends_on("blas")
-    depends_on("scalapack", when="+mpi")
-    depends_on("mpi", when="+mpi")
+    depends_on("cmake@3.16:", type="build", when="@20.1:")
+    depends_on("ninja@1.10", type="build", when="@20.1:")
+
+    depends_on("blas", when="-mpi")
+    depends_on("lapack", when="-mpi")
+
+    depends_on("arpack-ng", when="+arpack~mpi")
+    depends_on("simple-dftd3", when="+sdftd3")
     depends_on("elsi", when="+elsi")
     depends_on("magma", when="+gpu")
-    depends_on("arpack-ng", when="+arpack")
+    depends_on("mpi", when="+mpi")
+    depends_on("plumed", when="+plumed")
+    depends_on("scalapack", when="+mpi")
+    depends_on("python@3.2:", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))  # for tests
+    # Only for 19.1
     depends_on("dftd3-lib@0.9.2", when="+dftd3")
 
+    # Conflicts
+    conflicts("+python", when="~shared")
+    conflicts("-poisson", when="+transport")
+
+    # Extensions
+    extends("python", when="+python")
+
+    @when("@19.1")  # Only version without CMake
     def edit(self, spec, prefix):
         """
         First, change the ROOT variable, because, for some reason,
         the Makefile and the spack install script run in different directories
-
         Then, if using GCC, rename the file 'sys/make.x86_64-linux-gnu'
         to make.arch.
-
         After that, edit the make.arch to point to the dependencies
-
         And the last thing we do here is to set the installdir
         """
         dircwd = os.getcwd()
@@ -160,3 +236,79 @@ class Dftbplus(MakefilePackage):
             )
 
             mconfig.filter("WITH_DFTD3 := .*", "WITH_DFTD3 := 1")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("WITH_OPENMP", "openmp"),
+            self.define_from_variant("WITH_API", "api"),
+            self.define_from_variant("WITH_ARPACK", "arpack"),
+            self.define_from_variant("WITH_CHIMES", "chimes"),
+            self.define_from_variant("WITH_ELSI", "elsi"),
+            self.define_from_variant("WITH_GPU", "gpu"),
+            self.define_from_variant("WITH_MBD", "mbd"),
+            self.define_from_variant("WITH_MPI", "mpi"),
+            self.define_from_variant("WITH_PLUMED", "plumed"),
+            self.define_from_variant("WITH_POISSON", "poisson"),
+            self.define_from_variant("WITH_PYTHON", "python"),
+            self.define_from_variant("WITH_SDFTD3", "sdftd3"),
+            self.define_from_variant("WITH_SOCKETS", "sockets"),
+            self.define_from_variant("WITH_TBLITE", "tblite"),
+            self.define_from_variant("WITH_TRANSPORT", "transport"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+        ]
+        # SCALAPACK
+        # Note: dftbplus@20.1 uses plural form of the option names
+        #       (e.g. -DSCALAPACK_LIBRARIES)
+        # but dftbplus@20.2 onwards uses singular
+        #       (e.g. -DSCALAPACK_LIBRARY)
+        # and plural form is ignored.
+        # We set both inorder to be compatible with all versions.
+        if "+mpi" in self.spec:
+            # we use scalapack for linear algebra
+            args.extend(
+                [
+                    self.define("SCALAPACK_FOUND", "true"),
+                    self.define("SCALAPACK_INCLUDE_DIRS", self.spec["scalapack"].prefix.include),
+                    self.define("SCALAPACK_LIBRARIES", self.spec["scalapack"].libs.joined(";")),
+                    self.define("SCALAPACK_LIBRARY", self.spec["scalapack"].libs.joined(";")),
+                ]
+            )
+        else:
+            # we define the lapack and blas libraries
+            lapack_libs = self.spec["lapack"].libs.joined(";")
+            blas_libs = self.spec["blas"].libs.joined(";")
+            args.extend(
+                [
+                    self.define("LAPACK_FOUND", True),
+                    self.define("LAPACK_INCLUDE_DIRS", self.spec["lapack"].prefix.include),
+                    self.define("LAPACK_LIBRARIES", lapack_libs),
+                    self.define("LAPACK_LIBRARY", lapack_libs),
+                    self.define("BLAS_FOUND", True),
+                    self.define("BLAS_INCLUDE_DIRS", self.spec["blas"].prefix.include),
+                    self.define("BLAS_LIBRARIES", blas_libs),
+                    self.define("BLAS_LIBRARY", blas_libs),
+                ]
+            )
+        if "+python" in self.spec:
+            args.append(self.define("BUILD_SHARED_LIBS", True))
+        if self.run_tests:
+            args.append("-DWITH_UNIT_TESTS=ON")
+        else:
+            args.append("-DWITH_UNIT_TESTS=OFF")
+        return args
+
+    @run_after("build")
+    @on_package_attributes(run_tests=True)
+    def check_install(self):
+        """Run ctest after building binary.
+        only run the unit tests. If the unit tests fail, the installation throws
+        a warning."""
+
+        with working_dir(self.build_directory):
+            try:
+                ctest("")
+            except ProcessError:
+                warn = "Unit tests failed.\n"
+                warn += "Please report this failure to:\n"
+                warn += "https://github.com/dftbplus/dftbplus/issues"
+                tty.msg(warn)

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -130,7 +130,7 @@ class Dihydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("catch2@3.0.1:", type=("build", "test"), when="+developer")
     depends_on("cmake@3.21.0:", type="build")
     depends_on("cuda@11.0:", when="+cuda")
-    depends_on("spdlog@1.11.0", when="@:0.1,0.2:")
+    depends_on("spdlog@1.11.0:1.12.0", when="@:0.1,0.2:")
 
     with when("@0.3.0:"):
         depends_on("hydrogen +al")

--- a/var/spack/repos/builtin/packages/direnv/package.py
+++ b/var/spack/repos/builtin/packages/direnv/package.py
@@ -14,6 +14,7 @@ class Direnv(Package):
 
     maintainers("acastanedam", "alecbcs")
 
+    version("2.33.0", sha256="8ef18051aa6bdcd6b59f04f02acdd0b78849b8ddbdbd372d4957af7889c903ea")
     version("2.32.3", sha256="c66f6d1000f28f919c6106b5dcdd0a0e54fb553602c63c60bf59d9bbdf8bd33c")
     version("2.32.2", sha256="352b3a65e8945d13caba92e13e5666e1854d41749aca2e230938ac6c64fa8ef9")
     version("2.32.1", sha256="dc7df9a9e253e1124748aa74da94bf2b96f5a61d581c60d52d3f8e8dc86ecfde")

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -79,6 +79,22 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocsolver", when="+rocm")
     depends_on("rocthrust", when="+rocm")
 
+    # nvcc 11.2 and older is unable to detect fmt::formatter specializations.
+    # DLA-Future 0.3.1 includes a workaround to avoid including fmt in device
+    # code:
+    # https://github.com/pika-org/pika/issues/870
+    # https://github.com/eth-cscs/DLA-Future/pull/1045
+    conflicts("^fmt@10:", when="@:0.3.0 +cuda ^cuda@:11.2")
+
+    # Compilation problem triggered by the bundled fmt in Umpire together with
+    # fmt 10, which only happens with GCC 9 and nvcc 11.2 and older:
+    # https://github.com/eth-cscs/DLA-Future/issues/1044
+    conflicts("^fmt@10:", when="@:0.3.0 %gcc@9 +cuda ^cuda@:11.2 ^umpire@2022.10:")
+
+    # Pedantic warnings, triggered by GCC 9 and 10, are always errors until 0.3.1:
+    # https://github.com/eth-cscs/DLA-Future/pull/1043
+    conflicts("%gcc@9:10", when="@:0.3.0")
+
     depends_on("hdf5 +cxx+mpi+threadsafe+shared", when="+hdf5")
 
     conflicts("+cuda", when="+rocm")

--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -13,7 +13,7 @@ class Ecbuild(CMakePackage):
     homepage = "https://github.com/ecmwf/ecbuild"
     url = "https://github.com/ecmwf/ecbuild/archive/refs/tags/3.6.1.tar.gz"
 
-    maintainers("skosukhin", "climbfuji")
+    maintainers("skosukhin", "climbfuji", "victoria-cherkas", "dominichofer")
 
     version("3.7.2", sha256="7a2d192cef1e53dc5431a688b2e316251b017d25808190faed485903594a3fb9")
     version("3.6.5", sha256="98bff3d3c269f973f4bfbe29b4de834cd1d43f15b1c8d1941ee2bfe15e3d4f7f")

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -45,7 +45,7 @@ class Eccodes(CMakePackage):
     git = "https://github.com/ecmwf/eccodes.git"
     list_url = "https://confluence.ecmwf.int/display/ECC/Releases"
 
-    maintainers("skosukhin")
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer", "climbfuji")
 
     version("develop", branch="develop")
     version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -48,6 +48,8 @@ class Eccodes(CMakePackage):
     maintainers("skosukhin")
 
     version("develop", branch="develop")
+    version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")
+    version("2.31.0", sha256="808ecd2c11fbf2c3f9fc7a36f8c2965b343f3151011b58a1d6e7cc2e6b3cac5d")
     version("2.25.0", sha256="8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
     version("2.24.2", sha256="c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403")
     version("2.23.0", sha256="cbdc8532537e9682f1a93ddb03440416b66906a4cc25dec3cbd73940d194bf0c")
@@ -70,7 +72,7 @@ class Eccodes(CMakePackage):
     )
     variant("png", default=False, description="Enable PNG support for decoding/encoding")
     variant(
-        "aec", default=False, description="Enable Adaptive Entropy Coding for decoding/encoding"
+        "aec", default=True, description="Enable Adaptive Entropy Coding for decoding/encoding"
     )
     variant("pthreads", default=False, description="Enable POSIX threads")
     variant("openmp", default=False, description="Enable OpenMP threads")
@@ -106,6 +108,7 @@ class Eccodes(CMakePackage):
     depends_on("cmake@3.12:", when="@2.19:", type="build")
 
     depends_on("ecbuild", type="build", when="@develop")
+    depends_on("ecbuild@3.7:", type="build", when="@2.25:")
 
     conflicts("+openmp", when="+pthreads", msg="Cannot enable both POSIX threads and OMP")
 

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -16,7 +16,7 @@ class Eckit(CMakePackage):
     git = "https://github.com/ecmwf/eckit.git"
     url = "https://github.com/ecmwf/eckit/archive/refs/tags/1.16.0.tar.gz"
 
-    maintainers("skosukhin", "climbfuji")
+    maintainers("skosukhin", "climbfuji", "victoria-cherkas", "dominichofer")
 
     version("1.24.4", sha256="b6129eb4f7b8532aa6905033e4cf7d09aadc8547c225780fea3db196e34e4671")
     version("1.23.1", sha256="cd3c4b7a3a2de0f4a59f00f7bab3178dd59c0e27900d48eaeb357975e8ce2f15")

--- a/var/spack/repos/builtin/packages/egl/package.py
+++ b/var/spack/repos/builtin/packages/egl/package.py
@@ -1,0 +1,92 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+import sys
+
+from spack.package import *
+
+
+class Egl(BundlePackage):
+    """Placeholder for external EGL(OpenGL) libraries from hardware vendors"""
+
+    homepage = "https://www.khronos.org/egl"
+    maintainers("biddisco")
+
+    version("1.5")
+
+    # This should really be when='platform=linux' but can't because of a
+    # current bug in when and how ArchSpecs are constructed
+    if sys.platform.startswith("linux"):
+        provides("gl@4.5")
+
+    # conflict with GLX
+    conflicts("glx")
+
+    # not always available, but sometimes
+    executables = ["^eglinfo$"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        if exe:
+            output = Executable(exe)(output=str, error=str)
+            match = re.search(r"EGL version string: (\S+)", output)
+            return match.group(1) if match else None
+        else:
+            return None
+
+    # Override the fetcher method to throw a useful error message;
+    # fixes GitHub issue (#7061) in which this package threw a
+    # generic, uninformative error during the `fetch` step,
+    @property
+    def fetcher(self):
+        msg = """This package is intended to be a placeholder for
+        system-provided EGL(OpenGL) libraries from hardware vendors.  Please
+        download and install EGL drivers/libraries for your graphics
+        hardware separately, and then set that up as an external package.
+        An example of a working packages.yaml:
+
+        packages:
+          egl:
+            buildable: False
+            externals:
+            - spec: egl@1.5.0
+              prefix: /usr/
+
+        In that case, /usr/ should contain these two folders:
+
+        include/EGL/      (egl headers, including "egl.h")
+        lib               (egl libraries, including "libEGL.so")
+
+        """
+        raise InstallError(msg)
+
+    @fetcher.setter  # Since fetcher is read-write, must override both
+    def fetcher(self):
+        _ = self.fetcher
+
+    @property
+    def headers(self):
+        return self.egl_headers
+
+    @property
+    def libs(self):
+        return self.egl_libs
+
+    @property
+    def egl_headers(self):
+        header_name = "GL/gl"
+        gl_header = find_headers(header_name, root=self.prefix, recursive=True)
+        header_name = "EGL/egl"
+        egl_header = find_headers(header_name, root=self.prefix, recursive=True)
+        return gl_header + egl_header
+
+    @property
+    def egl_libs(self):
+        lib_name = "libGL"
+        gl_lib = find_libraries(lib_name, root=self.prefix, recursive=True)
+        lib_name = "libEGL"
+        egl_lib = find_libraries(lib_name, root=self.prefix, recursive=True)
+        return gl_lib + egl_lib

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -140,7 +140,8 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hiop@0.3.99:", when="@0.99:+hiop")
     depends_on("hiop@0.5.1:", when="@1.1.0:+hiop")
     depends_on("hiop@0.5.3:", when="@1.3.0:+hiop")
-    depends_on("hiop@0.7.0:1.0.0", when="@1.5.0:+hiop")
+    depends_on("hiop@0.7.0:1.0.0", when="@1.5.0:1.6.0+hiop")
+    depends_on("hiop@1.0.1:", when="@develop:+hiop")
 
     depends_on("hiop~mpi", when="+hiop~mpi")
     depends_on("hiop+mpi", when="+hiop+mpi")
@@ -160,7 +161,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("petsc@3.13:3.14", when="@:1.2")
     depends_on("petsc@3.16", when="@1.3:1.4")
     depends_on("petsc@3.18:3.19", when="@1.5")
-    depends_on("petsc@3.20:", when="@1.6:")
+    depends_on("petsc@3.19:", when="@1.6:")
 
     depends_on("petsc~mpi", when="~mpi")
 

--- a/var/spack/repos/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/builtin/packages/fargparse/package.py
@@ -20,6 +20,7 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.6.0", sha256="055a0af44f50c302f8f20a8bcf3d26c5bbeacf5222cdbaa5b19da4cff56eb9c0")
     version("1.5.0", sha256="1c16ead5f1bacb9c2f33aab99a0889c68c1a1ece754ddc3fd340f10a0d5da2f7")
     version("1.4.2", sha256="2cd3f14845235407c6a4171ab4602499dade045e3f9b7dc75190f4a315ac8b44")
     version("1.4.1", sha256="8f9b92a80f05b0a8ab2dd5cd309ad165041c7fcdd589b96bf75c7dd889b9b584")

--- a/var/spack/repos/builtin/packages/fdb/package.py
+++ b/var/spack/repos/builtin/packages/fdb/package.py
@@ -14,7 +14,7 @@ class Fdb(CMakePackage):
     url = "https://github.com/ecmwf/fdb/archive/refs/tags/5.7.8.tar.gz"
     git = "https://github.com/ecmwf/fdb.git"
 
-    maintainers("skosukhin")
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
 
     version("master", branch="master")
     version("5.11.23", sha256="09b1d93f2b71d70c7b69472dfbd45a7da0257211f5505b5fcaf55bfc28ca6c65")

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -31,27 +31,6 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     version(
         "1.4.1", tag="v1.4.1", commit="ab974c3164056e6c406917c8ca771ffd43c5a031", submodules=True
     )
-    version(
-        "1.4.develop",
-        git="https://github.com/laristra/flecsi.git",
-        branch="1.4",
-        submodules=True,
-        deprecated=True,
-    )
-    version(
-        "1.4.2",
-        git="https://github.com/laristra/flecsi.git",
-        tag="v1.4.2",
-        submodules=True,
-        deprecated=True,
-    )
-    version(
-        "flecsph",
-        git="https://github.com/laristra/flecsi.git",
-        branch="stable/flecsph",
-        submodules=True,
-        deprecated=True,
-    )
 
     variant(
         "backend",
@@ -63,7 +42,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     variant("shared", default=True, description="Build shared libraries")
     variant("flog", default=False, description="Enable logging support")
     variant("graphviz", default=False, description="Enable GraphViz Support")
-    variant("doc", default=False, description="Enable documentation")
+    variant("doc", default=False, description="Enable documentation", when="@2.2:")
     variant("hdf5", default=True, description="Enable HDF5 Support")
     variant(
         "caliper_detail",
@@ -130,10 +109,12 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos@3.2.00:", when="+kokkos @2.0:")
     depends_on("kokkos +cuda +cuda_constexpr +cuda_lambda", when="+kokkos +cuda @2.0:")
     depends_on("kokkos +rocm", when="+kokkos +rocm @2.0:")
+    depends_on("kokkos +openmp", when="+kokkos +openmp @2.0:")
     depends_on("legion@cr", when="backend=legion @2.0:")
     depends_on("legion+shared", when="backend=legion +shared @2.0:")
     depends_on("legion+hdf5", when="backend=legion +hdf5 @2.0:")
     depends_on("legion+kokkos", when="backend=legion +kokkos @2.0:")
+    depends_on("legion+openmp", when="backend=legion +openmp @2.0:")
     depends_on("legion+cuda", when="backend=legion +cuda @2.0:")
     depends_on("legion+rocm", when="backend=legion +rocm @2.0:")
     depends_on("hdf5@1.10.7:", when="backend=legion +hdf5 @2.0:")
@@ -143,11 +124,11 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("openmpi@4.1.0:", when="@2.0: ^openmpi")
 
     # FleCSI 2.2+ documentation dependencies
-    depends_on("py-sphinx", when="@2.2: +doc")
-    depends_on("py-sphinx-rtd-theme", when="@2.2: +doc")
-    depends_on("py-recommonmark", when="@2.2: +doc")
-    depends_on("doxygen", when="@2.2: +doc")
-    depends_on("graphviz", when="@2.2: +doc")
+    depends_on("py-sphinx", when="+doc")
+    depends_on("py-sphinx-rtd-theme", when="+doc")
+    depends_on("py-recommonmark", when="+doc")
+    depends_on("doxygen", when="+doc")
+    depends_on("graphviz", when="+doc")
 
     # Propagate cuda_arch requirement to dependencies
     for _flag in CudaPackage.cuda_arch_values:
@@ -182,6 +163,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     # Due to overhauls of Legion and Gasnet spackages
     #   flecsi@:1.4 can no longer be built with a usable legion
     conflicts("backend=legion", when="@:1.4")
+    conflicts("+hdf5", when="@2: backend=hpx", msg="HPX backend doesn't support HDF5")
 
     def cmake_args(self):
         spec = self.spec
@@ -217,7 +199,6 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("ENABLE_KOKKOS", "kokkos"),
                 self.define_from_variant("ENABLE_OPENMP", "openmp"),
                 self.define_from_variant("ENABLE_DOXYGEN", "doxygen"),
-                self.define_from_variant("ENABLE_DOCUMENTATION", "doc"),
                 self.define_from_variant("ENABLE_COVERAGE_BUILD", "coverage"),
                 self.define_from_variant("ENABLE_FLOG", "flog"),
                 self.define_from_variant("ENABLE_FLECSIT", "tutorial"),

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -13,6 +13,7 @@ class Fmt(CMakePackage):
 
     homepage = "https://fmt.dev/"
     url = "https://github.com/fmtlib/fmt/releases/download/7.1.3/fmt-7.1.3.zip"
+    git = "https://github.com/fmtlib/fmt.git"
     maintainers("msimberg")
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -30,6 +30,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
 
     maintainers("adamjstewart")
 
+    version("3.8.1", sha256="75a20b23879bfa3d8c0db68e1d6f8b924f7f9d97f5fed089b01a72e404293900")
     version("3.8.0", sha256="ec0f78d9dc32352aeac6edc9c3b27a991b91f9dc6f92c452207d84431c58757d")
     version("3.7.3", sha256="e0a6f0c453ea7eb7c09967f50ac49426808fcd8f259dbc9888140eb69d7ffee6")
     version("3.7.2", sha256="40c0068591d2c711c699bbb734319398485ab169116ac28005d8302f80b923ad")

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -23,6 +23,7 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.7.0", sha256="8ba567133fcee6b93bc71f61b3bb2053b4b07c6d78f6ad98a04dfc40aa478de7")
     version("1.6.1", sha256="0e3e1e0c7e0c3f1576e296b3b199dcae4bbaad055fc8fe929c34e52d4b07b02c")
     version("1.6.0", sha256="90245b83aea9854bc5b9fbd553a68cf73ab12f6ed5a14753a9c84092047e8cb0")
     version("1.5.1", sha256="353d07cc22678d1a79b19dbf53d8ba54b889e424a15e315cc4f035b72eedb83a")

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -39,6 +39,7 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.11.0", sha256="b28935bc077749823b1505ad8c1208360a5ba7e961d7593c17a33b11455a32a4")
     version("1.10.0", sha256="d6086e8cba2497bacdae66d301f7cdacaed9138a0055f33f8ca1b778a0cf0dc5")
     version("1.9.0", sha256="4c7cb8b1313d87eaa5cc9aae242301085aa3b12688d0fddf54061503e95e4cc0")
     version("1.8.3", sha256="5864c6a427105c1194cbc0dcbe0dad2c3d14d42b2717f0a5e1626e0d56bba8a6")

--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -15,6 +15,8 @@ class Glew(CMakePackage):
     url = "https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz"
     root_cmakelists_dir = "build/cmake"
 
+    maintainers("biddisco")
+
     version("2.2.0", sha256="d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1")
     version("2.1.0", sha256="04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95")
     version("2.0.0", sha256="c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764")
@@ -22,20 +24,26 @@ class Glew(CMakePackage):
     variant(
         "gl",
         default="glx" if sys.platform.startswith("linux") else "other",
-        values=("glx", "osmesa", "other"),
+        values=("glx", "osmesa", "egl", "other"),
         multi=False,
         description="The OpenGL provider to use",
     )
     conflicts("^osmesa", when="gl=glx")
+    conflicts("^osmesa", when="gl=egl")
     conflicts("^osmesa", when="gl=other")
     conflicts("^glx", when="gl=osmesa")
     conflicts("^glx", when="gl=other")
+    conflicts("^glx", when="gl=egl")
+    conflicts("^egl", when="gl=glx")
+    conflicts("^egl", when="gl=osmesa")
+    conflicts("^egl", when="gl=other")
 
     depends_on("gl")
     depends_on("osmesa", when="gl=osmesa")
     depends_on("glx", when="gl=glx")
     depends_on("libx11", when="gl=glx")
     depends_on("xproto", when="gl=glx")
+    depends_on("egl", when="gl=egl")
 
     # glu is already forcibly disabled in the CMakeLists.txt.  This prevents
     # it from showing up in the .pc file
@@ -46,17 +54,22 @@ class Glew(CMakePackage):
         args = [
             self.define("BUILD_UTILS", True),
             self.define("GLEW_REGAL", False),
-            self.define("GLEW_EGL", False),
+            self.define("GLEW_EGL", "gl=egl" in spec),
             self.define("OpenGL_GL_PREFERENCE", "LEGACY"),
             self.define("OPENGL_INCLUDE_DIR", spec["gl"].headers.directories[0]),
             self.define("OPENGL_gl_LIBRARY", spec["gl"].libs[0]),
             self.define("OPENGL_opengl_LIBRARY", "IGNORE"),
             self.define("OPENGL_glx_LIBRARY", "IGNORE"),
-            self.define("OPENGL_egl_LIBRARY", "IGNORE"),
             self.define("OPENGL_glu_LIBRARY", "IGNORE"),
             self.define("GLEW_OSMESA", "gl=osmesa" in spec),
             self.define("GLEW_X11", "gl=glx" in spec),
             self.define("CMAKE_DISABLE_FIND_PACKAGE_X11", "gl=glx" not in spec),
         ]
+        if "gl=egl" in spec:
+            args.append(
+                self.define("OPENGL_egl_LIBRARY", [spec["egl"].libs[0], spec["egl"].libs[1]])
+            )
+        else:
+            args.append(self.define("OPENGL_egl_LIBRARY", "IGNORE"))
 
         return args

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -172,6 +172,7 @@ class Hpctoolkit(AutotoolsPackage):
 
     conflicts("^binutils@2.35:2.35.1", msg="avoid binutils 2.35 and 2.35.1 (spews errors)")
     conflicts("^xz@5.2.7:5.2.8", msg="avoid xz 5.2.7:5.2.8 (broken symbol versions)")
+    conflicts("^intel-xed@2023.08:", when="@:2023.09")
 
     conflicts("+cray", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")
     conflicts("+mpi", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 @IntelOneApiPackage.update_description
 class IntelMpi(IntelPackage):
-    """Intel MPI. This package has been replaced by intel-oneapi-mpi."""
+    """Intel MPI. This package has been deprecated. Use intel-oneapi-mpi instead."""
 
     maintainers("rscohn2")
 
@@ -18,107 +18,128 @@ class IntelMpi(IntelPackage):
         "2019.10.317",
         sha256="28e1b615e63d2170a99feedc75e3b0c5a7e1a07dcdaf0a4181831b07817a5346",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17534/l_mpi_2019.10.317.tgz",
+        deprecated=True,
     )
     version(
         "2019.9.304",
         sha256="618a5dc2de54306645e6428c5eb7d267b54b11b5a83dfbcad7d0f9e0d90bb2e7",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17263/l_mpi_2019.9.304.tgz",
+        deprecated=True,
     )
     version(
         "2019.8.254",
         sha256="fa163b4b79bd1b7509980c3e7ad81b354fc281a92f9cf2469bf4d323899567c0",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16814/l_mpi_2019.8.254.tgz",
+        deprecated=True,
     )
     version(
         "2019.7.217",
         sha256="90383b0023f84ac003a55d8bb29dbcf0c639f43a25a2d8d8698a16e770ac9c07",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16546/l_mpi_2019.7.217.tgz",
+        deprecated=True,
     )
     version(
         "2019.6.166",
         sha256="119be69f1117c93a9e5e9b8b4643918e55d2a55a78ad9567f77d16cdaf18cd6e",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16120/l_mpi_2019.6.166.tgz",
+        deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="9c59da051f1325b221e5bc4d8b689152e85d019f143069fa39e17989306811f4",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15838/l_mpi_2019.5.281.tgz",
+        deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="233a8660b92ecffd89fedd09f408da6ee140f97338c293146c9c080a154c5fcd",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15553/l_mpi_2019.4.243.tgz",
+        deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="5304346c863f64de797250eeb14f51c5cfc8212ff20813b124f20e7666286990",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15260/l_mpi_2019.3.199.tgz",
+        deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="6a3305933b5ef9e3f7de969e394c91620f3fa4bb815a4f439577739d04778b20",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15040/l_mpi_2019.2.187.tgz",
+        deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="dac86a5db6b86503313742b17535856a432955604f7103cb4549a9bfc256c3cd",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14879/l_mpi_2019.1.144.tgz",
+        deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="dfb403f49c1af61b337aa952b71289c7548c3a79c32c57865eab0ea0f0e1bc08",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13584/l_mpi_2019.0.117.tgz",
+        deprecated=True,
     )
     version(
         "2018.4.274",
         sha256="a1114b3eb4149c2f108964b83cad02150d619e50032059d119ac4ffc9d5dd8e0",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13741/l_mpi_2018.4.274.tgz",
+        deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="5021d14b344fc794e89f146e4d53d70184d7048610895d7a6a1e8ac0cf258999",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13112/l_mpi_2018.3.222.tgz",
+        deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="0927f1bff90d10974433ba2892e3fd38e6fee5232ab056a9f9decf565e814460",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12748/l_mpi_2018.2.199.tgz",
+        deprecated=True,
     )
     version(
         "2018.1.163",
         sha256="130b11571c3f71af00a722fa8641db5a1552ac343d770a8304216d8f5d00e75c",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12414/l_mpi_2018.1.163.tgz",
+        deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="debaf2cf80df06db9633dfab6aa82213b84a665a55ee2b0178403906b5090209",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12120/l_mpi_2018.0.128.tgz",
+        deprecated=True,
     )
     version(
         "2017.4.239",
         sha256="5a1048d284dce8bc75b45789471c83c94b3c59f8f159cab43d783fc44302510b",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12209/l_mpi_2017.4.239.tgz",
+        deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="dad9efbc5bbd3fd27cce7e1e2507ad77f342d5ecc929747ae141c890e7fb87f0",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11595/l_mpi_2017.3.196.tgz",
+        deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="106a4b362c13ddc6978715e50f5f81c58c1a4c70cd2d20a99e94947b7e733b88",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11334/l_mpi_2017.2.174.tgz",
+        deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="8d30a63674fe05f17b0a908a9f7d54403018bfed2de03c208380b171ab99be82",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11014/l_mpi_2017.1.132.tgz",
+        deprecated=True,
     )
     # built from parallel_studio_xe_2016.3.068
     version(
         "5.1.3.223",
         sha256="544f4173b09609beba711fa3ba35567397ff3b8390e4f870a3307f819117dd9b",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9278/l_mpi_p_5.1.3.223.tgz",
+        deprecated=True,
     )
 
     provides("mpi")

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -28,6 +28,12 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on("intel-oneapi-mpi")
 
     version(
+        "2021.11.1",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/07958f2f-8d95-422d-8c18-a4c7352b005c/l_oneapi_ccl_p_2021.11.1.9_offline.sh",
+        sha256="35817d40f57c0d35b9bacf3935cedc1c82fc8d809513d82580561f63f31cac17",
+        expand=False,
+    )
+    version(
         "2021.11.0",
         url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/9e63eba5-2b3d-4032-ad22-21f02e35b518/l_oneapi_ccl_p_2021.11.0.49161_offline.sh",
         sha256="35fde9862d620c211064addfd3c15c4fc33bcaac6fe050163eb59a006fb9d476",

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -29,61 +29,73 @@ class Intel(IntelPackage):
         "20.0.4",
         sha256="ac1efeff608a8c3a416e6dfe20364061e8abf62d35fbaacdffe3fc9676fc1aa3",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17117/parallel_studio_xe_2020_update4_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "20.0.2",
         sha256="42af16e9a91226978bb401d9f17b628bc279aa8cb104d4a38ba0808234a79bdd",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "20.0.1",
         sha256="26c7e7da87b8a83adfd408b2a354d872be97736abed837364c1bf10f4469b01e",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "20.0.0",
         sha256="9168045466139b8e280f50f0606b9930ffc720bbc60bc76f5576829ac15757ae",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.1.2",
         sha256="42af16e9a91226978bb401d9f17b628bc279aa8cb104d4a38ba0808234a79bdd",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.1.1",
         sha256="26c7e7da87b8a83adfd408b2a354d872be97736abed837364c1bf10f4469b01e",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.1.0",
         sha256="9168045466139b8e280f50f0606b9930ffc720bbc60bc76f5576829ac15757ae",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.0.5",
         sha256="e8c8e4b9b46826a02c49325c370c79f896858611bf33ddb7fb204614838ad56c",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15813/parallel_studio_xe_2019_update5_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.0.4",
         sha256="1915993445323e1e78d6de73702a88fa3df2036109cde03d74ee38fef9f1abf2",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15537/parallel_studio_xe_2019_update4_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.0.3",
         sha256="15373ac6df2a84e6dd9fa0eac8b5f07ab00cdbb67f494161fd0d4df7a71aff8e",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15272/parallel_studio_xe_2019_update3_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.0.1",
         sha256="db000cb2ebf411f6e91719db68a0c68b8d3f7d38ad7f2049ea5b2f1b5f006c25",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14832/parallel_studio_xe_2019_update1_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "19.0.0",
         sha256="e1a29463038b063e01f694e2817c0fcf1a8e824e24f15a26ce85f20afa3f963a",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13581/parallel_studio_xe_2019_composer_edition.tgz",
+        deprecated=True,
     )
 
     # Version 18.0.5 comes with parallel studio 2018 update 4. See:
@@ -92,83 +104,99 @@ class Intel(IntelPackage):
         "18.0.5",
         sha256="94aca8f091dff9535b02f022a37aef150b36925c8ef069335621496f8e4db267",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13722/parallel_studio_xe_2018_update4_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "18.0.3",
         sha256="f21f7759709a3d3e3390a8325fa89ac79b1fce8890c292e73b2ba3ec576ebd2b",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "18.0.2",
         sha256="02d2a9fb10d9810f85dd77700215c4348d2e4475e814e4f086eb1442462667ff",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12722/parallel_studio_xe_2018_update2_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "18.0.1",
         sha256="db9aa417da185a03a63330c9d76ee8e88496ae6b771584d19003a29eedc7cab5",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12381/parallel_studio_xe_2018_update1_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "18.0.0",
         sha256="ecad64360fdaff2548a0ea250a396faf680077c5a83c3c3ce2c55f4f4270b904",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12067/parallel_studio_xe_2018_composer_edition.tgz",
+        deprecated=True,
     )
     #
     version(
         "17.0.7",
         sha256="661e33b68e47bf335694d2255f5883955234e9085c8349783a5794eed2a937ad",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12860/parallel_studio_xe_2017_update7_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "17.0.6",
         sha256="771f50746fe130ea472394c42e25d2c7edae049ad809d2050945ef637becf65f",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12538/parallel_studio_xe_2017_update6_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "17.0.5",
         sha256="ede4ea9351fcf263103588ae0f130b4c2a79395529cdb698b0d6e866c4871f78",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12144/parallel_studio_xe_2017_update5_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "17.0.4",
         sha256="4304766f80206a27709be61641c16782fccf2b3fcf7285782cce921ddc9b10ff",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11541/parallel_studio_xe_2017_update4_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "17.0.3",
         sha256="3648578d7bba993ebb1da37c173979bfcfb47f26e7f4e17f257e78dea8fd96ab",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11464/parallel_studio_xe_2017_update3_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "17.0.2",
         sha256="abd26ab2a703e73ab93326984837818601c391782a6bce52da8b2a246798ad40",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11302/parallel_studio_xe_2017_update2_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "17.0.1",
         sha256="bc592abee829ba6e00a4f60961b486b80c15987ff1579d6560186407c84add6f",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/10978/parallel_studio_xe_2017_update1_composer_edition.tgz",
+        deprecated=True,
     )
     version(
         "17.0.0",
         sha256="d218db66a5bb57569bea00821ac95d4647eda7422bf8a178d1586b0fb314935a",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9656/parallel_studio_xe_2017_composer_edition.tgz",
+        deprecated=True,
     )
     #
     version(
         "16.0.4",
         sha256="17606c52cab6f5114223a2425923c8dd69f1858f5a3bdf280e0edea49ebd430d",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9785/parallel_studio_xe_2016_composer_edition_update4.tgz",
+        deprecated=True,
     )
     version(
         "16.0.3",
         sha256="fcec90ba97533e4705077e0701813b5a3bcc197b010b03e96f83191a35c26acf",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9063/parallel_studio_xe_2016_composer_edition_update3.tgz",
+        deprecated=True,
     )
     version(
         "16.0.2",
         sha256="6309ef8be1abba7737d3c1e17af64ca2620672b2da57afe2c3c643235f65b4c7",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8680/parallel_studio_xe_2016_composer_edition_update2.tgz",
+        deprecated=True,
     )
     #
     # Grandfathered release; different directory structure.
@@ -176,11 +204,13 @@ class Intel(IntelPackage):
         "15.0.6",
         sha256="b1e09833469ca76a2834cd0a5bb5fea11ec9986da85abf4c6eed42cd96ec24cb",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8432/l_compxe_2015.6.233.tgz",
+        deprecated=True,
     )
     version(
         "15.0.1",
         sha256="8a438fe20103e27bfda132955616d0c886aa6cfdd86dcd9764af5d937a8799d9",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz",
+        deprecated=True,
     )
 
     variant("rpath", default=True, description="Add rpath to .cfg files")

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -124,24 +124,24 @@ class Julia(MakefilePackage):
         "llvm",
         when="^llvm@12.0.1",
         patches=patch(
-            "https://github.com/JuliaLang/llvm-project/compare/fed41342a82f5a3a9201819a82bf7a48313e296b...980d2f60a8524c5546397db9e8bbb7d6ea56c1b7.patch",
-            sha256="37f2f6193e1205ea49b9a56100a70b038b64abf402115f263c6132cdf0df80c3",
+            "https://raw.githubusercontent.com/spack/patches/master/julia/10cb42f80c2eaad3e9c87cb818b6676f1be26737bdf972c77392d71707386aa4.patch",
+            sha256="10cb42f80c2eaad3e9c87cb818b6676f1be26737bdf972c77392d71707386aa4",
         ),
     )
     depends_on(
         "llvm",
         when="^llvm@13.0.1",
         patches=patch(
-            "https://github.com/JuliaLang/llvm-project/compare/75e33f71c2dae584b13a7d1186ae0a038ba98838...2f4460bd46aa80d4fe0d80c3dabcb10379e8d61b.patch",
-            sha256="d9e7f0befeddddcba40eaed3895c4f4734980432b156c39d7a251bc44abb13ca",
+            "https://raw.githubusercontent.com/spack/patches/master/julia/45f72c59ae5cf45461e9cd8b224ca49b739d885c79b3786026433c6c22f83b5f.patch",
+            sha256="45f72c59ae5cf45461e9cd8b224ca49b739d885c79b3786026433c6c22f83b5f",
         ),
     )
     depends_on(
         "llvm",
         when="^llvm@14.0.6",
         patches=patch(
-            "https://github.com/JuliaLang/llvm-project/compare/f28c006a5895fc0e329fe15fead81e37457cb1d1...381043941d2c7a5157a011510b6d0386c171aae7.diff",
-            sha256="f3fd1803459bdaac0e26d0f3b1874b0e3f97e9411a9e98043d36f788ab4fd00e",
+            "https://raw.githubusercontent.com/spack/patches/master/julia/f3def26930832532bbcd861d41b31ae03db993bc2b3510f89ef831a30bd3e099.patch",
+            sha256="f3def26930832532bbcd861d41b31ae03db993bc2b3510f89ef831a30bd3e099",
         ),
     )
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -25,6 +25,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("4.2.00", sha256="ac08765848a0a6ac584a0a46cd12803f66dd2a2c2db99bb17c06ffc589bf5be8")
     version("4.1.00", sha256="cf725ea34ba766fdaf29c884cfe2daacfdc6dc2d6af84042d1c78d0f16866275")
     version("4.0.01", sha256="bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0")
     version("4.0.00", sha256="1829a423883d4b44223c7c3a53d3c51671145aad57d7d23e6a1a4bebf710dcf6")
@@ -155,6 +156,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "gfx906": "vega906",
         "gfx908": "vega908",
         "gfx90a": "vega90A",
+        "gfx942": "amd_gfx942",
         "gfx1030": "navi1030",
         "gfx1100": "navi1100",
     }
@@ -234,6 +236,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     # Patches
     patch("hpx_profiling_fences.patch", when="@3.5.00 +hpx")
+    patch("sycl_bhalft_test.patch", when="@4.2.00 +sycl")
 
     variant("shared", default=True, description="Build shared libraries")
 

--- a/var/spack/repos/builtin/packages/kokkos/sycl_bhalft_test.patch
+++ b/var/spack/repos/builtin/packages/kokkos/sycl_bhalft_test.patch
@@ -1,0 +1,14 @@
+diff -ruN spack-src/core/unit_test/TestNumericTraits.hpp spack-src-patched/core/unit_test/TestNumericTraits.hpp
+--- spack-src/core/unit_test/TestNumericTraits.hpp	2023-11-20 13:26:46.000000000 -0800
++++ spack-src-patched/core/unit_test/TestNumericTraits.hpp	2023-11-28 12:06:44.216150685 -0800
+@@ -110,8 +110,8 @@
+ 
+   KOKKOS_FUNCTION void operator()(Epsilon, int, int& e) const {
+     using Kokkos::Experimental::epsilon;
+-    auto const eps = epsilon<T>::value;
+-    auto const one = T(1);
++    T const eps = epsilon<T>::value;
++    T const one = 1;
+     // Avoid higher precision intermediate representation
+     compare() = one + eps;
+     e += (int)!(compare() != one);

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -3,13 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import datetime as dt
+import os
 
 import archspec
 
 from spack.package import *
 
 
-class Lammps(CMakePackage, CudaPackage, ROCmPackage):
+class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
     """LAMMPS stands for Large-scale Atomic/Molecular Massively
     Parallel Simulator.
     """
@@ -28,10 +29,16 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     #   marked deprecated=True
     # * patch releases older than a stable release should be marked deprecated=True
     version("develop", branch="develop")
+    version("20231121", sha256="704d8a990874a425bcdfe0245faf13d712231ba23f014a3ebc27bc14398856f1")
+    version(
+        "20230802.1",
+        sha256="0e5568485e5ee080412dba44a1b7a93f864f1b5c75121f11d528854269953ed0",
+        preferred=True,
+    )
     version(
         "20230802",
         sha256="48dc8b0b0583689e80ea2052275acbc3e3fce89707ac557e120db5564257f7df",
-        preferred=True,
+        deprecated=True,
     )
     version(
         "20230615",
@@ -343,6 +350,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     stable_versions = {
+        "20230802.1",
         "20230802",
         "20220623.4",
         "20220623.3",
@@ -437,7 +445,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
         "mofff": {"when": "@20210702:"},
         "molecule": {"default": True},
         "molfile": {"when": "@20210702:"},
-        "mpiio": {},
+        "mpiio": {"when": "@:20230802.1"},
         "netcdf": {"when": "@20210702:"},
         "openmp-package": {},
         "opt": {},
@@ -530,7 +538,12 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     variant("ffmpeg", default=False, description="Build with ffmpeg support")
     variant("openmp", default=True, description="Build with OpenMP")
     variant("opencl", default=False, description="Build with OpenCL")
-    variant("exceptions", default=False, description="Build with lammps exceptions")
+    variant(
+        "exceptions",
+        default=False,
+        description="Build with lammps exceptions",
+        when="@:20230802.1",
+    )
     variant(
         "cuda_mps",
         default=False,
@@ -563,6 +576,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
         multi=False,
     )
 
+    depends_on("cmake@3.16:", when="@20231121:")
     depends_on("mpi", when="+mpi")
     depends_on("mpi", when="+mpiio")
     depends_on("fftw-api@3", when="+kspace")
@@ -602,11 +616,14 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("plumed", when="+plumed")
     depends_on("eigen@3:", when="+user-smd")
     depends_on("eigen@3:", when="+machdyn")
-    depends_on("py-cython", when="+mliap+python")
-    depends_on("py-cython", when="+ml-iap+python")
-    depends_on("py-numpy", when="+python")
-    depends_on("py-mpi4py", when="+python+mpi")
-    depends_on("py-setuptools", when="@20220217:+python", type="build")
+    depends_on("py-cython", when="+mliap+python", type="build")
+    depends_on("py-cython", when="+ml-iap+python", type="build")
+    depends_on("py-pip", when="+python", type="build")
+    depends_on("py-wheel", when="+python", type="build")
+    depends_on("py-build", when="+python", type="build")
+    depends_on("py-numpy", when="+python", type=("build", "run"))
+    depends_on("py-mpi4py", when="+python+mpi", type=("build", "run"))
+    depends_on("py-setuptools@42:", when="@20220217:+python", type=("build", "run"))
     depends_on("n2p2@2.1.4:", when="+user-hdnnp")
     depends_on("n2p2@2.1.4:", when="+ml-hdnnp")
     depends_on("n2p2+shared", when="+lib ^n2p2")
@@ -686,8 +703,8 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     # Older LAMMPS does not compile with Kokkos 4.x
     conflicts(
         "^kokkos@4:",
-        when="@:20230802",
-        msg="LAMMPS is incompatible with Kokkos 4.x until @20230802",
+        when="@:20230802.1",
+        msg="LAMMPS is incompatible with Kokkos 4.x until @20230802.1",
     )
 
     patch("lib.patch", when="@20170901")
@@ -706,6 +723,16 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     )
     patch("hip_cmake.patch", when="@20220623:20221222 ~kokkos+rocm")
 
+    # Add large potential files
+    resource(
+        name="C_10_10.mesocnt",
+        url="https://download.lammps.org/potentials/C_10_10.mesocnt",
+        sha256="923f600a081d948eb8b4510f84aa96167b5a6c3e1aba16845d2364ae137dc346",
+        expand=False,
+        placement={"C_10_10.mesocnt": "potentials/C_10_10.mesocnt"},
+        when="+mesont",
+    )
+
     root_cmakelists_dir = "cmake"
 
     def cmake_args(self):
@@ -723,6 +750,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("{}_MPI".format(mpi_prefix), "mpi"),
             self.define_from_variant("BUILD_OMP", "openmp"),
             self.define("ENABLE_TESTING", self.run_tests),
+            self.define("DOWNLOAD_POTENTIALS", False),
         ]
         if "~kokkos" in spec:
             # LAMMPS can be build with the GPU package OR the KOKKOS package
@@ -824,6 +852,9 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
         if "+rocm" in spec:
             args.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
+        if "+python" in spec:
+            args.append(self.define("Python_EXECUTABLE", spec["python"].command.path))
+
         return args
 
     def setup_build_environment(self, env):
@@ -833,5 +864,20 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     def setup_run_environment(self, env):
         env.set("LAMMPS_POTENTIALS", self.prefix.share.lammps.potentials)
         if "+python" in self.spec:
-            env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
-            env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
+            if self.spec.platform == "darwin":
+                env.prepend_path("DYLD_FALLBACK_LIBRARY_PATH", self.prefix.lib)
+                env.prepend_path("DYLD_FALLBACK_LIBRARY_PATH", self.prefix.lib64)
+            else:
+                env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
+                env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
+
+    @run_after("install")
+    def install_python(self):
+        # do LAMMPS Python package installation using pip
+        if self.spec.satisfies("@20230328: +python"):
+            with working_dir("python"):
+                os.environ["LAMMPS_VERSION_FILE"] = join_path(
+                    self.stage.source_path, "src", "version.h"
+                )
+                args = std_pip_args + ["--prefix=" + self.prefix, "."]
+                pip(*args)

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -71,7 +71,9 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant("vtune", default=False, description="Builds with support for Intel VTune")
     variant("onednn", default=False, description="Support for OneDNN")
     variant("onnx", default=False, description="Support for exporting models into ONNX format")
-    variant("nvshmem", default=False, description="Support for NVSHMEM", when="+distconv")
+    variant(
+        "nvshmem", default=False, sticky=True, description="Support for NVSHMEM", when="+distconv"
+    )
     variant(
         "python",
         default=True,
@@ -144,6 +146,17 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     # Add Aluminum variants
     depends_on("aluminum@master", when="@develop")
 
+    # Note that while Aluminum typically includes the dependency for the AWS OFI
+    # plugins, if Aluminum is pre-built, LBANN needs to make sure that the module
+    # is loaded
+    with when("+cuda"):
+        if spack.platforms.cray.slingshot_network():
+            depends_on("aws-ofi-nccl")  # Note: NOT a CudaPackage
+
+    with when("+rocm"):
+        if spack.platforms.cray.slingshot_network():
+            depends_on("aws-ofi-rccl")
+
     depends_on("hdf5+mpi", when="+distconv")
 
     for arch in CudaPackage.cuda_arch_values:
@@ -151,13 +164,15 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         depends_on("aluminum cuda_arch=%s" % arch, when="+cuda cuda_arch=%s" % arch)
         depends_on("dihydrogen cuda_arch=%s" % arch, when="+cuda cuda_arch=%s" % arch)
         depends_on("nccl cuda_arch=%s" % arch, when="+cuda cuda_arch=%s" % arch)
+        depends_on("hwloc cuda_arch=%s" % arch, when="+cuda cuda_arch=%s" % arch)
 
     # variants +rocm and amdgpu_targets are not automatically passed to
     # dependencies, so do it manually.
     for val in ROCmPackage.amdgpu_targets:
-        depends_on("hydrogen amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
-        depends_on("aluminum amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
-        depends_on("dihydrogen amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
+        depends_on("hydrogen amdgpu_target=%s" % val, when="+rocm amdgpu_target=%s" % val)
+        depends_on("aluminum amdgpu_target=%s" % val, when="+rocm amdgpu_target=%s" % val)
+        depends_on("dihydrogen amdgpu_target=%s" % val, when="+rocm amdgpu_target=%s" % val)
+        depends_on(f"hwloc amdgpu_target={val}", when=f"+rocm amdgpu_target={val}")
 
     depends_on("roctracer-dev", when="+rocm +distconv")
 
@@ -166,8 +181,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("hipcub", when="+rocm")
     depends_on("mpi")
     depends_on("hwloc@1.11:")
-    depends_on("hwloc +cuda +nvml", when="+cuda")
-    depends_on("hwloc@2.3.0:", when="+rocm")
+    depends_on("hwloc +cuda +nvml ~rocm", when="+cuda")
+    depends_on("hwloc@2.3.0: +rocm ~cuda", when="+rocm")
     depends_on("hiptt", when="+rocm")
 
     depends_on("half", when="+half")
@@ -223,7 +238,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("onnx", when="+onnx")
     depends_on("nvshmem", when="+nvshmem")
 
-    depends_on("spdlog@1.11.0")
+    depends_on("spdlog@1.11.0:1.12.0")
     depends_on("zstr")
 
     depends_on("caliper+adiak+mpi", when="+caliper")
@@ -272,15 +287,36 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             # of CMake
             entries.append(cmake_cache_option("CMAKE_EXPORT_COMPILE_COMMANDS", True))
 
+        entries.append(cmake_cache_string("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "ON"))
+        linker_flags = "-Wl,--disable-new-dtags"
+        entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", linker_flags))
+        entries.append(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS", linker_flags))
+
         # Use lld high performance linker
         if "+lld" in spec:
-            entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", "-fuse-ld=lld"))
-            entries.append(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS", "-fuse-ld=lld"))
+            entries.append(
+                cmake_cache_string(
+                    "CMAKE_EXE_LINKER_FLAGS", "{0} -fuse-ld=lld".format(linker_flags)
+                )
+            )
+            entries.append(
+                cmake_cache_string(
+                    "CMAKE_SHARED_LINKER_FLAGS", "{0} -fuse-ld=lld".format(linker_flags)
+                )
+            )
 
         # Use gold high performance linker
         if "+gold" in spec:
-            entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", "-fuse-ld=gold"))
-            entries.append(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS", "-fuse-ld=gold"))
+            entries.append(
+                cmake_cache_string(
+                    "CMAKE_EXE_LINKER_FLAGS", "{0} -fuse-ld=gold".format(linker_flags)
+                )
+            )
+            entries.append(
+                cmake_cache_string(
+                    "CMAKE_SHARED_LINKER_FLAGS", "{0} -fuse-ld=gold".format(linker_flags)
+                )
+            )
 
         # Set the generator in the cached config
         if self.spec.satisfies("generator=make"):

--- a/var/spack/repos/builtin/packages/libdap4/package.py
+++ b/var/spack/repos/builtin/packages/libdap4/package.py
@@ -32,6 +32,14 @@ class Libdap4(AutotoolsPackage):
     depends_on("curl")
     depends_on("libxml2")
     depends_on("uuid")
+    depends_on("rpc")
+
+    def setup_build_environment(self, env):
+        # Configure script will search for RPC library, but not actually add RPC library references
+        # during configure tests. This can cause a failure with libtirpc if the following variable
+        # is not set.
+        if self.spec.satisfies("^libtirpc"):
+            env.set("TIRPC_LIBS", self.spec["rpc"].libs)
 
     def configure_args(self):
         # libxml2 exports ./include/libxml2/ instead of ./include/, which we

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -125,6 +125,12 @@ class Libfabric(AutotoolsPackage):
 
     conflicts("@1.9.0", when="platform=darwin", msg="This distribution is missing critical files")
     conflicts("fabrics=opx", when="@:1.14.99")
+    conflicts(
+        "fabrics=opx",
+        when="@1.20.0",
+        msg="Libfabric 1.20.0 uses values in memory that are not correctly "
+        "set by OPX, resulting in undefined behavior.",
+    )
 
     flag_handler = build_system_flags
 

--- a/var/spack/repos/builtin/packages/lsd/package.py
+++ b/var/spack/repos/builtin/packages/lsd/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Lsd(CargoPackage):
+    """A rewrite of GNU ls with lots of added features like colors, icons, tree-view,
+    more formatting options etc."""
+
+    homepage = "https://github.com/lsd-rs/lsd"
+    url = "https://github.com/lsd-rs/lsd/archive/refs/tags/v1.0.0.tar.gz"
+
+    maintainers("trws")
+
+    license("Apache-2.0")
+
+    version("1.0.0", sha256="ab34e9c85bc77cfa42b43bfb54414200433a37419f3b1947d0e8cfbb4b7a6325")
+
+    depends_on("rust@1.63:")

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -106,7 +106,7 @@ class Met(AutotoolsPackage):
             ldflags.append(nc_config("--libs", "--static", output=str).strip())
             libs.append(nc_config("--libs", "--static", output=str).strip())
 
-        zlib = spec["zlib"]
+        zlib = spec["zlib-api"]
         cppflags.append("-D__64BIT__")
         ldflags.append("-L" + zlib.prefix.lib)
         libs.append("-lz")
@@ -128,6 +128,7 @@ class Met(AutotoolsPackage):
         if "+python" in spec:
             python = spec["python"]
             env.set("MET_PYTHON", python.command.path)
+            env.set("MET_PYTHON_BIN_EXE", python.command.path)
             env.set("MET_PYTHON_CC", "-I" + python.headers.directories[0])
             py_ld = [python.libs.ld_flags]
             if spec["python"].satisfies("~shared"):
@@ -142,6 +143,11 @@ class Met(AutotoolsPackage):
             hdfeos = spec["hdf-eos2"]
             env.set("MET_HDF5", hdf.prefix)
             env.set("MET_HDFEOS", hdfeos.prefix)
+
+            if "+szip" in hdf:
+                libs.append(" ".join(hdf["szip"].libs))
+            if "+external-xdr" in hdf:
+                libs.append(" ".join(hdf["rpc"].libs))
 
         if "+graphics" in spec:
             cairo = spec["cairo"]

--- a/var/spack/repos/builtin/packages/metkit/package.py
+++ b/var/spack/repos/builtin/packages/metkit/package.py
@@ -13,7 +13,7 @@ class Metkit(CMakePackage):
     homepage = "https://github.com/ecmwf/metkit"
     url = "https://github.com/ecmwf/metkit/archive/refs/tags/1.7.0.tar.gz"
 
-    maintainers("skosukhin")
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
 
     version("1.10.17", sha256="1c525891d77ed28cd4c87b065ba4d1aea24d0905452c18d885ccbd567bbfc9b1")
     version("1.10.2", sha256="a038050962aecffda27b755c40b0a6ed0db04a2c22cad3d8c93e6109c8ab4b34")

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -473,6 +473,11 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     patch("mfem-4.0.0-makefile-syntax-fix.patch", when="@4.0.0")
     patch("mfem-4.5.patch", when="@4.5.0")
     patch("mfem-4.6.patch", when="@4.6.0")
+    patch(
+        "https://github.com/mfem/mfem/pull/4005.patch?full_index=1",
+        when="@4.6.0 +gslib+shared+miniapps",
+        sha256="2a31682d876626529e2778a216d403648b83b90997873659a505d982d0e65beb",
+    )
 
     phases = ["configure", "build", "install"]
 

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -751,12 +751,14 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                     )
                     gfortran_lib = LibraryList(libfile)
                     sp_lib += [ld_flags_from_library_list(gfortran_lib)]
-                if ("^mpich" in strumpack) or ("^mvapich2" in strumpack):
-                    sp_lib += ["-lmpifort"]
-                elif "^openmpi" in strumpack:
-                    sp_lib += ["-lmpi_mpifh"]
-                elif "^spectrum-mpi" in strumpack:
-                    sp_lib += ["-lmpi_ibm_mpifh"]
+                if "+mpi" in strumpack:
+                    mpi = strumpack["mpi"]
+                    if ("^mpich" in strumpack) or ("^mvapich2" in strumpack):
+                        sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpifort"])]
+                    elif "^openmpi" in strumpack:
+                        sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_mpifh"])]
+                    elif "^spectrum-mpi" in strumpack:
+                        sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_ibm_mpifh"])]
             if "+openmp" in strumpack:
                 # The '+openmp' in the spec means strumpack will TRY to find
                 # OpenMP; if not found, we should not add any flags -- how do

--- a/var/spack/repos/builtin/packages/mgis/package.py
+++ b/var/spack/repos/builtin/packages/mgis/package.py
@@ -24,6 +24,8 @@ class Mgis(CMakePackage):
 
     # development branches
     version("master", branch="master")
+    version("rliv-2.2", branch="rliv-2.2")
+    version("rliv-2.1", branch="rliv-2.1")
     version("rliv-2.0", branch="rliv-2.0")
     version("rliv-1.2", branch="rliv-1.2")
     version("rliv-1.1", branch="rliv-1.1")
@@ -31,10 +33,12 @@ class Mgis(CMakePackage):
 
     # released version
     version(
-        "2.0",
-        sha256="cb427d77f2c79423e969815b948a8b44da33a4370d1760e8c1e22a569f3585e2",
+        "2.2",
+        sha256="b3776d7b3a534ca626525a42b97665f7660ae2b28ea57b3f53fd7e8538da1ceb",
         preferred=True,
     )
+    version("2.1", sha256="f5b556aab130da0c423f395fe4c35d6bf509dd8fc958242f2e37ea788464aea9")
+    version("2.0", sha256="cb427d77f2c79423e969815b948a8b44da33a4370d1760e8c1e22a569f3585e2")
     version("1.2.2", sha256="dc24e85cc90ec656ed707eef3d511317ad800915014d9e4e9cf8818b406586d5")
     version("1.2.1", sha256="a2d7cae3a24546adcf1d1bf7f13f012170d359370f5b6b2c1730b19eb507601d")
     version("1.2", sha256="ed82ab91cbe17c00ef36578dbfcb4d1817d4c956619b7cccbea3e3f1a3b31940")
@@ -47,14 +51,10 @@ class Mgis(CMakePackage):
     variant("fortran", default=True, description="Enables fortran bindings")
     variant("python", default=True, description="Enables python bindings")
     variant("static", default=False, description="Enables static libraries")
-    variant(
-        "build_type",
-        default="Release",
-        description="The build type to build",
-        values=("Debug", "Release"),
-    )
 
     # dependencies
+    depends_on("tfel@4.2.0", when="@2.2")
+    depends_on("tfel@4.1.0", when="@2.1")
     depends_on("tfel@4.0.0", when="@2.0")
     depends_on("tfel@3.4.3", when="@1.2.2")
     depends_on("tfel@3.4.1", when="@1.2.1")
@@ -62,6 +62,9 @@ class Mgis(CMakePackage):
     depends_on("tfel@3.3.0", when="@1.1")
     depends_on("tfel@3.2.1", when="@1.0.1")
     depends_on("tfel@3.2.0", when="@1.0")
+    depends_on("tfel@rliv-4.2", when="@rliv-2.2")
+    depends_on("tfel@rliv-4.1", when="@rliv-2.1")
+    depends_on("tfel@rliv-4.0", when="@rliv-2.0")
     depends_on("tfel@rliv-3.4", when="@rliv-1.2")
     depends_on("tfel@rliv-3.3", when="@rliv-1.1")
     depends_on("tfel@rliv-3.2", when="@rliv-1.0")

--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -17,6 +17,7 @@ class MochiMargo(AutotoolsPackage):
     maintainers("carns", "mdorier", "fbudin69500")
 
     version("main", branch="main")
+    version("0.15.0", sha256="f962f02ddaae125eaf15bf89126ee47b4f852d366b14248d2d67a0be8f661224")
     version("0.14.1", sha256="69229a9126b76aff7fd47e25c4a8f72804f101c5c603c4e4ef93f4fb7a1b6662")
     version("0.14.0", sha256="ff0e3fa786630b63280606243c35f1ea3a25fa2ba6f08bf9065cab9fcc7fa1c7")
     version("0.13.1", sha256="cff1decb94089cd0f9c0930b02092838679827b09ce4a2f3a359d59caee28782")

--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -16,6 +16,10 @@ class MochiThallium(CMakePackage):
     maintainers("mdorier")
 
     version("main", branch="main")
+    version("0.11.3", sha256="d1ffd7ee1ccbcfb00f246cb29c5bc2560e59f8808609cbc19b7098aa8fc903c4")
+    version("0.11.2", sha256="4f1e57ca843b7592525c179dec73bfb603a27fbda4feaf028d636e05c1b38e36")
+    version("0.11.1", sha256="be99bec2309ce1945a777fba720175f409972cbf27b73388728a740d6406a040")
+    version("0.11.0", sha256="c216310fdef9281e1c7e3264c148c560d7f5edd15816d35866efcc543185b7ee")
     version("0.10.1", sha256="5a8dc1f1622f4186b02fbabd47a8a33ca6be3d07757010f3d63d30e9f74fec8c")
     version("0.10.0", sha256="5319e25a42deab7c639e980885fe3be717cda2c2c693a1906f5a6c79b31edef8")
     version("0.9.1", sha256="dee884d0e054c838807f9c17781acfa99b26e3be1cc527bf09ceaa997336b3e4")
@@ -51,6 +55,7 @@ class MochiThallium(CMakePackage):
     )
 
     depends_on("pkgconfig", type=("build"))
+    depends_on("mochi-margo@0.12.0:", when="@0.11.2:")
     depends_on("mochi-margo@0.9.8:", when="@0.10.0:")
     depends_on("mochi-margo@0.7:", when="@0.7:")
     depends_on("mochi-margo@0.6:", when="@0.5:")

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -18,6 +18,9 @@ class Mumps(Package):
 
     maintainers("jcortial-safran")
 
+    version("5.6.2", sha256="13a2c1aff2bd1aa92fe84b7b35d88f43434019963ca09ef7e8c90821a8f1d59a")
+    version("5.6.1", sha256="1920426d543e34d377604070fde93b8d102aa38ebdf53300cbce9e15f92e2896")
+    version("5.6.0", sha256="3e08c1bdea7aaaba303d3cf03059f3b4336fa49bef93f4260f478f067f518289")
     version("5.5.1", sha256="1abff294fa47ee4cfd50dfd5c595942b72ebfcedce08142a75a99ab35014fa15")
     version("5.5.0", sha256="e54d17c5e42a36c40607a03279e0704d239d71d38503aab68ef3bfe0a9a79c13")
     version("5.4.1", sha256="93034a1a9fe0876307136dcde7e98e9086e199de76f1c47da822e7d4de987fa8")

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -441,7 +441,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         if "~shared" in hdf5:
             if "+szip" in hdf5:
                 extra_libs.append(hdf5["szip"].libs)
-            extra_libs.append(hdf5["zlib"].libs)
+            extra_libs.append(hdf5["zlib-api"].libs)
 
         if self.spec.satisfies("@4.9.0:+shared"):
             lib_search_dirs.extend(self.spec["zlib-api"].libs.directories)

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -93,6 +93,9 @@ class Openblas(CMakePackage, MakefilePackage):
     provides("lapack@3.9.1:", when="@0.3.15:")
     provides("lapack@3.7.0", when="@0.2.20")
 
+    # https://github.com/OpenMathLib/OpenBLAS/pull/4328
+    patch("xcode15-fortran.patch", when="@0.3.25 %apple-clang@15:")
+
     # https://github.com/xianyi/OpenBLAS/pull/2519/files
     patch("ifort-msvc.patch", when="%msvc")
 

--- a/var/spack/repos/builtin/packages/openblas/xcode15-fortran.patch
+++ b/var/spack/repos/builtin/packages/openblas/xcode15-fortran.patch
@@ -1,0 +1,22 @@
+From 47b03fd4b4ce7bc51d5b56397e52e6da3c5f3f36 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Sat, 18 Nov 2023 23:45:02 +0100
+Subject: [PATCH] Copy XCode15-specific workaround to Fortran flags to fix
+ build of tests
+
+---
+ Makefile.system | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Makefile.system b/Makefile.system
+index 1b84195e45..ff06e503cb 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -407,6 +407,7 @@ XCVER = $(shell pkgutil --pkg-info=com.apple.pkg.CLTools_Executables |awk '/vers
+ endif
+ ifeq (x$(XCVER), x 15)
+ CCOMMON_OPT += -Wl,-ld_classic
++FCOMMON_OPT += -Wl,-ld_classic
+ endif
+ endif
+ 

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -13,8 +13,8 @@ class Opengl(BundlePackage):
     """Placeholder for external OpenGL libraries from hardware vendors"""
 
     homepage = "https://www.opengl.org/"
-
     version("4.5")
+    maintainers("biddisco")
 
     # This should really be when='platform=linux' but can't because of a
     # current bug in when and how ArchSpecs are constructed
@@ -83,15 +83,20 @@ class Opengl(BundlePackage):
         _ = self.fetcher
 
     @property
+    def headers(self):
+        return self.gl_headers
+
+    @property
     def libs(self):
         return self.gl_libs
 
     @property
     def gl_headers(self):
-        if "platform=darwin":
-            header_name = "OpenGL/gl.h"
+        spec = self.spec
+        if "platform=darwin" in spec:
+            header_name = "OpenGL/gl"
         else:
-            header_name = "GL/gl.h"
+            header_name = "GL/gl"
         return find_headers(header_name, root=self.prefix, recursive=True)
 
     @property

--- a/var/spack/repos/builtin/packages/perl-carp-assert/package.py
+++ b/var/spack/repos/builtin/packages/perl-carp-assert/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCarpAssert(PerlPackage):
+    """Carp::Assert - executable comments."""
+
+    homepage = "https://metacpan.org/pod/Carp::Assert"
+    url = "https://cpan.metacpan.org/authors/id/Y/YV/YVES/Carp-Assert-0.22.tar.gz"
+
+    version("0.22", sha256="807ea97c6bed76ac2e4969efba7dae48fefeb9f28797f112671b3ac8a49355f7")
+
+    depends_on("perl-extutils-makemaker", type="build")

--- a/var/spack/repos/builtin/packages/perl-carp-assert/package.py
+++ b/var/spack/repos/builtin/packages/perl-carp-assert/package.py
@@ -15,10 +15,11 @@ class PerlCarpAssert(PerlPackage):
     maintainers("chissg", "gartung", "marcmengel", "vitodb")  # AUTO-CPAN2Spack
 
     version("0.22", sha256="807ea97c6bed76ac2e4969efba7dae48fefeb9f28797f112671b3ac8a49355f7")
-    version("0.21",
-            url="https://cpan.metacpan.org/authors/id/N/NE/NEILB/Carp-Assert-0.21.tar.gz",
-            sha256="924f8e2b4e3cb3d8b26246b5f9c07cdaa4b8800cef345fa0811d72930d73a54e",
-            )
+    version(
+        "0.21",
+        url="https://cpan.metacpan.org/authors/id/N/NE/NEILB/Carp-Assert-0.21.tar.gz",
+        sha256="924f8e2b4e3cb3d8b26246b5f9c07cdaa4b8800cef345fa0811d72930d73a54e",
+    )
 
     depends_on("perl@5.6:", type="run")
 

--- a/var/spack/repos/builtin/packages/perl-parse-yapp/package.py
+++ b/var/spack/repos/builtin/packages/perl-parse-yapp/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlParseYapp(PerlPackage):
+    """Parse::Yapp - Perl extension for generating and using LALR parsers."""
+
+    homepage = "https://metacpan.org/pod/Parse::Yapp"
+    url = "https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz"
+
+    version("1.21", sha256="3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5")
+
+    depends_on("perl-extutils-makemaker", type="build")

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -22,6 +22,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
+    version("3.20.2", sha256="2a2d08b5f0e3d0198dae2c42ce1fd036f25c153ef2bb4a2d320ca141ac7cd30b")
     version("3.20.1", sha256="3d54f13000c9c8ceb13ca4f24f93d838319019d29e6de5244551a3ec22704f32")
     version("3.20.0", sha256="c152ccb12cb2353369d27a65470d4044a0c67e0b69814368249976f5bb232bd4")
     version("3.19.6", sha256="6045e379464e91bb2ef776f22a08a1bc1ff5796ffd6825f15270159cbb2464ae")

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -20,6 +20,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.11.0", sha256="bf197b6f223a75c7d3eee23888cdde204b5aea053c308852a3f8f677784b8899")
     version("1.10.0", sha256="8e25564699c0adcbe9a23fded6637668ce659480b39420be5a4c8181cd44ad53")
     version("1.9.5", sha256="baa3ebb83962f1b6c8c5b0413fe9d02411d3e379c76b8c190112e158c10ac0ac")
     version("1.9.3", sha256="f300fab515a25b728889ef6c2ab64aa90e7f94c98fd8190dd11a9b1ebd38117a")

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -19,6 +19,7 @@ class Pfunit(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
+    version("4.8.0", sha256="b5c66ab949fd23bee5c3b4d93069254f7ea40decb8d21f622fd6aa45ee68ef10")
     version("4.7.4", sha256="ac850e33ea99c283f503f75293bf238b4b601885d7adba333066e6185dad5c04")
     version("4.7.3", sha256="247239298b55e847417b7830183d7fc62cca93dc92c8ec7c0067784b7ce34544")
     version("4.7.2", sha256="3142a1e56b7d127fdc9589cf6deff8505174129834a6a268d0ce7e296f51ab02")

--- a/var/spack/repos/builtin/packages/photospline/package.py
+++ b/var/spack/repos/builtin/packages/photospline/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Photospline(CMakePackage):
+    """Library for interpolating multi-dimensional detector response histograms."""
+
+    homepage = "https://github.com/icecube/photospline"
+    url = "https://github.com/icecube/photospline/archive/refs/tags/v2.2.1.tar.gz"
+
+    license("BSD-2-Clause")
+
+    version("2.2.1", sha256="2b455daf8736d24bf57cae9eb67d48463a6c4bd6a66c3ffacf52296454bb82ad")
+    version("2.2.0", sha256="81f79b42fd63e12c13cc369fb5c6ef356389f7c7aaa10a584aae2e22dba79ccf")
+    version("2.1.1", sha256="0a0dae8e1b994a35be23896982bd572fa97c617ad55a99b3da34782ad9435de8")
+    version("2.1.0", sha256="bd6c58df8893917909b79ef2510a2043f909fbb7020bdace328d4d36e0222b60")
+    version("2.0.7", sha256="59a3607c4aa036c55bcd233e8a0ec11575bd74173f3b4095cc6a77aa50baebcd")
+    version("2.0.6", sha256="2f87c377e548f5fb44f8090c7559b2895f463a395b40a3276a04db44f39b1a4d")
+    version("2.0.5", sha256="7e2679fac733fb4d881ff9d16fc99348a62b421811f256641f2449b98a6fb041")
+    version("2.0.4", sha256="0a675ffe27e1d99fe482cdd7692320d6852c11c9a63de7e710ba075989e0bfb5")
+    version("2.0.3", sha256="7045a631c41489085037b05fac98fd9cad73dc4262b7eead143d09e5f8265dec")
+    version("2.0.2", sha256="0a3368205a7971a6919483ad5b5f0fbebb74614ec1891c95bb6a4fc9d3b950d4")
+
+    depends_on("cfitsio")

--- a/var/spack/repos/builtin/packages/py-autodocsumm/package.py
+++ b/var/spack/repos/builtin/packages/py-autodocsumm/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAutodocsumm(PythonPackage):
+    """Extended sphinx autodoc including automatic autosummaries."""
+
+    homepage = "https://github.com/Chilipp/autodocsumm"
+    pypi = "autodocsumm/autodocsumm-0.2.11.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("0.2.11", sha256="183212bd9e9f3b58a96bb21b7958ee4e06224107aa45b2fd894b61b83581b9a9")
+
+    depends_on("py-setuptools@61.0:", type="build")
+    depends_on("py-versioneer+toml", type="build")
+    depends_on("py-sphinx@2.2:7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-beartype/package.py
+++ b/var/spack/repos/builtin/packages/py-beartype/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyBeartype(PythonPackage):
+    """Unbearably fast near-real-time hybrid runtime-static type-checking in pure Python."""
+
+    homepage = "https://beartype.readthedocs.io/"
+    pypi = "beartype/beartype-0.15.0.tar.gz"
+
+    version("0.16.2", sha256="47ec1c8c3be3f999f4f9f829e8913f65926aa7e85b180d9ffd305dc78d3e7d7b")
+    version("0.15.0", sha256="2af6a8d8a7267ccf7d271e1a3bd908afbc025d2a09aa51123567d7d7b37438df")
+
+    # See PYTHON_VERSION_MIN in beartype/meta.py
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools@:49,50.1:", type="build")

--- a/var/spack/repos/builtin/packages/py-cma/package.py
+++ b/var/spack/repos/builtin/packages/py-cma/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCma(PythonPackage):
+    """
+    Python implementation of CMA-ES Covariance Matrix Adaptation Evolution Str
+    ategy for non-linear numerical optimization in Python
+    """
+
+    homepage = "https://github.com/CMA-ES/pycma"
+    pypi = "cma/cma-3.3.0.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("3.3.0", sha256="b748b8e03f4e7ae816157d7b9bb2fc6b1fb2fee1d5fd3399329b646bb75861ec")
+
+    variant("plotting", default=False, description="Build with matplotlib support.")
+    variant(
+        "constrained_solution_tracking",
+        default=False,
+        description="Build with moarchiving support.",
+    )
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"), when="+plotting")
+    depends_on("py-moarchiving", type=("build", "run"), when="+constrained_solution_tracking")

--- a/var/spack/repos/builtin/packages/py-cylc-flow/package.py
+++ b/var/spack/repos/builtin/packages/py-cylc-flow/package.py
@@ -12,8 +12,9 @@ class PyCylcFlow(PythonPackage):
     homepage = "https://cylc.org"
     pypi = "cylc-flow/cylc-flow-8.1.4.tar.gz"
 
-    maintainers("LydDeb")
+    maintainers("LydDeb", "climbfuji")
 
+    version("8.2.3", sha256="dd5bea9e4b8dad00edd9c3459a38fb778e5a073da58ad2725bc9b84ad718e073")
     version("8.2.0", sha256="cbe35e0d72d1ca36f28a4cebe9b9040a3445a74253bc94051a3c906cf179ded0")
     version("8.1.4", sha256="d1835ac18f6f24f3115c56b2bc821185484e834a86b12fd0033ff7e4dc3c1f63")
 
@@ -24,7 +25,8 @@ class PyCylcFlow(PythonPackage):
     depends_on("py-colorama@0.4:1", type=("build", "run"))
     depends_on("py-graphene@2.1:2", type=("build", "run"))
     depends_on("py-jinja2@3.0", type=("build", "run"))
-    depends_on("py-metomi-isodatetime@3.0", type=("build", "run"))
+    depends_on("py-metomi-isodatetime@3.0", type=("build", "run"), when="@:8.2.0")
+    depends_on("py-metomi-isodatetime@3:3.1", type=("build", "run"), when="@8.2.3:")
     depends_on("py-protobuf@4.21.2:4.21", type=("build", "run"))
     depends_on("py-psutil@5.6.0:", type=("build", "run"))
     depends_on("py-pyzmq@22:", type=("build", "run"), when="@8.2:")
@@ -34,3 +36,6 @@ class PyCylcFlow(PythonPackage):
     depends_on("py-rx", type=("build", "run"))
     depends_on("py-promise", type=("build", "run"))
     depends_on("py-tomli@2:", type=("build", "run"), when="^python@:3.10")
+
+    # Non-Python dependencies
+    depends_on("graphviz", type="run")

--- a/var/spack/repos/builtin/packages/py-gidgethub/package.py
+++ b/var/spack/repos/builtin/packages/py-gidgethub/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyGidgethub(PythonPackage):
+    """An async GitHub API library for Python."""
+
+    homepage = "https://github.com/gidgethub/gidgethub"
+    pypi = "gidgethub/gidgethub-5.3.0.tar.gz"
+    git = "https://github.com/gidgethub/gidgethub.git"
+
+    maintainers("alecbcs")
+
+    license("Apache-2.0")
+
+    version("main", branch="main")
+    version("5.3.0", sha256="9ece7d37fbceb819b80560e7ed58f936e48a65d37ec5f56db79145156b426a25")
+
+    variant(
+        "aiohttp", default=False, description="Enable aiohttp functionality through dependency."
+    )
+    variant(
+        "tornado", default=False, description="Enable tornado functionality through dependency."
+    )
+
+    depends_on("py-flit", type="build", when="@:5.3.0")
+    depends_on("py-flit-core", type="build", when="@5.3.1:")
+
+    depends_on("py-uritemplate@3.0.1:", type=("build", "run"))
+    depends_on("py-pyjwt+crypto@2.4.0:", type=("build", "run"))
+
+    depends_on("py-aiohttp", type=("build", "run"), when="+aiohttp")
+    depends_on("py-tornado", type=("build", "run"), when="+tornado")

--- a/var/spack/repos/builtin/packages/py-gidgetlab/package.py
+++ b/var/spack/repos/builtin/packages/py-gidgetlab/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyGidgetlab(PythonPackage):
+    """An asynchronous GitLab API library."""
+
+    homepage = "https://gitlab.com/beenje/gidgetlab"
+    pypi = "gidgetlab/gidgetlab-1.1.0.tar.gz"
+    git = "https://gitlab.com/beenje/gidgetlab.git"
+
+    maintainers("alecbcs")
+
+    license("Apache-2.0")
+
+    version("main", branch="main")
+    version("1.1.0", sha256="314ec2cddc898317ec45d99068665dbf33c0fee1f52df6671f28ad35bb51f902")
+
+    variant(
+        "aiohttp", default=False, description="Enable aiohttp functionality through dependency."
+    )
+
+    depends_on("py-setuptools@45:", type=("build", "run"))
+    depends_on("py-setuptools-scm@6.2:", type="build")
+
+    depends_on("py-aiohttp", type=("build", "run"), when="+aiohttp")
+    depends_on("py-cachetools", type=("build", "run"), when="+aiohttp")

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -9,18 +9,17 @@ from spack.package import *
 
 
 class PyKeras(PythonPackage):
-    """Deep Learning for humans.
+    """Multi-backend Keras.
 
-    Keras is a deep learning API written in Python, running on top of the machine
-    learning platform TensorFlow. It was developed with a focus on enabling fast
-    experimentation. Being able to go from idea to result as fast as possible is
-    key to doing good research.
+    Keras 3 is a new multi-backend implementation of the Keras API,
+    with support for TensorFlow, JAX, and PyTorch.
     """
 
     homepage = "https://keras.io"
     git = "https://github.com/keras-team/keras.git"
-    url = "https://github.com/keras-team/keras/archive/refs/tags/v2.7.0.tar.gz"
+    pypi = "keras/keras-3.0.0.tar.gz"
 
+    version("3.0.0", sha256="82a9fa4b32a049b38151d11188ed15d74f21f853f163e78da0950dce1f244ccc")
     version("2.14.0", sha256="a845d446b6ae626f61dde5ab2fa952530b6c17b4f9ed03e9362bd20172d00cca")
     version("2.13.1", sha256="b3591493cce75a69adef7b192cec6be222e76e2386d132cd4e34aa190b0ecbd5")
     version("2.12.0", sha256="6336cebb6b2b0a91f7efd3ff3a9db3a94f2abccf07a40323138afb80826aec62")
@@ -43,25 +42,51 @@ class PyKeras(PythonPackage):
     version("2.2.1", sha256="0d3cb14260a3fa2f4a5c4c9efa72226ffac3b4c50135ba6edaf2b3d1d23b11ee")
     version("2.2.0", sha256="5b8499d157af217f1a5ee33589e774127ebc3e266c833c22cb5afbb0ed1734bf")
 
-    # Supported Python versions listed in multiple places:
-    # * keras/tools/pip_package/setup.py
-    # * CONTRIBUTING.md
-    # * PKG-INFO
+    variant(
+        "backend",
+        default="tensorflow",
+        description="backend library",
+        values=["tensorflow", "jax", "torch"],
+        multi=False,
+        when="@3:",
+    )
+
+    # setup.py
+    depends_on("python@3.9:", type=("build", "run"), when="@3:")
     depends_on("python@3.8:", type=("build", "run"), when="@2.12:")
     depends_on("py-setuptools", type="build")
-
-    # Required dependencies listed in multiple places:
-    # * BUILD
-    # * WORKSPACE
     depends_on("py-absl-py", type=("build", "run"), when="@2.6:")
-    depends_on("py-h5py", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-pandas", type=("build", "run"))
-    depends_on("pil", type=("build", "run"))
-    depends_on("py-portpicker", type=("build", "run"), when="@2.10:")
-    depends_on("py-pydot", type=("build", "run"))
+    depends_on("py-rich", type=("build", "run"), when="@3:")
+    depends_on("py-namex", type=("build", "run"), when="@3:")
+    depends_on("py-h5py", type=("build", "run"))
+    depends_on("py-dm-tree", type=("build", "run"), when="@3:")
+
+    # requirements-common.txt
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-six", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-requests", type=("build", "run"), when="@3:")
+    depends_on("py-protobuf", type=("build", "run"), when="@3:")
+
+    # requirements-tensorflow-cuda.txt
+    conflicts("backend=tensorflow", msg="Requires TensorFlow 2.16, not yet released")
+    # depends_on("py-tensorflow@2.16.0", type=("build", "run"), when="@3.0.0 backend=tensorflow")
+
+    # requirements-jax-cuda.txt
+    depends_on("py-jax", type=("build", "run"), when="@3.0.0: backend=jax")
+
+    # requirements-torch-cuda.txt
+    depends_on("py-torch@2.1.0", type=("build", "run"), when="@3.0.0 backend=torch")
+    depends_on("py-torchvision@0.16.0", type=("build", "run"), when="@3.0.0 backend=torch")
+
+    # Historical dependencies
+    depends_on("bazel", type="build", when="@2.5:2")
+    depends_on("protobuf", type="build", when="@2.5:2")
+    depends_on("pil", type=("build", "run"), when="@:2")
+    depends_on("py-portpicker", type=("build", "run"), when="@2.10:2")
+    depends_on("py-pydot", type=("build", "run"), when="@:2")
+    depends_on("py-pyyaml", type=("build", "run"), when="@:2")
+    depends_on("py-six", type=("build", "run"), when="@:2")
     for minor_ver in range(6, 15):
         depends_on(
             "py-tensorflow@2.{}".format(minor_ver),
@@ -73,18 +98,21 @@ class PyKeras(PythonPackage):
             type=("build", "run"),
             when="@2.{}".format(minor_ver),
         )
-    depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("bazel", type="build", when="@2.5:")
-    depends_on("protobuf", type="build", when="@2.5:")
 
     def url_for_version(self, version):
-        if version >= Version("2.6"):
-            return super().url_for_version(version)
+        if version >= Version("3"):
+            url = "https://files.pythonhosted.org/packages/source/k/keras/keras-{}.tar.gz"
+        elif version >= Version("2.6"):
+            url = "https://github.com/keras-team/keras/archive/refs/tags/v{}.tar.gz"
         else:
-            url = "https://pypi.io/packages/source/K/Keras/Keras-{0}.tar.gz"
-            return url.format(version.dotted)
+            url = "https://files.pythonhosted.org/packages/source/k/keras/Keras-{}.tar.gz"
+        return url.format(version)
 
-    @when("@2.5:")
+    def setup_run_environment(self, env):
+        if self.spec.satisfies("@3:"):
+            env.set("KERAS_BACKEND", self.spec.variants["backend"].value)
+
+    @when("@2.5:2")
     def patch(self):
         infile = join_path(self.package_dir, "protobuf_build.patch")
         with open(infile, "r") as source_file:
@@ -99,7 +127,7 @@ class PyKeras(PythonPackage):
             string=True,
         )
 
-    @when("@2.5:")
+    @when("@2.5:2")
     def install(self, spec, prefix):
         self.tmp_path = tempfile.mkdtemp(prefix="spack")
         env["HOME"] = self.tmp_path

--- a/var/spack/repos/builtin/packages/py-mahotas/package.py
+++ b/var/spack/repos/builtin/packages/py-mahotas/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMahotas(PythonPackage):
+    """Mahotas: Computer Vision Library."""
+
+    homepage = "http://luispedro.org/software/mahotas"
+    pypi = "mahotas/mahotas-1.4.13.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("1.4.13", sha256="a78dfe15045a20a0d9e01538b80f874580cd3525ae3eaa2c83ced51eb455879c")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
+++ b/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
@@ -14,6 +14,7 @@ class PyMetomiIsodatetime(PythonPackage):
 
     maintainers("LydDeb")
 
+    version("3.1.0", sha256="2ec15eb9c323d5debd0678f33af99bc9a91aa0b534ee5f65f3487aed518ebf2d")
     version("3.0.0", sha256="2141e8aaa526ea7f7f1cb883e6c8ed83ffdab73269658d84d0624f63a6e1357e")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -17,6 +17,7 @@ class PyMpi4py(PythonPackage):
     git = "https://github.com/mpi4py/mpi4py.git"
 
     version("master", branch="master")
+    version("3.1.5", sha256="a706e76db9255135c2fb5d1ef54cb4f7b0e4ad9e33cbada7de27626205f2a153")
     version("3.1.4", sha256="17858f2ebc623220d0120d1fa8d428d033dde749c4bc35b33d81a66ad7f93480")
     version("3.1.3", sha256="f1e9fae1079f43eafdd9f817cdb3fd30d709edc093b5d5dada57a461b2db3008")
     version("3.1.2", sha256="40dd546bece8f63e1131c3ceaa7c18f8e8e93191a762cd446a8cfcf7f9cce770")
@@ -29,14 +30,11 @@ class PyMpi4py(PythonPackage):
     version("1.3.1", sha256="e7bd2044aaac5a6ea87a87b2ecc73b310bb6efe5026031e33067ea3c2efc3507")
 
     depends_on("py-setuptools@40.9:", type="build")
+    depends_on("py-cython@0.27:2", type="build")
     depends_on("mpi")
-    depends_on("py-cython@0.27.0:", type="build")
-
-    # https://github.com/mpi4py/mpi4py/pull/311
-    conflicts("^py-cython@3:")
 
     def setup_build_environment(self, env):
-        env.set("MPICC", f"{self.spec['mpi'].mpicc} -shared")
+        env.set("MPICC", self.spec["mpi"].mpicc)
 
     @run_before("install")
     def cythonize(self):

--- a/var/spack/repos/builtin/packages/py-namex/package.py
+++ b/var/spack/repos/builtin/packages/py-namex/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyNamex(PythonPackage):
+    """A simple utility to separate the implementation of your Python package
+    and its public API surface."""
+
+    pypi = "namex/namex-0.0.7.tar.gz"
+
+    license("Apache-2.0")
+
+    version("0.0.7", sha256="84ba65bc4d22bd909e3d26bf2ffb4b9529b608cb3f9a4336f776b04204ced69b")
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -13,6 +13,9 @@ class PyNumba(PythonPackage):
     pypi = "numba/numba-0.35.0.tar.gz"
     git = "https://github.com/numba/numba.git"
 
+    skip_modules = ["numba.core.rvsdg_frontend"]
+
+    version("0.58.1", sha256="487ded0633efccd9ca3a46364b40006dbdaca0f95e99b8b83e778d1195ebcbaa")
     version("0.57.0", sha256="2af6d81067a5bdc13960c6d2519dbabbf4d5d597cf75d640c5aeaefd48c6420a")
     version("0.56.4", sha256="32d9fef412c81483d7efe0ceb6cf4d3310fde8b624a9cecca00f790573ac96ee")
     version("0.56.0", sha256="87a647dd4b8fce389869ff71f117732de9a519fe07663d9a02d75724eb8e244d")
@@ -24,14 +27,16 @@ class PyNumba(PythonPackage):
     version("0.48.0", sha256="9d21bc77e67006b5723052840c88cc59248e079a907cc68f1a1a264e1eaba017")
     version("0.40.1", sha256="52d046c13bcf0de79dbfb936874b7228f141b9b8e3447cc35855e9ad3e12aa33")
 
-    depends_on("python@3.8:3.11", when="@0.57", type=("build", "run"))
+    depends_on("python@3.8:3.11", when="@0.57:", type=("build", "run"))
     depends_on("python@3.7:3.10", when="@0.55:0.56", type=("build", "run"))
     depends_on("python@3.7:3.9", when="@0.54", type=("build", "run"))
     depends_on("python@3.6:3.9", when="@0.53", type=("build", "run"))
     depends_on("python@3.6:3.8", when="@0.52", type=("build", "run"))
     depends_on("python@3.6:3.8", when="@0.48:0.51", type=("build", "run"))
     depends_on("python@3.3:3.7", when="@0.40.1:0.47", type=("build", "run"))
-    depends_on("py-numpy@1.21:1.24", when="@0.57:", type=("build", "run"))
+    depends_on("py-numpy@1.22:1.26", when="@0.58.1:", type=("build", "run"))
+    depends_on("py-numpy@1.21:1.25", when="@0.58.0", type=("build", "run"))
+    depends_on("py-numpy@1.21:1.24", when="@0.57", type=("build", "run"))
     depends_on("py-numpy@1.18:1.23", when="@0.56.1:0.56.4", type=("build", "run"))
     depends_on("py-numpy@1.18:1.22", when="@0.55.2:0.56.0", type=("build", "run"))
     depends_on("py-numpy@1.18:1.21", when="@0.55.0:0.55.1", type=("build", "run"))
@@ -39,6 +44,7 @@ class PyNumba(PythonPackage):
     depends_on("py-numpy@1.15:1.20", when="@0.48:0.53", type=("build", "run"))
     depends_on("py-numpy@1.10:1.20", when="@:0.47", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-llvmlite@0.41", when="@0.58", type=("build", "run"))
     depends_on("py-llvmlite@0.40", when="@0.57", type=("build", "run"))
     depends_on("py-llvmlite@0.39", when="@0.56", type=("build", "run"))
     depends_on("py-llvmlite@0.38", when="@0.55", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-petsc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-petsc4py/package.py
@@ -18,6 +18,7 @@ class PyPetsc4py(PythonPackage):
     maintainers("balay")
 
     version("main", branch="main")
+    version("3.20.2", sha256="d3f24aa6612ded3e9b9ae11d5533f319d1df1705bea6d81385fea023d01175c9")
     version("3.20.1", sha256="dcc9092040d13130496f1961b79c36468f383b6ede398080e004f1966c06ad38")
     version("3.20.0", sha256="c2461eef3977ae5c214ad252520adbb92ec3a31d00e79391dd92535077bbf03e")
     version("3.19.6", sha256="bd7891b651eb83504c744e70706818cf63ecbabee3206c1fed7c3013873802b9")

--- a/var/spack/repos/builtin/packages/py-pygeos/package.py
+++ b/var/spack/repos/builtin/packages/py-pygeos/package.py
@@ -18,14 +18,16 @@ class PyPygeos(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("0.14", sha256="30fbc17f64844200b85133b885fcfb65541b8779531f6ef4f8fe467d3fba7623")
     version("0.10", sha256="8ad4703cf8f983a6878a885765be975709a2fe300e54bc6c8623ddbca4903b6c")
     version("0.9", sha256="c0584b20e95f80ee57277a6eb1e5d7f86600f8b1ef3c627d238e243afdcc0cc7")
     version("0.8", sha256="45b7e1aaa5fc9ff53565ef089fb75c53c419ace8cee18385ec1d7c1515c17cbc")
 
-    depends_on("python@3.6:", when="@0.10:", type=("build", "link", "run"))
-    depends_on("python@3:", type=("build", "link", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("python", type=("build", "link", "run"))
+    depends_on("py-cython@0.29:0", when="@0.14:", type="build")
     depends_on("py-cython", type="build")
+    depends_on("py-setuptools@61:", when="@0.14:", type="build")
+    depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.13:", when="@0.9:", type=("build", "link", "run"))
     depends_on("py-numpy@1.10:", type=("build", "link", "run"))
     depends_on("geos@3.5:")

--- a/var/spack/repos/builtin/packages/py-pyglet/package.py
+++ b/var/spack/repos/builtin/packages/py-pyglet/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -11,12 +13,30 @@ class PyPyglet(PythonPackage):
     for developing games and other visually rich applications.
     """
 
-    homepage = "https://github.com/pyglet/pygle://github.com/pyglet/pyglet"
-    pypi = "pyglet/pyglet-1.4.2.tar.gz"
+    homepage = "https://github.com/pyglet/pyglet"
+    pypi = "pyglet/pyglet-2.0.9.zip"
 
+    version("2.0.10", sha256="242beb1b3bd67c5bebdfe5ba11ec56b696ad86b50c6e7f2a317f8d783256b9c9")
+    version("2.0.9", sha256="a0922e42f2d258505678e2f4a355c5476c1a6352c3f3a37754042ddb7e7cf72f")
     version("1.4.2", sha256="fda25ae5e99057f05bd339ea7972196d2f44e6fe8fb210951ab01f6609cdbdb7")
     version("1.2.1", sha256="d1afb253d6de230e73698377566da333ef42e1c82190216aa7a0c1b729d6ff4d")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-future", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
+    depends_on("py-future", type=("build", "run"), when="@:1")
+    depends_on("python@2.7:2.8,3.4:", type=("build", "run"), when="@:1")
+    depends_on("python@3.8:", type=("build", "run"), when="@2.0:")
+    depends_on("gl", type=("build", "run"), when="@2.0: platform=linux")
+    depends_on("pil", type=("build", "run"), when="@2.0: platform=linux")
+    depends_on("pulseaudio", type=("build", "run"), when="@2.0: platform=linux")
+
+    def url_for_version(self, version):
+        if version <= Version("1.4.2"):
+            return (
+                f"https://files.pythonhosted.org/packages/source/p/pyglet/pyglet-{version}.tar.gz"
+            )
+
+    @when("@2.0.9:2.0.10")
+    def patch(self):
+        # 2.0.9 and 2.0.10 had a broken pyproject.toml in their PyPI zipfile
+        if os.path.exists("pyproject.toml"):
+            os.remove("pyproject.toml")

--- a/var/spack/repos/builtin/packages/py-requests-file/package.py
+++ b/var/spack/repos/builtin/packages/py-requests-file/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRequestsFile(PythonPackage):
+    """File transport adapter for Requests."""
+
+    homepage = "http://github.com/dashea/requests-file"
+    pypi = "requests-file/requests-file-1.5.1.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("1.5.1", sha256="07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-requests@1.0.0:", type=("build", "run"))
+    depends_on("py-six", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-jinja2-compat/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-jinja2-compat/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxJinja2Compat(PythonPackage):
+    """Patches Jinja2 v3 to restore compatibility with earlier Sphinx versions."""
+
+    homepage = "https://github.com/sphinx-toolbox/sphinx-jinja2-compat"
+    pypi = "sphinx_jinja2_compat/sphinx_jinja2_compat-0.2.0.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("0.2.0", sha256="c41346d859653e202b623f4236da8936243ed734abf5984adc3bef59d6f9a946")
+
+    depends_on("py-whey", type="build")
+    depends_on("py-whey-pth", type="build")
+    depends_on("py-jinja2@2.10:", type=("build", "run"))
+    depends_on("py-markupsafe@1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-removed-in/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-removed-in/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxRemovedIn(PythonPackage):
+    """versionremoved and removed-in directives for Sphinx."""
+
+    homepage = "https://github.com/MrSenko/sphinx-removed-in"
+    pypi = "sphinx-removed-in/sphinx-removed-in-0.2.1.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("0.2.1", sha256="0588239cb534cd97b1d3900d0444311c119e45296a9f73f1ea81ea81a2cd3db1")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-sphinx", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -14,6 +14,9 @@ class PySphinx(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("7.2.6", sha256="9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5")
+    version("7.2.5", sha256="1a9290001b75c497fd087e92b0334f1bbfa1a1ae7fddc084990c4b7bd1130b88")
+    version("7.2.4", sha256="1aeec862bf1edff4374012ac38082e0d1daa066c9e327841a846401164797988")
     version("7.2.3", sha256="ece68bb4d77b7dc090573825db45a6f9183e74098d1c21573485de250b1d1e3f")
     version("7.2.2", sha256="1c0abe6d4de7a6b2c2b109a2e18387bf27b240742e1b34ea42ac3ed2ac99978c")
     version("7.2.1", sha256="dad5e865dcdeb1486f70d8963cc9140561836bb243c311868cf11eb0f741497a")

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-moderncmakedomain/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-moderncmakedomain/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxcontribModerncmakedomain(PythonPackage):
+    """Sphinx Domain for Modern CMake."""
+
+    homepage = "https://github.com/scikit-build/moderncmakedomain"
+    pypi = "sphinxcontrib_moderncmakedomain/sphinxcontrib_moderncmakedomain-3.25.0.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("3.27.0", sha256="51e259e91f58d17cc0fac9307fd40106aa59d5acaa741887903fc3660361d1a1")
+    version("3.26.4", sha256="c4a62d586ed1a9baf1790b816fcc04c249dd3ac239bc7c7b79663951a0a463b8")
+    version("3.25.0", sha256="4138e4d3f60e5c4b3982caa10033693bfc1009cdd851766754d5990d9d1e992a")
+
+    depends_on("py-hatchling", type="build")
+    depends_on("py-sphinx@2:", when="@3.27:", type=("build", "run"))
+    depends_on("py-sphinx", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -17,6 +17,10 @@ class PyTensorflowEstimator(Package):
 
     maintainers("aweits")
 
+    version("2.14.0", sha256="622797bf5311f239c2b123364fa360868ae97d16b678413e5e0633241f7d7d5c")
+    version("2.13.0", sha256="4175e9276a1eb8b5e4e876d228e4605871832e7bd8517965d6a47f1481af2c3e")
+    version("2.12.0", sha256="86c75e830c6ba762d0e3cf04c160096930fb12a992e69b3f24674b9f58902063")
+    version("2.11.0", sha256="922f9187de79e8e7f7d7a5b2d6d3aabc81bbbd6ba5f12a4f52967dd302214a43")
     version("2.10", sha256="60df309377cf4e584ca20198f9639beb685d50616395f50770fc0999092d6d85")
     version("2.9.0", sha256="62d7b5a574d9c995542f6cb485ff1c18ad115afd9ec6d63437b2aab227c35ef6")
     version("2.8.0", sha256="58a2c3562ca6491c257e9a4d9bd8825667883257edcdb452181efa691c586b17")
@@ -32,12 +36,17 @@ class PyTensorflowEstimator(Package):
 
     extends("python")
 
+    # tensorflow_estimator/tools/pip_package/setup.py
     depends_on("python@3.7:", when="@2.9:", type=("build", "run"))
 
-    for ver in ["2.10", "2.9", "2.8", "2.7", "2.6"]:
+    for ver in ["2.14", "2.13", "2.12", "2.11", "2.10", "2.9", "2.8", "2.7", "2.6"]:
         depends_on("py-keras@" + ver, when="@" + ver, type=("build", "run"))
 
     for ver in [
+        "2.14",
+        "2.13",
+        "2.12",
+        "2.11",
         "2.10",
         "2.9",
         "2.8",

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -14,6 +14,8 @@ class PyUrllib3(PythonPackage):
     pypi = "urllib3/urllib3-1.25.6.tar.gz"
     git = "https://github.com/urllib3/urllib3.git"
 
+    version("2.1.0", sha256="df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54")
+    version("2.0.7", sha256="c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84")
     version("2.0.6", sha256="b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564")
     version("2.0.5", sha256="13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594")
     version("1.26.12", sha256="3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e")
@@ -27,9 +29,11 @@ class PyUrllib3(PythonPackage):
     version("1.14", sha256="dd4fb13a4ce50b18338c7e4d665b21fd38632c5d4b1d9f1a1379276bd3c08d37")
 
     variant("brotli", default=False, when="@1.25:", description="Add Brotli support")
-    variant("secure", default=False, description="Add SSL/TLS support")
     variant("socks", default=False, when="@1.15:", description="SOCKS and HTTP proxy support")
+    # Historical variant
+    variant("secure", default=False, when="@:2.0", description="Add SSL/TLS support")
 
+    depends_on("python@3.8:", when="@2.1:", type=("build", "run"))
     depends_on("py-hatchling@1.6:1", when="@2:", type="build")
 
     with when("+brotli"):
@@ -38,6 +42,9 @@ class PyUrllib3(PythonPackage):
         # Historical dependencies
         depends_on("py-brotlipy@0.6:", when="@:1.26.8", type=("build", "run"))
 
+    depends_on("py-pysocks@1.5.6,1.5.8:1", when="+socks", type=("build", "run"))
+
+    # Historical dependencies
     with when("+secure"):
         depends_on("py-pyopenssl@17.1:", when="@2:", type=("build", "run"))
         depends_on("py-pyopenssl@0.14:", when="@1", type=("build", "run"))
@@ -47,8 +54,5 @@ class PyUrllib3(PythonPackage):
         depends_on("py-certifi", type=("build", "run"))
         depends_on("py-urllib3-secure-extra", when="@1.26.12:", type=("build", "run"))
 
-    depends_on("py-pysocks@1.5.6,1.5.8:1", when="+socks", type=("build", "run"))
-
-    # Historical dependencies
     depends_on("py-setuptools", when="@1", type="build")
     depends_on("python@3.6:3", when="@1.26.12:1", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-whey-pth/package.py
+++ b/var/spack/repos/builtin/packages/py-whey-pth/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyWheyPth(PythonPackage):
+    """Extension to whey to support .pth files."""
+
+    homepage = "https://github.com/repo-helper/whey-pth"
+    pypi = "whey-pth/whey-pth-0.0.5.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("0.0.5", sha256="cbfcc723bc587ecde44c6b0c83270673d38d88c3fc8f8268a49b21db1fd60747")
+
+    depends_on("py-wheel@0.34.2:", type="build")
+    depends_on("py-setuptools@40.6.0:60,62:", type="build")
+    depends_on("py-dom-toml@0.4.0:", type=("build", "run"))
+    depends_on("py-whey@0.0.15:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-xmlplain/package.py
+++ b/var/spack/repos/builtin/packages/py-xmlplain/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyXmlplain(PythonPackage):
+    """XML as plain object module."""
+
+    homepage = "https://github.com/guillon/xmlplain"
+    pypi = "xmlplain/xmlplain-1.6.0.tar.gz"
+
+    maintainers("LydDeb")
+
+    version("1.6.0", sha256="a9ccfa8ab36e4df1b0580458312501b7ae7625bad3c4fcc1b8c124aad775d8e3")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pyyaml", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/quantum-espresso/gipaw-eccee44.patch
+++ b/var/spack/repos/builtin/packages/quantum-espresso/gipaw-eccee44.patch
@@ -1,0 +1,8 @@
+--- spack-src/external/submodule_commit_hash_records.org	2023-11-15 18:38:47.485317449 -0300
++++ spack-src/external/submodule_commit_hash_records	2023-11-15 18:39:02.661861757 -0300
+@@ -5,4 +5,4 @@
+ 82005cbb65bdf5d32ca021848eec8f19da956a77 mbd
+ f72ab25fa4ea755c1b4b230ae8074b47d5509c70 pw2qmcpack
+ 1d6b187374a2d50b509e5e79e2cab01a79ff7ce1 wannier90
+-f5823521ad8fdd8b8e9e29197eedb354f9b9146d qe-gipaw
++eccee44d3caf1c930fb72ad9c741fbb743eabf45 qe-gipaw

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -20,7 +20,12 @@ class R(AutotoolsPackage):
 
     extendable = True
 
+    license("GPL-2.0-or-later")
+
+    version("4.3.2", sha256="b3f5760ac2eee8026a3f0eefcb25b47723d978038eee8e844762094c860c452a")
+    version("4.3.1", sha256="8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99")
     version("4.3.0", sha256="45dcc48b6cf27d361020f77fde1a39209e997b81402b3663ca1c010056a6a609")
+    version("4.2.3", sha256="55e4a9a6d43be314e2c03d0266a6fa5444afdce50b303bfc3b82b3979516e074")
     version("4.2.2", sha256="0ff62b42ec51afa5713caee7c4fde7a0c45940ba39bef8c5c9487fef0c953df5")
     version("4.2.1", sha256="4d52db486d27848e54613d4ee977ad952ec08ce17807e1b525b10cd4436c643f")
     version("4.2.0", sha256="38eab7719b7ad095388f06aa090c5a2b202791945de60d3e2bb0eab1f5097488")
@@ -118,7 +123,7 @@ class R(AutotoolsPackage):
     @run_after("install")
     def install_rmath(self):
         if "+rmath" in self.spec:
-            with working_dir("src/nmath/standalone"):
+            with working_dir(join_path(self.build_directory, "src", "nmath", "standalone")):
                 make()
                 make("install", parallel=False)
 

--- a/var/spack/repos/builtin/packages/resolve/package.py
+++ b/var/spack/repos/builtin/packages/resolve/package.py
@@ -1,0 +1,62 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Resolve(CMakePackage, CudaPackage, ROCmPackage):
+    """ReSolve is a library of GPU-resident sparse linear solvers. It contains iterative and direct
+    solvers designed to run on NVIDIA and AMD GPUs, as well as CPU devices."""
+
+    homepage = "https://github.com/ORNL/ReSolve"
+    git = "https://github.com/ORNL/ReSolve.git"
+
+    maintainers("cameronrutherford", "pelesh", "ryandanehy", "kswirydo")
+
+    # version("1.0.0", submodules=False, branch="develop")
+    version("develop", submodules=False, branch="develop")
+
+    variant("klu", default=True, description="Use KLU, AMD and COLAMD Libraries from SuiteSparse")
+
+    depends_on("suite-sparse", when="+klu")
+
+    with when("+rocm"):
+        # Need at least 5.6+
+        depends_on("rocsparse@5.6:")
+        depends_on("rocblas@5.6:")
+        depends_on("rocsolver@5.6:")
+
+        # Optional profiling dependecies
+        # Will be controlled by variant in the future
+        # depends_on("roctracer-dev@5.6:")
+        # depends_on("roctracer-dev-api@5.6:")
+        # depends_on("rocprofiler-dev@5.6:")
+
+    def cmake_args(self):
+        args = []
+        spec = self.spec
+
+        args.extend(
+            [self.define("RESOLVE_USE_KLU", "klu"), self.define("RESOLVE_TEST_WITH_BSUB", False)]
+        )
+
+        if "+cuda" in spec:
+            cuda_arch_list = spec.variants["cuda_arch"].value
+            if cuda_arch_list[0] != "none":
+                args.append(self.define("CMAKE_CUDA_ARCHITECTURES", cuda_arch_list))
+            else:
+                args.append(self.define("CMAKE_CUDA_ARCHITECTURES", "70;75;80"))
+            args.append(self.define("RESOLVE_USE_CUDA", True))
+
+        elif "+rocm" in spec:
+            rocm_arch_list = spec.variants["amdgpu_target"].value
+            # `+rocm` conflicts with amdgpu_target == "none"...
+            # if rocm_arch_list[0] == "none":
+            #     rocm_arch_list = "gfx90a"
+            args.append(self.define("GPU_TARGETS", rocm_arch_list))
+            args.append(self.define("AMDGPU_TARGETS", rocm_arch_list))
+            args.append(self.define("RESOLVE_USE_HIP", True))
+
+        return args

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -32,7 +32,12 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
-        "2023-10-24", sha256="f93bf0327329c302ed3feb6adf2e3968f01ec325084a457b2c2dbbf6c4f751a2"
+        "2023-11-27", sha256="fea1c0a6959d46af7478c9c16aac64e76c6dc358da38e2fe8793c15c1cffa8fc"
+    )
+    version(
+        "2023-10-24",
+        sha256="f93bf0327329c302ed3feb6adf2e3968f01ec325084a457b2c2dbbf6c4f751a2",
+        deprecated=True,
     )
     version(
         "2023-05-30", sha256="3dd982841854466820a3902163ad1cf1b3fbab65ed7542456d328f2d1a5373c1"

--- a/var/spack/repos/builtin/packages/simgrid/package.py
+++ b/var/spack/repos/builtin/packages/simgrid/package.py
@@ -19,6 +19,8 @@ class Simgrid(CMakePackage):
 
     maintainers("viniciusvgp")
 
+    version("3.35", sha256="b4570d3de18d319cbd2e16c5a669f90760307673c0cc9940d4d11cfc537e69a8")
+    version("3.34", sha256="161f1c6c0ebb588c587aea6388114307bb31b3c6d5332fa3dc678151f1d0564d")
     version("3.32", sha256="837764eb81562f04e49dd20fbd8518d9eb1f94df00a4e4555e7ec7fa8aa341f0")
     version("3.31", sha256="4b44f77ad40c01cf4e3013957c9cbe39f33dec9304ff0c9c3d9056372ed4c61d")
     version("3.30", sha256="0cad48088c106e72efb42fb423e65d77fc9053cc03d6f3a5ff7ba4c712bb4eb8")

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -19,9 +19,18 @@ class SingularityEos(CMakePackage, CudaPackage):
     maintainers("rbberger")
 
     version("main", branch="main")
+    version("1.8.0", sha256="1f1ec496f714aa23cc7003c88a85bd10d0e53e37659ba7310541248e48a66558")
     version("1.7.0", sha256="ce0825db2e9d079503e98cecf1c565352be696109042b3a0941762b35f36dc49")
-    version("1.6.2", sha256="9c85fca679139a40cc9c72fcaeeca78a407cc1ca184734785236042de364b942")
-    version("1.6.1", sha256="c6d92dfecf9689ffe2df615791c039f7e527e9f47799a862e26fa4e3420fe5d7")
+    version(
+        "1.6.2",
+        sha256="9c85fca679139a40cc9c72fcaeeca78a407cc1ca184734785236042de364b942",
+        deprecated=True,
+    )
+    version(
+        "1.6.1",
+        sha256="c6d92dfecf9689ffe2df615791c039f7e527e9f47799a862e26fa4e3420fe5d7",
+        deprecated=True,
+    )
 
     # build with kokkos, kokkos-kernels for offloading support
     variant("kokkos", default=False, description="Enable kokkos")
@@ -47,20 +56,36 @@ class SingularityEos(CMakePackage, CudaPackage):
     # build the Python bindings
     variant("python", default=False, description="Enable building Python bindings")
 
-    variant("eospac", default=True, description="Pull in EOSPAC")
+    variant("eospac", default=True, description="Enable EOSPAC for table reads")
+
+    variant("hdf5", default=False, description="Enable HDF5 support")
+
+    variant("spiner", default=True, description="Use Spiner")
+
+    variant("closure", default=True, description="Build closure module")
 
     # building/testing/docs
-    depends_on("cmake@3.14:", type="build")
-    depends_on("catch2@2.13.7", type="test")
+    depends_on("cmake@3.19:", type="build")
     depends_on("python@3:", when="+python")
     depends_on("py-pybind11@2.9.1:", when="+python")
+    depends_on("catch2@2.13.7", type="test")
+    depends_on("py-numpy", type="test")
 
     # linear algebra when not using GPUs
-    depends_on("eigen@3.3.8", when="~cuda")
+    depends_on("eigen@3.3.8", when="~kokkos-kernels~cuda")
 
     depends_on("eospac", when="+eospac")
-    depends_on("spiner")
-    depends_on("spiner +kokkos", when="+kokkos")
+
+    depends_on("ports-of-call@1.4.2,1.5.2:", when="@:1.7.0")
+    depends_on("ports-of-call@1.5.2:", when="@1.7.1:")
+    depends_on("ports-of-call@main", when="@main")
+
+    depends_on("spiner +kokkos", when="+kokkos+spiner")
+    depends_on("spiner +hdf5", when="+hdf5+spiner")
+
+    depends_on("spiner@:1.6.0", when="@:1.7.0 +spiner")
+    depends_on("spiner@1.6.1:", when="@1.8.0: +spiner")
+    depends_on("spiner@main", when="@main +spiner")
 
     depends_on("mpark-variant")
     depends_on(
@@ -72,14 +97,18 @@ class SingularityEos(CMakePackage, CudaPackage):
         when="+cuda",
     )
 
+    for _myver, _kver in zip(("@:1.6.2", "@1.7.0:"), ("@3.2:", "@3.3:")):
+        depends_on("kokkos" + _kver, when=_myver + "+kokkos")
+        depends_on("kokkos-kernels" + _kver, when=_myver + "+kokkos-kernels")
+
     # set up kokkos offloading dependencies
     for _flag in ("~cuda", "+cuda", "~openmp", "+openmp"):
-        depends_on("kokkos@3.2: ~shared" + _flag, when="+kokkos" + _flag)
-        depends_on("kokkos-kernels@3.2:" + _flag, when="+kokkos-kernels" + _flag)
+        depends_on("kokkos ~shared" + _flag, when="+kokkos" + _flag)
+        depends_on("kokkos-kernels" + _flag, when="+kokkos-kernels" + _flag)
         depends_on("spiner" + _flag, when="+kokkos" + _flag)
 
     # specfic specs when using GPU/cuda offloading
-    depends_on("kokkos +wrapper+cuda_lambda+cuda_relocatable_device_code", when="+cuda+kokkos")
+    depends_on("kokkos +wrapper+cuda_lambda", when="+cuda+kokkos")
 
     # fix for older spacks
     if spack.version.Version(spack.spack_version) >= spack.version.Version("0.17"):
@@ -92,19 +121,21 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     conflicts("cuda_arch=none", when="+cuda", msg="CUDA architecture is required")
 
-    # NOTE: we can do depends_on("libfoo cppflags='-fPIC -O2'") for compiler options
-
     # these are mirrored in the cmake configuration
     conflicts("+cuda", when="~kokkos")
     conflicts("+openmp", when="~kokkos")
     conflicts("+kokkos-kernels", when="~kokkos")
+    conflicts("+hdf5", when="~spiner")
+
+    conflicts("+fortran", when="~closure")
 
     # NOTE: these are set so that dependencies in downstream projects share
     # common MPI dependence
     for _flag in ("~mpi", "+mpi"):
-        depends_on("hdf5~cxx+hl" + _flag, when=_flag)
+        depends_on("hdf5~cxx+hl" + _flag, when="+hdf5" + _flag)
         depends_on("py-h5py" + _flag, when="@:1.6.2 " + _flag)
 
+    # can be removed once <1.8.0 versions have been removed
     def flag_handler(self, name, flags):
         if name == "fflags":
             if self.spec.satisfies("%cce+fortran"):
@@ -122,8 +153,10 @@ class SingularityEos(CMakePackage, CudaPackage):
             self.define_from_variant("SINGULARITY_USE_KOKKOS", "kokkos"),
             self.define_from_variant("SINGULARITY_USE_KOKKOSKERNELS", "kokkos-kernels"),
             self.define_from_variant("SINGULARITY_USE_FORTRAN", "fortran"),
-            self.define_from_variant("SINGULARITY_BUILD_CLOSURE", "fortran"),
+            self.define_from_variant("SINGULARITY_BUILD_CLOSURE", "closure"),
             self.define_from_variant("SINGULARITY_BUILD_PYTHON", "python"),
+            self.define_from_variant("SINGULARITY_USE_SPINER", "spiner"),
+            self.define_from_variant("SINGULARITY_USE_SPINER_WITH_HDF5", "hdf5"),
             self.define("SINGULARITY_BUILD_TESTS", self.run_tests),
             self.define(
                 "SINGULARITY_BUILD_SESAME2SPINER",
@@ -142,8 +175,8 @@ class SingularityEos(CMakePackage, CudaPackage):
                 ("stellarcollapse" in self.spec.variants["build_extra"].value and self.run_tests),
             ),
             self.define("SINGULARITY_TEST_PYTHON", ("+python" in self.spec and self.run_tests)),
-            self.define("SINGULARITY_USE_HDF5", "^hdf5" in self.spec),
-            self.define("SINGULARITY_USE_EOSPAC", "^eospac" in self.spec),
+            self.define_from_variant("SINGULARITY_USE_HDF5", "hdf5"),
+            self.define_from_variant("SINGULARITY_USE_EOSPAC", "eospac"),
         ]
 
         if "+kokkos+cuda" in self.spec:
@@ -151,34 +184,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
         return args
 
-    # specify the name of the auto-generated cmake cache config
-    @property
-    def cmake_config_fname(self):
-        return "singularity-eos_spackconfig.cmake"
-
-    # generate the pre-configured cmake cache file that reflects the spec options
-    # NOTE: this file isn't replaced if the same spec is already installed -
-    # you may need to uninstall the old spec first
-    @run_after("cmake")
-    def generate_cmake_configuration(self):
-        config_fname = self.cmake_config_fname
-        cmake_config = self.cmake_args()
-
-        with working_dir("cmake-gen", create=True):
-            with open(config_fname, "w") as cmc:
-                for arg in cmake_config:
-                    kt, v = arg.replace("-D", "").split("=")
-                    k, t = kt.split(":")
-                    cmc.write('set({} "{}" CACHE {} "" FORCE)\n'.format(k, v, t))
-            install(config_fname, join_path(prefix, config_fname))
-
-    # run when loaded
-    # NOTE: to use:
-    #   cmake -C $SINGULARITY_SPACK_CMAKE_CONFIG ...
     def setup_run_environment(self, env):
-        env.set(
-            "SINGULARITY_SPACK_CMAKE_CONFIG", os.path.join(self.prefix, self.cmake_config_fname)
-        )
         if os.path.isdir(self.prefix.lib64):
             lib_dir = self.prefix.lib64
         else:

--- a/var/spack/repos/builtin/packages/sirius/fj.patch
+++ b/var/spack/repos/builtin/packages/sirius/fj.patch
@@ -1,0 +1,13 @@
+diff --git a/src/hamiltonian/hamiltonian.cpp b/src/hamiltonian/hamiltonian.cpp
+index 54a91df..ea66ecf 100644
+--- a/src/hamiltonian/hamiltonian.cpp
++++ b/src/hamiltonian/hamiltonian.cpp
+@@ -74,7 +74,7 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__)
+                     for (int j1 = 0; j1 <= j2; j1++) {
+                         int lm1    = type.indexb(j1).lm;
+                         int idxrf1 = type.indexb(j1).idxrf;
+-                        hmt_[ia](j1, j2) = atom.radial_integrals_sum_L3<spin_block_t::nm>(idxrf1, idxrf2,
++                        hmt_[ia](j1, j2) = atom.template radial_integrals_sum_L3<spin_block_t::nm>(idxrf1, idxrf2,
+                                                                                 type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                         hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
+                     }

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -187,6 +187,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("umpire+rocm~device_alloc", when="+rocm")
 
     patch("mpi_datatypes.patch", when="@:7.2.6")
+    patch("fj.patch", when="@7.3.2: %fj")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/tfel/package.py
+++ b/var/spack/repos/builtin/packages/tfel/package.py
@@ -34,6 +34,8 @@ class Tfel(CMakePackage):
 
     # development branches
     version("master", branch="master")
+    version("rliv-4.2", branch="rliv-4.2")
+    version("rliv-4.1", branch="rliv-4.1")
     version("rliv-4.0", branch="rliv-4.0")
     version("rliv-3.4", branch="rliv-3.4")
     version("rliv-3.3", branch="rliv-3.3")
@@ -45,18 +47,29 @@ class Tfel(CMakePackage):
 
     # released version
     version(
-        "4.0.0",
-        sha256="7a0c32c8a9cd2fd65cbcb54fff802f303665d7cba5d46f92ff3d55f057c92845",
+        "4.2.0",
+        sha256="cf8a309c4d19a8e36232f8540ff28aa0d6285645f8dfb1ac57dd481ba3453e02",
         preferred=True,
     )
+    version("4.1.1", sha256="e0f229094e88a2d6c6a78ae60fa77d2f4b8294e9d810c21fd7df61004bf29a33")
+    version("4.1.0", sha256="7505c41da9df5fb3c281651ff29b58a18fd4d91b92f839322f0267269c5f1375")
+    version("4.0.2", sha256="f5c8a285e00f334fd3e1a95f9a393fed393990ee827dae3766da1decfaa1074e")
+    version("4.0.1", sha256="f54741b7e654cb12511ca68c6494a4789ba41b5ada4cd345ad2bc7da631309d1")
+    version("4.0.0", sha256="7a0c32c8a9cd2fd65cbcb54fff802f303665d7cba5d46f92ff3d55f057c92845")
+    version("3.4.5", sha256="8092db9571df3d256a56ff269691a871a68b9b19ce163461531879a36e05a100")
+    version("3.4.4", sha256="a518a7a761fec6c92fab6dc9df5694c28aad2554c7c649d707dfdc71fe93d2ca")
     version("3.4.3", sha256="e58515effe57d473385fe0b592d9e1d1286c0901496c61268d9efd92a2550849")
     version("3.4.2", sha256="f39e65b2282fd3b108081388f161ba662407b192fed68fafe324c7528026a202")
     version("3.4.1", sha256="04cd4257e39e1b05e02b12ad941106fff4d439934bdfe6e950c08bab23e2a4ba")
     version("3.4.0", sha256="176feb4c1726d0f21f4c656b20620dce6f99ab7f5f09a66905aeb643a316bbc1")
+    version("3.3.4", sha256="3829e0b07520a14b17a8e75f879683a0d97b04b897aeb3ad0dd96dc94c0fcd6b")
     version("3.3.3", sha256="5a1fb43a8086e594e0a7234c1f227e6e005d384fd84affe3acadccb68fe2bbf6")
     version("3.3.2", sha256="17127ffdf92367c10041258f70a88ac3dcb0a7d89c1766a6aa1ebaeb4d03d55d")
     version("3.3.1", sha256="ad07329c25874832fbacc999b5f88d9b9ab84415bc897a6f3cae5b4afcd7661f")
     version("3.3.0", sha256="884ad68b0fbbededc3a602d559433c24114ae4534dc9f0a759d31ca3589dace0")
+    version("3.2.9", sha256="4ee26f2b5db24dc10113100ae0165cbbe8c7960c99c0e64ec96410788774aa54")
+    version("3.2.8", sha256="8bc3db975a87c3f0da3a857ab45cd237ee02f4ab35094a7db28b01d92676a78c")
+    version("3.2.7", sha256="05a055a955dd52f0b2dbf9d518a86c58805b2b63f3766268d72cacd6126c187d")
     version("3.2.6", sha256="ae80c76d92aeae207e307436aed32bbaed913a437ae57b5ee128ce4f543f20a9")
     version("3.2.5", sha256="194e799ca8d2f7ffea25aa3842c48cfc12850c252d851ce03941b5e3ae533b21")
     version("3.2.4", sha256="e7ac7e61fb3e02301285885bb3dc81ca1b09bd6e2929d15c755555d66088fe33")
@@ -64,6 +77,8 @@ class Tfel(CMakePackage):
     version("3.2.2", sha256="69b01ae0d1f9140b619aaa9135948284ff40d4654672c335e55ab4934c02eb43")
     version("3.2.1", sha256="12786480524a7fe86889120fb334fa00211dfd44ad5ec71e2279e7adf1ddc807")
     version("3.2.0", sha256="089d79745e9f267a2bd03dcd8841d484e668bd27f5cc2ff7453634cb39016848")
+    version("3.1.12", sha256="770aa4680063ddd7be4f735ed1ec9402e83502d1ceb688c79cdba27490b7bf98")
+    version("3.1.11", sha256="578e3463db029bfed7b24bfa1226394e6998cc95959b46246ab9bf5cfb6d65f0")
     version("3.1.10", sha256="635a2507f139bb6d893e0a7bb223cd1d9ddab5dfddee179a3b2e9f8b0b63e065")
     version("3.1.9", sha256="8aeb020beddd125c207271e01d3e7d3985a91268dbf0bbc6132d217cc72b12a8")
     version("3.1.8", sha256="8c99ef80a27b3e791d78de2ceb1111396989942424697eccbc886edc3983163f")
@@ -75,6 +90,8 @@ class Tfel(CMakePackage):
     version("3.1.2", sha256="2eaa191f0699031786d8845ac769320a42c7e035991d82b3738289886006bfba")
     version("3.1.1", sha256="a4c0c21c6c22752cc90c82295a6bafe637b3395736c66fcdfcfe4aeccb5be7af")
     version("3.1.0", sha256="dd67b400b5f157aef503aa3615b9bf6b52333876a29e75966f94ee3f79ab37ad")
+    version("3.0.12", sha256="f7dae9e5a00c721445b3167ec7bc71747bab047ddb36103f232b72d3e4d3cd00")
+    version("3.0.11", sha256="3d2d249534563887d301f6be5c4c2e4be33258b9d712d550d4c71271b764cc2d")
     version("3.0.10", sha256="1604f22948b4af6ef84839d97909f7011ce614254e1a6de092ddc61832f7d343")
     version("3.0.9", sha256="461dbb9e78fb6de9eaff21e387f5441020a077bba51d47b6510f11312e5ee333")
     version("3.0.8", sha256="3639f11d14278e20814e8673e097d26161e26117128289516be5b1b1e1387e57")
@@ -110,17 +127,11 @@ class Tfel(CMakePackage):
     variant("comsol", default=True, description="Enables comsol interface")
     variant("diana-fea", default=True, description="Enables DIANA-FEA interface")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="The build type to build",
-        values=("Debug", "Release"),
-    )
-
     depends_on("java", when="+java")
     depends_on("python", when="+python", type=("build", "link", "run"))
     depends_on("python", when="+python_bindings", type=("build", "link", "run"))
     depends_on("py-numpy", when="+python_bindings", type=("build", "link", "run"))
+
     # As boost+py has py runtime dependency, boost+py needs types link and run as well:
     depends_on(
         "boost+python+numpy+exception+container",

--- a/var/spack/repos/builtin/packages/verible/package.py
+++ b/var/spack/repos/builtin/packages/verible/package.py
@@ -1,0 +1,56 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Verible(Package):
+    """The Verible project’s main mission is to parse SystemVerilog
+    (IEEE 1800-2017) (as standardized in the [SV-LRM]) for a wide variety of
+    applications, including developer tools.
+
+    It was born out of a need to parse un-preprocessed source files, which is
+    suitable for single-file applications like style-linting and formatting.
+    In doing so, it can be adapted to parse preprocessed source files, which
+    is what real compilers and toolchains require.
+
+    The spirit of the project is that no-one should ever have to develop a
+    SystemVerilog parser for their own application, because developing a
+    standard-compliant parser is an enormous task due to the syntactic
+    complexity of the language. Verible’s parser is also regularly tested
+    against an ever-growing suite of (tool-independent) language compliance
+    tests at https://symbiflow.github.io/sv-tests/.
+
+    A lesser (but notable) objective is that the language-agnostic components
+    of Verible be usable for rapidly developing language support tools for
+    other languages."""
+
+    homepage = "https://chipsalliance.github.io/verible"
+    git = "https://github.com/chipsalliance/verible.git"
+
+    version("master", branch="master")
+
+    version(
+        "0.0.3430",
+        sha256="580ab39c82da9f67523658c0bb0859e2b6c662f7c06855859f476eeedd92a7e0",
+        url="https://github.com/chipsalliance/verible/archive/refs/tags/v0.0-3430-g060bde0f.tar.gz",
+    )
+    version(
+        "0.0.3428",
+        sha256="2b83497662b890f875bfe859175aa8e4b87db6e6a177ad08a0694002b8767cb0",
+        url="https://github.com/chipsalliance/verible/archive/refs/tags/v0.0-3428-gcfcbb82b.tar.gz",
+    )
+
+    maintainers("davekeeshan")
+
+    depends_on("flex", type="build")
+    depends_on("bison", type="build")
+    depends_on("bazel", type="build")
+
+    conflicts("%gcc@:8", msg="Only works with gcc9 and above")
+
+    def install(self, spec, prefix):
+        bazel("build", "-c", "opt", "//...")
+        bazel("run", "-c", "opt", ":install", "--", prefix.bin)

--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -70,10 +70,12 @@ class Verilator(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("help2man", type="build")
     depends_on("bison", type="build")
-    depends_on("flex", type="build")
+    depends_on("flex")
     depends_on("ccache", type=("build", "run"), when="@5.018:")
     depends_on("perl", type=("build", "run"))
     depends_on("bash", type="build")
+
+    conflicts("%gcc@:6", msg="C++14 support required")
 
     # we need to fix the CXX and LINK paths, as they point to the spack
     # wrapper scripts which aren't usable without spack

--- a/var/spack/repos/builtin/packages/vtk-m/mr3160-rocthrust-fix.patch
+++ b/var/spack/repos/builtin/packages/vtk-m/mr3160-rocthrust-fix.patch
@@ -1,0 +1,74 @@
+From c9ec6ae6a62b9bd257e727e999987ef31384e3ac Mon Sep 17 00:00:00 2001
+From: Vicente Adolfo Bolea Sanchez <vicente.bolea@kitware.com>
+Date: Thu, 30 Nov 2023 15:55:32 -0500
+Subject: [PATCH] kokkos: let link vtkm_cont to roc::rocthrust
+
+Also reorder the declarion of the option VTKm_ENABLE_KOKKOS_THRUST
+to be set before calling VTKmDeviceAdapters.
+---
+ CMake/VTKmDeviceAdapters.cmake           |  5 +----
+ CMakeLists.txt                           | 10 +++++-----
+ vtkm/cont/kokkos/internal/CMakeLists.txt |  3 +++
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/CMake/VTKmDeviceAdapters.cmake b/CMake/VTKmDeviceAdapters.cmake
+index fb13d0bf85..7b8bf2df9b 100644
+--- a/CMake/VTKmDeviceAdapters.cmake
++++ b/CMake/VTKmDeviceAdapters.cmake
+@@ -360,10 +360,7 @@ if(VTKm_ENABLE_KOKKOS AND NOT TARGET vtkm_kokkos)
+ 
+     # Make sure rocthrust is available if requested
+     if(VTKm_ENABLE_KOKKOS_THRUST)
+-      find_package(rocthrust)
+-      if(NOT rocthrust_FOUND)
+-        message(FATAL_ERROR "rocthrust not found. Please set VTKm_ENABLE_KOKKOS_THRUST to OFF.")
+-      endif()
++      find_package(rocthrust REQUIRED CONFIG)
+     endif()
+   endif()
+ 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 39a9b3bc09..d8204114c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,6 +191,11 @@ vtkm_option(VTKm_OVERRIDE_CTEST_TIMEOUT "Disable default ctest timeout" OFF)
+ # VTKm_ENABLE_MPI=ON.
+ cmake_dependent_option(VTKm_ENABLE_GPU_MPI "Enable GPU AWARE MPI support" OFF "VTKm_ENABLE_MPI" OFF)
+ 
++# By default: Set VTKm_ENABLE_KOKKOS_THRUST to ON if VTKm_ENABLE_KOKKOS is ON, otherwise
++# disable it (or if the user explicitly turns this option OFF)
++cmake_dependent_option(VTKm_ENABLE_KOKKOS_THRUST "Enable Kokkos thrust support (only valid with CUDA and HIP)"
++  ON "VTKm_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP" OFF)
++
+ mark_as_advanced(
+   VTKm_ENABLE_LOGGING
+   VTKm_NO_ASSERT
+@@ -232,11 +237,6 @@ include(VTKmBuildType)
+ # Include the vtk-m wrappers
+ include(VTKmWrappers)
+ 
+-# By default: Set VTKm_ENABLE_KOKKOS_THRUST to ON if VTKm_ENABLE_KOKKOS is ON, otherwise
+-# disable it (or if the user explicitly turns this option OFF)
+-cmake_dependent_option(VTKm_ENABLE_KOKKOS_THRUST "Enable Kokkos thrust support (only valid with CUDA and HIP)"
+-  ON "VTKm_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP" OFF)
+-
+ # Create vtkm_compiler_flags library. This is an interface library that
+ # holds all the C++ compiler flags that are needed for consumers and
+ # when building VTK-m.
+diff --git a/vtkm/cont/kokkos/internal/CMakeLists.txt b/vtkm/cont/kokkos/internal/CMakeLists.txt
+index 9f924b0f4b..9b731c9fdd 100644
+--- a/vtkm/cont/kokkos/internal/CMakeLists.txt
++++ b/vtkm/cont/kokkos/internal/CMakeLists.txt
+@@ -34,6 +34,9 @@ if (TARGET vtkm_kokkos)
+   elseif(TARGET vtkm_kokkos_hip)
+     set_source_files_properties(${sources} TARGET_DIRECTORY vtkm_cont PROPERTIES LANGUAGE HIP)
+     kokkos_compilation(SOURCE ${sources})
++    if (VTKm_ENABLE_KOKKOS_THRUST)
++      target_link_libraries(vtkm_cont INTERFACE roc::rocthrust)
++    endif()
+   endif()
+ 
+ else()
+-- 
+2.35.3
+

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -29,12 +29,12 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("release", branch="release")
-    version("2.1.0-rc2", sha256="94631fff9f668f40c9c797f03cf32a0d22d57111e309b1e8133c2a3f292b4af1")
     version(
-        "2.0.0",
-        sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3",
+        "2.1.0",
+        sha256="9cf3522b6dc0675281a1a16839464ebd1cc5f9c08c20eabee1719b3bcfdcf41f",
         preferred=True,
     )
+    version("2.0.0", sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3")
     version("1.9.0", sha256="12355dea1a24ec32767260068037adeb71abb3df2f9f920c92ce483f35ff46e4")
     version("1.8.0", sha256="fcedee6e8f4ac50dde56e8c533d48604dbfb663cea1561542a837e8e80ba8768")
     version("1.7.1", sha256="7ea3e945110b837a8c2ba49b41e45e1a1d8d0029bb472b291f7674871dbbbb63")
@@ -123,6 +123,8 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
         )
 
     depends_on("hip@3.7:", when="+rocm")
+    # CUDA thrust is already include in the CUDA pkg
+    depends_on("rocthrust", when="@2.1: +kokkos+rocm")
 
     # The rocm variant is only valid options for >= 1.7. It would be better if
     # this could be expressed as a when clause to disable the rocm variant,
@@ -146,6 +148,10 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     # VTK-M PR#2972
     # https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/2972
     patch("vtkm-cuda-swap-conflict-pr2972.patch", when="@1.9 +cuda ^cuda@12:")
+
+    # VTK-M PR#3160
+    # https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/3160
+    patch("mr3160-rocthrust-fix.patch", when="@2.1:")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/win-wdk/package.py
+++ b/var/spack/repos/builtin/packages/win-wdk/package.py
@@ -133,7 +133,7 @@ class WinWdk(Package):
             except ProcessError as pe:
                 reg = winreg.WindowsRegistryView(
                     "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots",
-                    root_key=spack.util.windows_registry.HKEY_LOCAL_MACHINE,
+                    root_key=spack.util.windows_registry.HKEY.HKEY_LOCAL_MACHINE,
                 )
                 if not reg:
                     # No Kits are available, failure was genuine

--- a/var/spack/repos/builtin/packages/xcdf/package.py
+++ b/var/spack/repos/builtin/packages/xcdf/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Xcdf(CMakePackage):
+    """Binary data format designed to store data fields with user-specified accuracy."""
+
+    homepage = "https://github.com/jimbraun/XCDF"
+    url = "https://github.com/jimbraun/XCDF/archive/refs/tags/v3.00.03.tar.gz"
+
+    license("BSD-2-Clause")
+
+    version("3.00.03", sha256="4e445a2fea947ba14505d08177c8d5b55856f8411f28de1fe4d4c00f6824b711")
+
+    patch("remove_python_support.patch")

--- a/var/spack/repos/builtin/packages/xcdf/remove_python_support.patch
+++ b/var/spack/repos/builtin/packages/xcdf/remove_python_support.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3270f47..e5648d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,7 +45,6 @@ SET (XCDF_PATCH_VERSION  1 CACHE STRING "Patch number")
+ # ------------------------------------------------------------------------------
+ SET (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+ INCLUDE (Utility)
+-INCLUDE (Python)
+ 
+ INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR}/include)
+ INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR}/include/utility)

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -28,6 +28,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.2.0", sha256="912a4248bbf2e2e84cf3e36f2ae8483bee6b32d2eaa4406dd2100ad660c9bfc6")
     version("1.1.0", sha256="f0be81afe643adc2452055e5485f09cdb509a8fdd5a4ec5547b0c31dd22b4830")
     version("1.0.7", sha256="54f5c87e86c12e872e615fbc9540610ae38053f844f1e75d1e753724fea85c64")
     version("1.0.6", sha256="8075e1349d900985f5b5a81159561568720f21c5f011c43557c46f5bbedd0661")

--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -16,6 +16,7 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
 
     maintainers("haampie")
 
+    version("2.1.5", sha256="3f6576971397b379d4205ae5451ff5a68edf6c103b2f03c4188ed7075fbb5f04")
     version("2.1.4", sha256="a0293475e6a44a3f6c045229fe50f69dc0eebc62a42405a51f19d46a5541e77a")
     version(
         "2.1.3",


### PR DESCRIPTION
- Fix an issue with deconcretization/reconcretization of environments (#41294)
- CMake: add v3.27.9 (#41301)
- unit tests: use --verbose to see order on macos (#41314)
- cuda: fix compiler conflicts (#41304)
- fmt: Add git attribute (#41293)
- Simplify _create_mock_configuration_scopes (#41318)
- dla-future: Add conflicts for compilation issues pre-0.3.1 (#41317)
- intel-oneapi-ccl 2021.11.1: added new version to packages (#41300)
- Add gipaw when building quantum-espresso with cmake (#41142)
- Refactor a test to not use the "working_env" fixture (#41308)
- kokkos: add v4.2.00 (#41203)
- py-pygeos: add v0.14 (#41248)
- py-numba: add v0.58.1 (#41262)
- MFEM: add mpi link dir (#41337)
- SEACAS: new release (#41273)
- tests: fix issue with os.environ binding (#41342)
- argparse: make scope choices lazy s.t. validation in tests works (#41344)
- Fix a typo in an integrity constraint (#41334)
- use double quotes where spack style finds errors (#41349)
- simgrid: add v3.34 and v3.35 (#41340)
- Update SIRIUS version for CP2K master (#41264)
- --scope: lazy defaults (#41353)
- test_variant_propagation_with_unify_false: missing fixture (#41345)
- tests: fix side effects of default_config fixture (#41361)
- tests: add missing mutable db (#41359)
- reuse concretization: allow externals from remote when locally configured (#35975)
- developer tools stack try 2 (#40921)
- GDAL: add v3.8.1 (#41365)
- py-tensorflow-estimator: add new versions (#41364)
- Fix issue with latest mypy (#41363)
- acfl: truncate version version number (#41354)
- perl-parse-yapp: add new package with version 1.21 (#41348)
- perl-carp-assert: add new package with version 0.22 (#41347)
- Move compiler renaming to filter_compiler_wrappers (#41336)
- Fix flex for build and link, limit gcc to 7 or greater (#41335)
- Singularity-EOS update (#41333)
- trilinos: new pytrilinos2 variant (#40615)
- tests: use temporary_store (#41369)
- mochi-thallium: adding a few new versions (#41323)
- mochi-margo: added version 0.15.0 (#41319)
- r: add license and missing versions and fix rmath build directory (#41260)
- [intel-mpi] deprecation (#41322)
- Add support for new versions of TFEL and MGIS (#41357)
- vtk-m: bump vtk-m 2.1.0 (#41351)
- build(deps): bump mypy from 1.6.1 to 1.7.1 in /.github/workflows/style (#41242)
- build(deps): bump docker/metadata-action from 5.0.0 to 5.2.0 (#41371)
- build(deps): bump mypy from 1.7.0 to 1.7.1 in /lib/spack/docs (#41243)
- build(deps): bump sphinx-rtd-theme in /lib/spack/docs (#41305)
- build(deps): bump pygments from 2.17.1 to 2.17.2 in /lib/spack/docs (#41212)
- py-mpi4py: fix build with Apple Clang (#41362)
- py-beartype: new package with versions 0.15.0 and 0.16.2 (#39759)
- Update py-cylc-flow (add version 8.2.3) (#41209)
- py-urllib3: add 2.1.0 and 2.0.7 (#41358)
- petsc, py-petsc4py: add v3.20.2 (#41366)
- py-sphinx-removed-in: new package (#41325)
- py-sphinx-jinja2-compat: new package (#41310)
- [add] py-autodocsumm: new package (#41309)
- py-requests-file: new package (#41328)
- py-xmlplain: new package (#41324)
- LAMMPS updates (#40879)
- py-mahotas: new package (#41329)
- py-cma: new package (#41326)
- build(deps): bump docutils from 0.18.1 to 0.20.1 in /lib/spack/docs (#38174)
- eccodes: add v2.32.0, v2.31.0 (#40770)
- dftbplus: Update and add upstream maintainer (#33243)
- Various FleCSI updates (#41068)
- py-keras: add v3.0.0 (#41356)
- verible: add new package (#41270)
- py-pyglet: version bump (#41082)
- amrex: add v23.12 (#41385)
- Libfabric: Introduce OPX provider conflict for v1.20.0 (#41343)
- removed cmake build version pointing to fork (#41368)
- MET fixes for 11.1 and HDF4 support (#41372)
- Add PhotoSpline. (#41374)
- Add XCDF. (#41379)
- Fix curl install using Intel compilers (#41380)
- Add MUMPS versions 5.6.0, 5.6.1 and 5.6.2 (#41386)
- resolve: add package with cuda and rocm support (#40871)
- Allow exago to use hiop@develop past v1.0.1 (#41384)
- Windows: fix kit base path and reference to windows registry key (#41388)
- PythonPackage: type hints (#40539)
- ci.py: fix missing import (#41391)
- zlib-ng: add v2.1.5 (#41402)
- direnv: add v2.33.0 (#41397)
- Add EGL support to ParaView and Glew (#39800)
- A few changes to quantum-espresso (#41225)
- [intel] deprecate all versions (#41412)
- Updating the LBANN, Hydrogen, and DiHydrogen recipes (#41390)
- arrow: add versions up to v14.0.1 (#41424)
- build(deps): bump docker/metadata-action from 5.2.0 to 5.3.0 (#41423)
- extensions: improve docs, fix unit-tests (#41425)
- openblas: fix macOS build when using XCode 15 or newer (#41420)
- cprnc: update sha256 for github artifacts (#41418)
- hpctoolkit: add conflict for recent intel-xed (#41413)
- bugfix: sort variants in `spack info --variants-by-name` (#41389)
- openfoam-org: fix for being able to build manually checked out repository (#41000)
- spack buildcache check: use same interface as push (#41378)
- py-sphinxcontrib-moderncmakedomain: add new package (#41331)
- sirius: fix build error with Fujitsu compiler (#41101)
- documentation: add instructions on how to use external opengl  (#40987)
- libdap4: add explicit RPC dependency (#40019)
- py-sphinx: add versions 7.2.4, 7.2.5 and 7.2.6 (#41411)
- Update versions of GFE packages (#41429)
- MFEM: Add a patch to fix the `+gslib+shared+miniapps` build (#41399)
- Add maintainers to fdb, eckit, ecbuild, metkit, eccodes (#41433)
- py-gidgetlab: add new package (#41338)
- py-gidgethub: add new package (#41286)
- julia: fix LLVM paches hashes (#41410)
- CDash: Spack dumps stage errors to configure phase (#41436)
