### PR TITLE
ups table file generation update

### DIFF
--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -7,8 +7,6 @@ from typing import Callable, Dict
 
 import spack.cmd.modules.lmod
 import spack.cmd.modules.tcl
-import spack.cmd.modules.ups_table
-import spack.cmd.modules.ups_version
 
 description = "generate/manage module files"
 section = "user environment"
@@ -22,8 +20,6 @@ def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="module_command")
     spack.cmd.modules.lmod.add_command(sp, _subcommands)
     spack.cmd.modules.tcl.add_command(sp, _subcommands)
-    spack.cmd.modules.ups_table.add_command(sp, _subcommands)
-    spack.cmd.modules.ups_version.add_command(sp, _subcommands)
 
 
 def module(parser, args):

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -18,14 +18,15 @@ FLAVOR=ANY
 {%endif%}
 
 {%if  upscompquals  %}
-QUALIFIERS="{{upscompquals}}:{{upsdebugquals}}"
+QUALIFIERS="{{upscompquals}}:{{upsdebugquals}}{%if "experiment" in spec.variants%}:{{spec.variants["experiment"]|replace('=','_')}}{%endif%}"
 {%else%}
-QUALIFIERS=""
+QUALIFIERS="{%if "experiment" in spec.variants%}{{spec.variants["experiment"]|replace('=','_')}}{%endif%}"
 {%endif%}
 
-
-{%set spack_root = os.environ['SPACK_ROOT'] %}
+{%set spack_root = os.path.realpath(os.environ['SPACK_ROOT']) %}
 {%set install_root = spack_root[0:spack_root.find('/spack/')] %}
+# prefix: {{spec.prefix}}
+# install_root: {{install_root}}
 {%if spec.prefix.startswith(install_root) %}
 
 Action = setup
@@ -33,7 +34,7 @@ Action = setup
     setupEnv()
 {% for package in spec._dependencies.keys() %}
    {% if spec[package].prefix.startswith(install_root) %}
-    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@=')[0] == package%}{{c.split('@=')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+    setupRequired({{package|replace("-","_")}} {{spec[package].version}} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
    {% endif %}
 {% endfor %}
 

--- a/share/spack/templates/modules/modulefile.ups_version
+++ b/share/spack/templates/modules/modulefile.ups_version
@@ -38,15 +38,17 @@ VERSION = {{spec.version}}
 {% elif (spec.compiler|string).find('clang@5.0.1')==0 %}{%set upscompquals = 'c2' %}
 {% endif %}
 
+# spec.variants[experiment]: {%if "experiment" in spec.variants%}:{{spec.variants["experiment"]}}{%endif%}
+
 {% if (spec.compiler_flags|string).find('-g')>0 %}{%set upsdebugquals="debug"%}
 {%else%}{%set upsdebugquals="opt"%}
 {%endif%}
 
 FLAVOR="{{upsos}}{{upsbits}}{{upsrelglibc}}"
 {%if  upscompquals  %}
-QUALIFIERS="{{upscompquals}}:{{upsdebugquals}}"
+QUALIFIERS="{{upscompquals}}:{{upsdebugquals}}{%if "experiment" in spec.variants%}:{{spec.variants["experiment"]|replace('=','_')}}{%endif%}"
 {%else%}
-QUALIFIERS=""
+QUALIFIERS="{%if "experiment" in spec.variants%}:{{spec.variants["experiment"]|replace('=','_')}}{%endif%}"
 {%endif%}
 
   DECLARER = {{username}}


### PR DESCRIPTION
Minor fixups to ups table generation; 
* use realpath(path) for locality check. 
* include experiment=whatever variants as qualifer experiment_whatever
* add back into spack module command list.
* fix dependency version extraction