### PR TITLE
package recipe updates from NOvA

### DIFF
--- a/var/spack/repos/builtin/packages/py-oracledb/package.py
+++ b/var/spack/repos/builtin/packages/py-oracledb/package.py
@@ -16,11 +16,17 @@ class PyOracledb(PythonPackage):
 
     license("Apache-2.0")
 
-    version("1.2.2", sha256="dd9f63084e44642b484a46b2fcfb4fc921f39facf494a1bab00628fa6409f4fc")
+    version("2.4.1", sha256="bd5976bef0e466e0f9d1b9f6531fb5b8171dc8534717ccb04b26e680b6c7571d")
+    version("2.3.0", sha256="b9b0c4ec280b10063e6789bed23ddc2435ae98569ebe64e0b9a270780b9103d5")
+    version("1.4.2", sha256="e28ed9046f2735dc2dd5bbcdf3667f284e384e0ec7eed3eeb3798fa8a7d47e36")
+
+    depends_on("python@3.8:3.13", when="@2.4:")
+    depends_on("python@3.8:3.12", when="@2.0:2.3")
+    depends_on("python@3.8:3.11", when="@:1.4")
 
     depends_on("py-setuptools@40.6.0:", type="build")
     depends_on("py-cryptography@3.2.1:", type=("build", "run"))
-    depends_on("py-cython", type="build")
+    depends_on("py-cython@3:", type="build")
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("oracle-instant-client", type="run", when="impl=thick")
 

--- a/var/spack/repos/builtin/packages/xsd/package.py
+++ b/var/spack/repos/builtin/packages/xsd/package.py
@@ -21,6 +21,13 @@ class Xsd(MakefilePackage):
     depends_on("xerces-c")
     depends_on("libtool", type="build")
 
+    variant(
+        "cxxstd",
+        default="14", values=("98", "11", "14"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+    )
+
     patch(
         "https://git.codesynthesis.com/cgit/libxsd-frontend/libxsd-frontend/patch/?id=5029f8665190879285787a9dcdaf5f997cadd2e2",
         sha256="d57e0aed8784d2b947983209b6513c81ac593c9936c3d7b809b4cd60d4c28607",
@@ -33,6 +40,8 @@ class Xsd(MakefilePackage):
     def setup_build_environment(self, env):
         xercesc_lib_flags = self.spec["xerces-c"].libs.search_flags
         env.append_flags("LDFLAGS", xercesc_lib_flags)
+        cxxstdflag = "cxx{0}_flag".format(self.spec.variants["cxxstd"].value)
+        env.append_flags("CXXFLAGS", getattr(self.compiler, cxxstdflag))
 
     def url_for_version(self, version):
         url = "https://www.codesynthesis.com/download/xsd/{0}/xsd-{1}+dep.tar.bz2"


### PR DESCRIPTION
propagating package recipe updates to NOvA packages. the `py-oracledb` recipe updates were merged into mainline spack in https://github.com/spack/spack/pull/47313, and the `xsd` recipe updates are in a PR currently under review at https://github.com/spack/spack/pull/49702.