### PR TITLE
use bash-python startup,

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -11,11 +11,11 @@
 # See https://stackoverflow.com/a/47886254
 """:"
 # prefer SPACK_PYTHON environment variable, python3, python, then python2
-SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
+SPACK_PREFERRED_PYTHONS="/usr/bin/python3 python3 python python2 /usr/libexec/platform-python"
 for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
         export SPACK_PYTHON="$(command -v "$cmd")"
-        exec "${SPACK_PYTHON}" "$0" "$@"
+        exec "${SPACK_PYTHON}" -E "$0" "$@"
     fi
 done
 


### PR DESCRIPTION
… but prefer /usr/bin/python3 and include -E to defend against PYTHONHOME/PYHONPATH
