### PR TITLE
readonly patch reapplied

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -155,7 +155,16 @@ class ConfigScope:
             with open(filename, "w") as f:
                 syaml.dump_config(data, stream=f, default_flow_style=False)
         except (syaml.SpackYAMLError, IOError) as e:
-            raise ConfigFileError(f"cannot write to '{filename}'") from e
+            if hasattr(e, 'errno') and e.errno in [13, 30]:
+                tty.warn("Ignoring write error on readonly %s" % filename)
+                # for the moment, stubbing this out because spack is trying to
+                # update the bootstrap.yaml in the bootstrap area *all* *the* *time*
+                # (with what is already in there) which keeps you from using
+                # a bootstrap area in cvmfs...  Really need to fix upstream
+                # from here to not update the config file if its already right...
+            else:
+                raise ConfigFileError(f"cannot write to '{filename}'") from e
+
 
     def clear(self):
         """Empty cached config information."""
@@ -285,7 +294,16 @@ class SingleFileScope(ConfigScope):
             rename(tmp, self.path)
 
         except (syaml.SpackYAMLError, IOError) as e:
-            raise ConfigFileError(f"cannot write to config file {str(e)}") from e
+            if hasattr(e, 'errno') and e.errno in [13, 30]:
+                tty.warn("Ignoring write error on readonly %s" % filename)
+                # for the moment, stubbing this out because spack is trying to
+                # update the bootstrap.yaml in the bootstrap area *all* *the* *time*
+                # (with what is already in there) which keeps you from using
+                # a bootstrap area in cvmfs...  Really need to fix upstream
+                # from here to not update the config file if its already right...
+            else:
+                raise ConfigFileError(f"cannot write to '{filename}'") from e
+
 
     def __repr__(self):
         return "<SingleFileScope: %s: %s>" % (self.name, self.path)


### PR DESCRIPTION
Making this a pull request on 0.21.0-fermi-mu2e as well, so we can get our class examples working for mu2e again...