### PR TITLE
fix py-hatch-vcs not getting put in PYTHONPATH

### DIFF
--- a/var/spack/repos/builtin/packages/py-hatch-vcs/package.py
+++ b/var/spack/repos/builtin/packages/py-hatch-vcs/package.py
@@ -18,3 +18,5 @@ class PyHatchVcs(PythonPackage):
     depends_on("py-hatchling@1.1:", when="@0.3:", type=("build", "run"))
     depends_on("py-hatchling@0.21.0:", type=("build", "run"))
     depends_on("py-setuptools-scm@6.4.0:", type=("build", "run"))
+    depends_on("python")
+    extends("python")


### PR DESCRIPTION
Pretty simple; the python setup_dependent_xxx() methods only add things that  *directly* depend on/extend python to the PYTHONPATH... 