### PR TITLE
update package recipes

### DIFF
--- a/var/spack/repos/builtin/packages/py-maturin/package.py
+++ b/var/spack/repos/builtin/packages/py-maturin/package.py
@@ -18,6 +18,7 @@ class PyMaturin(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.8.2", sha256="e31abc70f6f93285d6e63d2f4459c079c94c259dd757370482d2d4ceb9ec1fa0")
     version("1.6.0", sha256="b955025c24c8babc808db49e0ff90db8b4b1320dcc16b14eb26132841737230d")
     version("1.5.1", sha256="3dd834ece80edb866af18cbd4635e0ecac40139c726428d5f1849ae154b26dca")
     version("1.4.0", sha256="ed12e1768094a7adeafc3a74ebdb8dc2201fa64c4e7e31f14cfc70378bf93790")
@@ -43,4 +44,5 @@ class PyMaturin(PythonPackage):
     # May be an accidental dependency, remove in the future
     # https://git.alpinelinux.org/aports/commit/?id=7ad298b467403b96a6b97d050170e367f147a75f
     # https://patchwork.yoctoproject.org/project/oe-core/patch/8803dc101b641c948805cab9e5784c38f43b0e51.1702791173.git.tim.orling@konsulko.com/
-    depends_on("bzip2", when="platform=darwin")
+    # This seems to still be an issue for others
+    depends_on("bzip2")

--- a/var/spack/repos/builtin/packages/xsd/package.py
+++ b/var/spack/repos/builtin/packages/xsd/package.py
@@ -24,6 +24,14 @@ class Xsd(MakefilePackage):
     depends_on("xerces-c")
     depends_on("libtool", type="build")
 
+    variant(
+        "cxxstd",
+        default="14",
+        values=("98", "11", "14"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+    )
+
     patch(
         "https://git.codesynthesis.com/cgit/libxsd-frontend/libxsd-frontend/patch/?id=5029f8665190879285787a9dcdaf5f997cadd2e2",
         sha256="d57e0aed8784d2b947983209b6513c81ac593c9936c3d7b809b4cd60d4c28607",
@@ -36,6 +44,8 @@ class Xsd(MakefilePackage):
     def setup_build_environment(self, env):
         xercesc_lib_flags = self.spec["xerces-c"].libs.search_flags
         env.append_flags("LDFLAGS", xercesc_lib_flags)
+        cxxstdflag = "cxx{0}_flag".format(self.spec.variants["cxxstd"].value)
+        env.append_flags("CXXFLAGS", getattr(self.compiler, cxxstdflag))
 
     def url_for_version(self, version):
         url = "https://www.codesynthesis.com/download/xsd/{0}/xsd-{1}+dep.tar.bz2"


### PR DESCRIPTION
pull in a couple of commits to the `v0.23.0-fermi` branch that have already been merged to the parent spack repository. these commits are necessary for building packages in the NOvA software stack.