### PR TITLE
Add --quiet to git checkout tag

### DIFF
--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -118,7 +118,7 @@ def pull_checkout_tag(
         fetch_args.append(f"--depth={depth}")
 
     git_exe("fetch", *fetch_args, remote)
-    git_exe("checkout", tag)
+    git_exe("checkout", "--quiet", tag)
 
 
 def pull_checkout_branch(


### PR DESCRIPTION
This stops spack from printing the output of git every time it checks  out an include file from git.