### PR TITLE
fix z3 bug in llvm package recipe

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -956,7 +956,8 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
                 cmake_args.append(from_variant("CLANG_ANALYZER_ENABLE_Z3_SOLVER", "z3"))
             elif spec.satisfies("@9:"):
                 cmake_args.append(from_variant("LLVM_ENABLE_Z3_SOLVER", "z3"))
-                cmake_args.append(define("LLVM_Z3_INSTALL_DIR", self.spec["z3"].prefix))
+                if self.spec.satisfies("+z3"):
+                    cmake_args.append(define("LLVM_Z3_INSTALL_DIR", self.spec["z3"].prefix))
 
         if spec.satisfies("+flang"):
             projects.append("flang")


### PR DESCRIPTION
only set LLVM_Z3_INSTALL_DIR if z3 variant of llvm is enabled – otherwise querying the z3 spec in this code block throws an error.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
