### PR TITLE
make SPACK_PYTHON work again

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -I
+#!/bin/sh
 # -*- python -*-
 # Fermi change, just use system python3, insulated 
 # avoid experiment python builds, PYTHONPATH, etc.
@@ -14,11 +14,11 @@
 # See https://stackoverflow.com/a/47886254
 """:"
 # prefer SPACK_PYTHON environment variable, python3, python, then python2
-SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
+SPACK_PREFERRED_PYTHONS="/usr/bin/python3 python3 python python2 /usr/libexec/platform-python"
 for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
         export SPACK_PYTHON="$(command -v "$cmd")"
-        exec "${SPACK_PYTHON}" "$0" "$@"
+        exec "${SPACK_PYTHON}" -E "$0" "$@"
     fi
 done
 

--- a/bin/spack
+++ b/bin/spack
@@ -1,8 +1,5 @@
 #!/bin/sh
 # -*- python -*-
-# Fermi change, just use system python3, insulated 
-# avoid experiment python builds, PYTHONPATH, etc.
-#!/bin/sh
 #
 # Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.


### PR DESCRIPTION
Go back to bash-python startup, but include -E to defend against PYTHONPATH/PYTHONHOME woes
and prefer specifically /usr/bin/python3.
