### PR TITLE
cvmfs workaround reborn

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -212,7 +212,15 @@ class DirectoryConfigScope(ConfigScope):
             with open(filename, "w", encoding="utf-8") as f:
                 syaml.dump_config(data, stream=f, default_flow_style=False)
         except (syaml.SpackYAMLError, OSError) as e:
-            raise ConfigFileError(f"cannot write to '{filename}'") from e
+            if hasattr(e, 'errno') and e.errno in [13, 30]:
+                tty.warn("Ignoring write error on readonly %s" % filename)
+                # for the moment, stubbing this out because spack is trying to
+                # update the bootstrap.yaml in the bootstrap area *all* *the* *time*
+                # (with what is already in there) which keeps you from using
+                # a bootstrap area in cvmfs...  Really need to fix upstream
+                # from here to not update the config file if its already right...
+            else:
+                raise ConfigFileError(f"cannot write to '{filename}'") from e
 
 
 class SingleFileScope(ConfigScope):
@@ -344,7 +352,7 @@ class SingleFileScope(ConfigScope):
             filesystem.rename(tmp, self.path)
 
         except (syaml.SpackYAMLError, OSError) as e:
-            raise ConfigFileError(f"cannot write to config file {str(e)}") from e
+            raise ConfigFileError(f"cannot write to '{filename}'") from e
 
     def __repr__(self) -> str:
         return f"<SingleFileScope: {self.name}: {self.path}>"

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -352,7 +352,7 @@ class SingleFileScope(ConfigScope):
             filesystem.rename(tmp, self.path)
 
         except (syaml.SpackYAMLError, OSError) as e:
-            raise ConfigFileError(f"cannot write to '{filename}'") from e
+            raise ConfigFileError(f"cannot write to config file {str(e)}") from e
 
     def __repr__(self) -> str:
         return f"<SingleFileScope: {self.name}: {self.path}>"


### PR DESCRIPTION
This is the same patch we ran in older spack to workaround cvmfs errors from unneccesarily updating bootstrap.yaml
